### PR TITLE
Challenges Addon Rework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>world.bentobox</groupId>
 	<artifactId>challenges</artifactId>
-	<version>0.3.1-SNAPSHOT</version>
+	<version>0.5.0-SNAPSHOT</version>
 
 	<name>Challenges</name>
 	<description>Challenges is an add-on for BentoBox, an expandable Minecraft Bukkit plugin for island-type games like ASkyBlock or AcidIsland.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -100,19 +100,7 @@
 		<dependency>
 			<groupId>world.bentobox</groupId>
 			<artifactId>bentobox</artifactId>
-			<version>1.1-SNAPSHOT</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>world.bentobox</groupId>
-			<artifactId>bskyblock</artifactId>
-			<version>1.0</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>world.bentobox</groupId>
-			<artifactId>acidisland</artifactId>
-			<version>1.0</version>
+			<version>1.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/world/bentobox/challenges/ChallengesAddon.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesAddon.java
@@ -2,7 +2,6 @@ package world.bentobox.challenges;
 
 import org.bukkit.Bukkit;
 
-import world.bentobox.acidisland.AcidIsland;
 import world.bentobox.bentobox.api.configuration.Config;
 import world.bentobox.challenges.commands.ChallengesCommand;
 import world.bentobox.challenges.commands.admin.Challenges;
@@ -75,45 +74,22 @@ public class ChallengesAddon extends Addon {
         // Challenge import setup
         this.importManager = new ChallengesImportManager(this);
 
+        this.getPlugin().getAddonsManager().getGameModeAddons().forEach(gameModeAddon -> {
+        	if (!this.settings.getDisabledGameModes().contains(gameModeAddon.getDescription().getName()))
+			{
+				if (gameModeAddon.getPlayerCommand().isPresent())
+				{
+					new ChallengesCommand(this, gameModeAddon.getPlayerCommand().get());
+					this.hooked = true;
+				}
 
-        // Integrate into AcidIsland.
-        if (this.settings.getDisabledGameModes().isEmpty() ||
-            !this.settings.getDisabledGameModes().contains("AcidIsland"))
-        {
-            this.getPlugin().getAddonsManager().getAddonByName("AcidIsland").ifPresent(
-                addon -> {
-                    AcidIsland acidIsland = (AcidIsland) addon;
-
-                    new Challenges(this,
-                        this.getPlugin().getCommandsManager().getCommand(
-                            acidIsland.getSettings().getAdminCommand()));
-
-                    new ChallengesCommand(this,
-                        this.getPlugin().getCommandsManager().getCommand(
-                            acidIsland.getSettings().getIslandCommand()));
-
-                    this.hooked = true;
-                });
-        }
-
-        // Integrate into BSkyBlock.
-        if (this.settings.getDisabledGameModes().isEmpty() ||
-            !this.settings.getDisabledGameModes().contains("BSkyBlock"))
-        {
-            this.getPlugin().getAddonsManager().getAddonByName("BSkyBlock").ifPresent(
-                addon -> {
-//                  BSkyBlock skyBlock = (BSkyBlock) addon;
-//                  SkyBlock addon cannot change commands ;(
-
-                    new Challenges(this,
-                        this.getPlugin().getCommandsManager().getCommand("bsbadmin"));
-
-                    new ChallengesCommand(this,
-                        this.getPlugin().getCommandsManager().getCommand("island"));
-
-                    this.hooked = true;
-                });
-        }
+				if (gameModeAddon.getAdminCommand().isPresent())
+				{
+					new Challenges(this, gameModeAddon.getAdminCommand().get());
+					this.hooked = true;
+				}
+			}
+		});
 
         if (this.hooked) {
             // Try to find Level addon and if it does not exist, display a warning

--- a/src/main/java/world/bentobox/challenges/ChallengesAddon.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesAddon.java
@@ -28,6 +28,15 @@ public class ChallengesAddon extends Addon {
 
     private boolean hooked;
 
+    /**
+     * This indicate if economy plugin exists.
+     */
+    private boolean economyProvided;
+
+    /**
+     * This indicate if level addon exists.
+     */
+    private boolean levelProvided;
 
 // ---------------------------------------------------------------------
 // Section: Constants
@@ -93,8 +102,17 @@ public class ChallengesAddon extends Addon {
 
         if (this.hooked) {
             // Try to find Level addon and if it does not exist, display a warning
-            if (!this.getAddonByName("Level").isPresent()) {
+
+            this.levelProvided = this.getAddonByName("Level").isPresent();
+
+            if (!this.levelProvided) {
                 this.logWarning("Level add-on not found so level challenges will not work!");
+            }
+
+            this.economyProvided = this.getPlugin().getVault().isPresent() && this.getPlugin().getVault().get().hook();
+
+            if (!this.economyProvided) {
+                this.logWarning("Economy plugin not found so money options will not work!");
             }
 
             // Register the reset listener
@@ -184,5 +202,25 @@ public class ChallengesAddon extends Addon {
     public Settings getChallengesSettings()
     {
         return this.settings;
+    }
+
+
+    /**
+     *
+     * @return economyProvided variable.
+     */
+    public boolean isEconomyProvided()
+    {
+        return economyProvided;
+    }
+
+
+    /**
+     *
+     * @return levelProvided variable.
+     */
+    public boolean isLevelProvided()
+    {
+        return levelProvided;
     }
 }

--- a/src/main/java/world/bentobox/challenges/ChallengesAddon.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesAddon.java
@@ -40,8 +40,9 @@ public class ChallengesAddon extends Addon {
 
     /**
      * VaultHook that process economy.
+     * todo: because of BentoBox limitations.
      */
-    private VaultHook vaultHook;
+    private Optional<VaultHook> vaultHook = null;
 
     /**
      * Level addon.
@@ -131,18 +132,19 @@ public class ChallengesAddon extends Addon {
                 this.levelAddon = (Level) level.get();
             }
 
-            Optional<VaultHook> vault = this.getPlugin().getVault();
-
-            if (!vault.isPresent() || !vault.get().hook())
-            {
-                this.vaultHook = null;
-                this.logWarning("Economy plugin not found so money options will not work!");
-            }
-            else
-            {
-                this.economyProvided = true;
-                this.vaultHook = vault.get();
-            }
+            // BentoBox limitation. Cannot check hooks, as HookManager is created after loading addons.
+//            Optional<VaultHook> vault = this.getPlugin().getVault();
+//
+//            if (!vault.isPresent() || !vault.get().hook())
+//            {
+//                this.vaultHook = null;
+//                this.logWarning("Economy plugin not found so money options will not work!");
+//            }
+//            else
+//            {
+//                this.economyProvided = true;
+//                this.vaultHook = vault.get();
+//            }
 
             // Register the reset listener
             this.registerListener(new ResetListener(this));
@@ -245,7 +247,13 @@ public class ChallengesAddon extends Addon {
      */
     public boolean isEconomyProvided()
     {
-        return economyProvided;
+        if (!this.economyProvided && this.getPlugin().getVault().isPresent() && this.vaultHook == null)
+        {
+            this.vaultHook = this.getPlugin().getVault();
+            this.economyProvided = this.vaultHook.get().hook();
+        }
+
+        return this.economyProvided;
     }
 
 
@@ -256,7 +264,7 @@ public class ChallengesAddon extends Addon {
      */
     public VaultHook getEconomyProvider()
     {
-        return vaultHook;
+        return vaultHook.orElseGet(null);
     }
 
 

--- a/src/main/java/world/bentobox/challenges/ChallengesAddon.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesAddon.java
@@ -1,16 +1,16 @@
 package world.bentobox.challenges;
 
-import org.bukkit.Bukkit;
 
+import org.bukkit.Bukkit;
 import java.util.Optional;
 
+import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.configuration.Config;
 import world.bentobox.bentobox.hooks.VaultHook;
 import world.bentobox.challenges.commands.ChallengesCommand;
 import world.bentobox.challenges.commands.admin.Challenges;
 import world.bentobox.challenges.listeners.ResetListener;
 import world.bentobox.challenges.listeners.SaveListener;
-import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.level.Level;
 
 
@@ -177,6 +177,11 @@ public class ChallengesAddon extends Addon {
     public void onDisable() {
         if (this.hooked) {
             this.challengesManager.save();
+        }
+
+        if (this.settings != null)
+        {
+            new Config<>(this, Settings.class).saveConfigObject(this.settings);
         }
     }
 

--- a/src/main/java/world/bentobox/challenges/ChallengesImportManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesImportManager.java
@@ -16,8 +16,8 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 
-import world.bentobox.challenges.database.object.ChallengeLevels;
-import world.bentobox.challenges.database.object.Challenges;
+import world.bentobox.challenges.database.object.ChallengeLevel;
+import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.util.Util;
 
@@ -78,7 +78,7 @@ public class ChallengesImportManager
             String[] lvs = levels.split(" ");
             int order = 0;
             for (String level : lvs) {
-                ChallengeLevels challengeLevel = new ChallengeLevels();
+                ChallengeLevel challengeLevel = new ChallengeLevel();
                 challengeLevel.setFriendlyName(level);
                 challengeLevel.setUniqueId(level);
                 challengeLevel.setOrder(order++);
@@ -110,7 +110,7 @@ public class ChallengesImportManager
         // Parse the challenge file
         ConfigurationSection chals = chal.getConfigurationSection("challenges.challengeList");
         for (String challenge : chals.getKeys(false)) {
-            Challenges newChallenge = new Challenges();
+            Challenge newChallenge = new Challenge();
             newChallenge.setUniqueId(Util.getWorld(world).getName() + "_" + challenge);
             newChallenge.setDeployed(true);
             ConfigurationSection details = chals.getConfigurationSection(challenge);
@@ -119,7 +119,7 @@ public class ChallengesImportManager
             newChallenge.setDescription(addon.getChallengesManager().stringSplit(details.getString("description", "")));
             newChallenge.setIcon(new ParseItem(addon, details.getString("icon") + ":1").getItem());
             newChallenge.setLevel(details.getString("level", ChallengesManager.FREE));
-            newChallenge.setChallengeType(Challenges.ChallengeType.valueOf(details.getString("type","INVENTORY").toUpperCase()));
+            newChallenge.setChallengeType(Challenge.ChallengeType.valueOf(details.getString("type","INVENTORY").toUpperCase()));
             newChallenge.setTakeItems(details.getBoolean("takeItems",true));
             newChallenge.setRewardText(details.getString("rewardText", ""));
             newChallenge.setRewardCommands(details.getStringList("rewardcommands"));
@@ -135,11 +135,11 @@ public class ChallengesImportManager
             newChallenge.setReqMoney(details.getInt("requiredMoney"));
             newChallenge.setReqExp(details.getInt("requiredExp"));
             String reqItems = details.getString("requiredItems","");
-            if (newChallenge.getChallengeType().equals(Challenges.ChallengeType.INVENTORY)) {
+            if (newChallenge.getChallengeType().equals(Challenge.ChallengeType.INVENTORY)) {
                 newChallenge.setRequiredItems(parseItems(reqItems));
-            } else if (newChallenge.getChallengeType().equals(Challenges.ChallengeType.LEVEL)) {
+            } else if (newChallenge.getChallengeType().equals(Challenge.ChallengeType.LEVEL)) {
                 newChallenge.setReqIslandlevel(Long.parseLong(reqItems));
-            } else if (newChallenge.getChallengeType().equals(Challenges.ChallengeType.ISLAND)) {
+            } else if (newChallenge.getChallengeType().equals(Challenge.ChallengeType.ISLAND)) {
                 parseEntities(newChallenge, reqItems);
             }
             newChallenge.setRewardItems(parseItems(details.getString("itemReward")));
@@ -158,7 +158,7 @@ public class ChallengesImportManager
      * @param challenge - challenge to be adjusted
      * @param string - string from YAML file
      */
-    private void parseEntities(Challenges challenge, String string) {
+    private void parseEntities(Challenge challenge, String string) {
         Map<EntityType, Integer> req = new EnumMap<>(EntityType.class);
         Map<Material, Integer> blocks = new EnumMap<>(Material.class);
         if (!string.isEmpty()) {

--- a/src/main/java/world/bentobox/challenges/ChallengesImportManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesImportManager.java
@@ -83,7 +83,7 @@ public class ChallengesImportManager
             for (String level : lvs) {
                 ChallengeLevel challengeLevel = new ChallengeLevel();
                 challengeLevel.setFriendlyName(level);
-                challengeLevel.setUniqueId(level);
+                challengeLevel.setUniqueId(Util.getWorld(world).getName() + "_" + level);
                 challengeLevel.setOrder(order++);
                 challengeLevel.setWorld(Util.getWorld(world).getName());
                 challengeLevel.setWaiverAmount(chal.getInt("challenges.waiveramount"));
@@ -120,7 +120,17 @@ public class ChallengesImportManager
             newChallenge.setFriendlyName(details.getString("friendlyname", challenge));
             newChallenge.setDescription(GuiUtils.stringSplit(details.getString("description", "")));
             newChallenge.setIcon(ItemParser.parse(details.getString("icon") + ":1"));
-            newChallenge.setChallengeType(Challenge.ChallengeType.valueOf(details.getString("type","INVENTORY").toUpperCase()));
+
+            if (details.getString("type").equalsIgnoreCase("level"))
+            {
+                // Fix for older version config
+                newChallenge.setChallengeType(Challenge.ChallengeType.OTHER);
+            }
+            else
+            {
+                newChallenge.setChallengeType(Challenge.ChallengeType.valueOf(details.getString("type","INVENTORY").toUpperCase()));
+            }
+
             newChallenge.setTakeItems(details.getBoolean("takeItems",true));
             newChallenge.setRewardText(details.getString("rewardText", ""));
             newChallenge.setRewardCommands(details.getStringList("rewardcommands"));

--- a/src/main/java/world/bentobox/challenges/ChallengesImportManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesImportManager.java
@@ -97,7 +97,7 @@ public class ChallengesImportManager
                     challengeLevel.setRewardExperience(unlock.getInt("expReward"));
                     challengeLevel.setRewardCommands(unlock.getStringList("commands"));
                 }
-                addon.getChallengesManager().storeLevel(challengeLevel);
+                addon.getChallengesManager().loadLevel(challengeLevel, overwrite, user, false);
             }
         } else {
             user.sendMessage("challenges.admin.import.no-levels");
@@ -118,7 +118,7 @@ public class ChallengesImportManager
             newChallenge.setDeployed(true);
             ConfigurationSection details = chals.getConfigurationSection(challenge);
             newChallenge.setFriendlyName(details.getString("friendlyname", challenge));
-            newChallenge.setDescription(addon.getChallengesManager().stringSplit(details.getString("description", "")));
+            newChallenge.setDescription(GuiUtils.stringSplit(details.getString("description", "")));
             newChallenge.setIcon(ItemParser.parse(details.getString("icon") + ":1"));
             newChallenge.setChallengeType(Challenge.ChallengeType.valueOf(details.getString("type","INVENTORY").toUpperCase()));
             newChallenge.setTakeItems(details.getBoolean("takeItems",true));
@@ -149,7 +149,7 @@ public class ChallengesImportManager
             this.addon.getChallengesManager().addChallengeToLevel(newChallenge,
                 addon.getChallengesManager().getLevel(Util.getWorld(world).getName() + "_" + details.getString("level")));
 
-            if (addon.getChallengesManager().storeChallenge(newChallenge, overwrite, user, false)) {
+            if (addon.getChallengesManager().loadChallenge(newChallenge, overwrite, user, false)) {
                 size++;
             }
         }

--- a/src/main/java/world/bentobox/challenges/ChallengesManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesManager.java
@@ -488,10 +488,10 @@ public class ChallengesManager
 		{
 			// To find how many challenges user still must do in previous level, we must
 			// know how many challenges there were and how many has been done. Then
-			// from waiver amount remove calculated value and you get count.
+			// remove waiver amount to get count of challenges that still necessary to do.
 
 			int challengesToDo = previousLevel == null ? 0 :
-				level.getWaiverAmount() - (previousLevel.getChallenges().size() - doneChallengeCount);
+				(previousLevel.getChallenges().size() - doneChallengeCount - level.getWaiverAmount());
 
 			// As level already contains unique ids of challenges, just iterate through them.
 			doneChallengeCount = (int) level.getChallenges().stream().filter(playerData::isChallengeDone).count();

--- a/src/main/java/world/bentobox/challenges/ChallengesManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesManager.java
@@ -554,7 +554,7 @@ public class ChallengesManager {
 
 	public boolean validateChallengeUniqueID(World world, String reply)
 	{
-		return false;
+		return true;
 	}
 
 
@@ -567,5 +567,17 @@ public class ChallengesManager {
 	public ChallengeLevels createLevel(String reply)
 	{
 		return new ChallengeLevels();
+	}
+
+
+	public void unlinkChallenge(ChallengeLevels challengeLevel, Challenges value)
+	{
+
+	}
+
+
+	public void linkChallenge(ChallengeLevels challengeLevel, Challenges value)
+	{
+
 	}
 }

--- a/src/main/java/world/bentobox/challenges/ChallengesManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesManager.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang.WordUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import java.util.*;
@@ -215,26 +216,37 @@ public class ChallengesManager {
      * @param world - world to check
      * @return Level status - how many challenges still to do on which level
      */
-    public List<LevelStatus> getChallengeLevelStatus(User user, World world) {
-        addPlayer(user);
-        ChallengesPlayerData pd = playerData.get(user.getUniqueId());
+    public List<LevelStatus> getChallengeLevelStatus(User user, World world)
+    {
+        this.addPlayer(user);
+        ChallengesPlayerData playerData = this.playerData.get(user.getUniqueId());
         List<LevelStatus> result = new ArrayList<>();
-        ChallengeLevels previousLevel = null;
+
         // The first level is always unlocked
-        boolean isUnlocked = true;
+        ChallengeLevels previousLevel = null;
+        int doneChallengeCount = Integer.MAX_VALUE;
+
         // For each challenge level, check how many the user has done
-        for (Entry<ChallengeLevels, Set<Challenges>> en : challengeMap.entrySet()) {
-            int total = challengeMap.values().size();
-            int waiverAmount = en.getKey().getWaiveramount();
-            int challengesDone = (int) en.getValue().stream().filter(ch -> pd.isChallengeDone(world, ch.getUniqueId())).count();
-            int challsToDo =  Math.max(0,total - challengesDone - waiverAmount);
-            boolean complete = challsToDo > 0 ? false : true;
+        for (Entry<ChallengeLevels, Set<Challenges>> entry : this.challengeMap.entrySet())
+        {
+            // Check how much challenges must be done in previous level.
+            int challengesToDo = Math.max(0, entry.getKey().getWaiveramount() - doneChallengeCount);
+
+            doneChallengeCount = (int) entry.getValue().stream().filter(
+                ch -> playerData.isChallengeDone(world, ch.getUniqueId())).count();
+
             // Create result class with the data
-            result.add(new LevelStatus(en.getKey(), previousLevel, challsToDo, complete, isUnlocked));
+            result.add(new LevelStatus(
+                entry.getKey(),
+                previousLevel,
+                challengesToDo,
+                entry.getValue().size() == doneChallengeCount,
+                challengesToDo <= 0));
+
             // Set up the next level for the next loop
-            previousLevel = en.getKey();
-            isUnlocked = complete;
+            previousLevel = entry.getKey();
         }
+
         return result;
     }
 
@@ -591,5 +603,38 @@ public class ChallengesManager {
     public void completeChallenge(UUID uniqueId, Challenges value)
     {
 
+    }
+
+
+    public List<Challenges> getFreeChallenges(User user, World world)
+    {
+        return Collections.emptyList();
+    }
+
+
+    public String getChallengesLevel(Challenges challenge)
+    {
+        return "HERE NEED LEVEL NAME";
+    }
+
+
+    public boolean isChallengeComplete(User user, Challenges challenge)
+    {
+        return this.isChallengeComplete(user, challenge.getUniqueId(), user.getWorld());
+    }
+
+
+    public long checkChallengeTimes(User user, Challenges challenge)
+    {
+       return this.checkChallengeTimes(user, challenge, user.getWorld());
+    }
+
+
+    public List<Player> getPlayers(World world)
+    {
+        List<Player> playerList = new ArrayList<>();
+
+
+        return playerList;
     }
 }

--- a/src/main/java/world/bentobox/challenges/ChallengesManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesManager.java
@@ -7,12 +7,11 @@ import org.bukkit.entity.Player;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import world.bentobox.bentobox.api.configuration.Config;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.Database;
 import world.bentobox.bentobox.util.Util;
-import world.bentobox.challenges.database.object.ChallengeLevel;
 import world.bentobox.challenges.database.object.Challenge;
+import world.bentobox.challenges.database.object.ChallengeLevel;
 import world.bentobox.challenges.database.object.ChallengesPlayerData;
 import world.bentobox.challenges.utils.LevelStatus;
 

--- a/src/main/java/world/bentobox/challenges/ChallengesManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesManager.java
@@ -580,4 +580,16 @@ public class ChallengesManager {
 	{
 
 	}
+
+
+    public void resetChallenge(UUID uniqueId, Challenges value)
+    {
+
+    }
+
+
+    public void completeChallenge(UUID uniqueId, Challenges value)
+    {
+
+    }
 }

--- a/src/main/java/world/bentobox/challenges/ChallengesManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesManager.java
@@ -574,6 +574,49 @@ public class ChallengesManager
 	}
 
 
+	/**
+	 * This method returns if given user has been already completed given level.
+	 * @param level Level that must be checked.
+	 * @param user User who need to be checked.
+	 * @return true, if level is already completed.
+	 */
+	public boolean isLevelCompleted(User user, ChallengeLevel level)
+	{
+		this.addPlayer(user);
+		return this.playerCacheData.get(user.getUniqueId()).isLevelDone(level.getUniqueId());
+	}
+
+
+	/**
+	 * This method checks all level challenges and checks if all challenges are done.
+	 * @param level Level that must be checked.
+	 * @param user User who need to be checked.
+	 * @return true, if all challenges are done, otherwise false.
+	 */
+	public boolean validateLevelCompletion(User user, ChallengeLevel level)
+	{
+		this.addPlayer(user);
+		ChallengesPlayerData playerData = this.playerCacheData.get(user.getUniqueId());
+		long doneChallengeCount = level.getChallenges().stream().filter(playerData::isChallengeDone).count();
+
+		return level.getChallenges().size() == doneChallengeCount;
+	}
+
+
+	/**
+	 * This method sets given level as completed.
+	 * @param level Level that must be completed.
+	 * @param user User who complete level.
+	 */
+	public void setLevelComplete(User user, ChallengeLevel level)
+	{
+		this.addPlayer(user);
+		this.playerCacheData.get(user.getUniqueId()).addCompletedLevel(level.getUniqueId());
+		// Save
+		this.savePlayer(user.getUniqueId());
+	}
+
+
 // ---------------------------------------------------------------------
 // Section: Challenges related methods
 // ---------------------------------------------------------------------

--- a/src/main/java/world/bentobox/challenges/ChallengesManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesManager.java
@@ -80,7 +80,7 @@ public class ChallengesManager {
      */
     public long checkChallengeTimes(User user, Challenge challenge, World world) {
         addPlayer(user);
-        return playerData.get(user.getUniqueId()).getTimes(world, challenge.getUniqueId());
+        return playerData.get(user.getUniqueId()).getTimes(challenge.getUniqueId());
     }
 
     /**
@@ -189,7 +189,7 @@ public class ChallengesManager {
      */
     public List<String> getAllChallengesList(World world) {
         List<String> result = new ArrayList<>();
-        challengeMap.values().forEach(ch -> ch.stream().filter(c -> c.getWorld().equals(Util.getWorld(world).getName())).forEach(c -> result.add(c.getUniqueId())));
+        challengeMap.values().forEach(ch -> ch.stream().filter(c -> c.getUniqueId().startsWith(Util.getWorld(world).getName())).forEach(c -> result.add(c.getUniqueId())));
         return result;
     }
 
@@ -230,10 +230,10 @@ public class ChallengesManager {
         for (Entry<ChallengeLevel, Set<Challenge>> entry : this.challengeMap.entrySet())
         {
             // Check how much challenges must be done in previous level.
-            int challengesToDo = Math.max(0, entry.getKey().getWaiveramount() - doneChallengeCount);
+            int challengesToDo = Math.max(0, entry.getKey().getWaiverAmount() - doneChallengeCount);
 
             doneChallengeCount = (int) entry.getValue().stream().filter(
-                ch -> playerData.isChallengeDone(world, ch.getUniqueId())).count();
+                ch -> playerData.isChallengeDone(ch.getUniqueId())).count();
 
             // Create result class with the data
             result.add(new LevelStatus(
@@ -270,7 +270,7 @@ public class ChallengesManager {
         Optional<ChallengeLevel> lv = challengeMap.keySet().stream().filter(l -> l.getUniqueId().equalsIgnoreCase(level)).findFirst();
         // Get the challenges applicable to this world
         return lv.isPresent() ? challengeMap.get(lv.get()).stream()
-                .filter(c -> c.getWorld().equalsIgnoreCase(worldName) || c.getWorld().isEmpty()).collect(Collectors.toSet())
+                .filter(c -> c.getUniqueId().startsWith(worldName)).collect(Collectors.toSet())
                 : new HashSet<>();
     }
 
@@ -319,7 +319,7 @@ public class ChallengesManager {
      */
     public boolean isChallenge(World world, String name) {
         for (Set<Challenge> ch : challengeMap.values())  {
-            if (ch.stream().filter(c -> c.getWorld().equals(Util.getWorld(world).getName())).anyMatch(c -> c.getUniqueId().equalsIgnoreCase(name))) {
+            if (ch.stream().filter(c -> c.getUniqueId().startsWith(Util.getWorld(world).getName())).anyMatch(c -> c.getUniqueId().equalsIgnoreCase(name))) {
                 return true;
             }
         }
@@ -328,13 +328,12 @@ public class ChallengesManager {
 
     /**
      * Checks if a challenge is complete or not
-     * @param uniqueId - unique ID - player's UUID
      * @param challengeName - Challenge uniqueId
      * @return - true if completed
      */
     public boolean isChallengeComplete(User user, String challengeName, World world) {
         addPlayer(user);
-        return playerData.get(user.getUniqueId()).isChallengeDone(world, challengeName);
+        return playerData.get(user.getUniqueId()).isChallengeDone(challengeName);
     }
 
     /**
@@ -396,7 +395,7 @@ public class ChallengesManager {
      */
     public void setChallengeComplete(User user, String challengeUniqueId, World world) {
         addPlayer(user);
-        playerData.get(user.getUniqueId()).setChallengeDone(world, challengeUniqueId);
+        playerData.get(user.getUniqueId()).setChallengeDone(challengeUniqueId);
         // Save
         savePlayer(user.getUniqueId());
     }
@@ -409,7 +408,7 @@ public class ChallengesManager {
      */
     public void setResetChallenge(User user, String challengeUniqueId, World world) {
         addPlayer(user);
-        playerData.get(user.getUniqueId()).setChallengeTimes(world, challengeUniqueId, 0);
+        playerData.get(user.getUniqueId()).setChallengeTimes(challengeUniqueId, 0);
         // Save
         savePlayer(user.getUniqueId());
     }
@@ -637,4 +636,17 @@ public class ChallengesManager {
 
         return playerList;
     }
+
+
+
+	public ChallengeLevel getLevel(String level)
+	{
+		return null;
+	}
+
+
+	public void addChallengeToLevel(Challenge newChallenge, ChallengeLevel level)
+	{
+
+	}
 }

--- a/src/main/java/world/bentobox/challenges/ChallengesManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesManager.java
@@ -154,7 +154,7 @@ public class ChallengesManager
 			{
 				if (!silent)
 				{
-					user.sendMessage("challenges.admin.import.skip",
+					user.sendMessage("challenges.admin.import.skipping",
 						"[object]", challenge.getFriendlyName());
 				}
 
@@ -219,7 +219,7 @@ public class ChallengesManager
 			{
 				if (!silent)
 				{
-					user.sendMessage("challenges.admin.import.skip",
+					user.sendMessage("challenges.admin.import.skipping",
 						"[object]", level.getFriendlyName());
 				}
 

--- a/src/main/java/world/bentobox/challenges/ChallengesManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesManager.java
@@ -1,654 +1,915 @@
 package world.bentobox.challenges;
 
 
-import org.apache.commons.lang.WordUtils;
-import org.bukkit.ChatColor;
-import org.bukkit.Material;
+import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
 import java.util.*;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import world.bentobox.bentobox.api.configuration.Config;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.Database;
 import world.bentobox.bentobox.util.Util;
-import world.bentobox.challenges.commands.admin.SurroundChallengeBuilder;
 import world.bentobox.challenges.database.object.ChallengeLevel;
 import world.bentobox.challenges.database.object.Challenge;
-import world.bentobox.challenges.database.object.Challenge.ChallengeType;
 import world.bentobox.challenges.database.object.ChallengesPlayerData;
-import world.bentobox.challenges.panel.ChallengesPanels;
 import world.bentobox.challenges.utils.LevelStatus;
 
 
-public class ChallengesManager {
+/**
+ * This class manges challenges. It allows access to all data that is stored to database.
+ * It also provides information about challenge level status for each user.
+ */
+public class ChallengesManager
+{
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
 
-    public static final String FREE = "Free";
-    private Map<ChallengeLevel, Set<Challenge>> challengeMap;
-    private Config<Challenge> chConfig;
-    private Config<ChallengeLevel> lvConfig;
-    private Database<ChallengesPlayerData> players;
-    private ChallengesPanels challengesPanels;
-    private Map<UUID,ChallengesPlayerData> playerData;
-    private ChallengesAddon addon;
+	/**
+	 * This config object stores structures for challenge objects.
+	 */
+	private Database<Challenge> challengeDatabase;
 
-    public ChallengesManager(ChallengesAddon addon) {
-        this.addon = addon;
-        // Set up the configs
-        chConfig = new Config<>(addon, Challenge.class);
-        lvConfig = new Config<>(addon, ChallengeLevel.class);
-        // Players is where all the player history will be stored
-        players = new Database<>(addon, ChallengesPlayerData.class);
-        // Cache of challenges
-        challengeMap = new LinkedHashMap<>();
-        // Cache of player data
-        playerData = new HashMap<>();
-        load();
-    }
+	/**
+	 * This config object stores structures for challenge level objects.
+	 */
+	private Database<ChallengeLevel> levelDatabase;
 
-    /**
-     * Load player from database into the cache or create new player data
-     * @param user - user to add
-     */
-    private void addPlayer(User user) {
-        if (playerData.containsKey(user.getUniqueId())) {
-            return;
-        }
-        // The player is not in the cache
-        // Check if the player exists in the database
-        if (players.objectExists(user.getUniqueId().toString())) {
-            // Load player from database
-            ChallengesPlayerData data = players.loadObject(user.getUniqueId().toString());
-            // Store in cache
-            playerData.put(user.getUniqueId(), data);
-        } else {
-            // Create the player data
-            ChallengesPlayerData pd = new ChallengesPlayerData(user.getUniqueId().toString());
-            players.saveObject(pd);
-            // Add to cache
-            playerData.put(user.getUniqueId(), pd);
-        }
-    }
+	/**
+	 * This database allows to access player challenge data.
+	 */
+	private Database<ChallengesPlayerData> playersDatabase;
 
-    /**
-     * Check how many times a player has done a challenge before
-     * @param user - user
-     * @param challenge - challenge
-     * @return - number of times
-     */
-    public long checkChallengeTimes(User user, Challenge challenge, World world) {
-        addPlayer(user);
-        return playerData.get(user.getUniqueId()).getTimes(challenge.getUniqueId());
-    }
+	/**
+	 * This is local cache that links challenge unique id with challenge object.
+	 */
+	private Map<String, Challenge> challengeCacheData;
 
-    /**
-     * Creates a simple example description of the requirements
-     * @param user - user of this command
-     * @param requiredItems - list of items
-     * @return Description list
-     */
-    private List<String> createDescription(User user, List<ItemStack> requiredItems) {
-        addPlayer(user);
-        List<String> result = new ArrayList<>();
-        result.add(user.getTranslation("challenges.admin.create.description"));
-        for (ItemStack item : requiredItems) {
-            result.add(user.getTranslation("challenges.admin.create.description-item-color") + item.getAmount() + " x " + Util.prettifyText(item.getType().toString()));
-        }
-        return result;
-    }
+	/**
+	 * This is local cache that links level unique id with level object.
+	 */
+	private Map<String, ChallengeLevel> levelCacheData;
 
-    /**
-     * Creates an inventory challenge
-     * @param user - the user who is making the challenge
-     * @param inventory - the inventory that will be used to make the challenge
-     */
-    public boolean createInvChallenge(User user, Inventory inventory) {
-        addPlayer(user);
-        if (inventory.getContents().length == 0) {
-            return false;
-        }
-        Challenge newChallenge = new Challenge();
-        newChallenge.setChallengeType(ChallengeType.INVENTORY);
-        newChallenge.setFriendlyName(inventory.getTitle());
-        newChallenge.setDeployed(false);
-        List<ItemStack> requiredItems = new ArrayList<>();
-        inventory.forEach(item -> {
-            if (item != null && !item.getType().equals(Material.AIR)) {
-                requiredItems.add(item);
-            }
-        });
-        newChallenge.setRequiredItems(requiredItems);
-        newChallenge.setTakeItems(true);
-        newChallenge.setUniqueId(inventory.getTitle());
-        newChallenge.setIcon(new ItemStack(Material.MAP));
-        newChallenge.setLevel(FREE);
-        newChallenge.setDescription(createDescription(user, requiredItems));
+	/**
+	 * This is local cache that links UUID with corresponding player challenge data.
+	 */
+	private Map<UUID, ChallengesPlayerData> playerCacheData;
 
-        // Move all the items back to the player's inventory
-        inventory.forEach(item -> {
-            if (item != null) {
-                Map<Integer, ItemStack> residual = user.getInventory().addItem(item);
-                // Drop any residual items at the foot of the player
-                residual.forEach((k, v) -> user.getWorld().dropItem(user.getLocation(), v));
-            }
-        });
-
-        // Save the challenge
-        if (!chConfig.saveConfigObject(newChallenge)) {
-            user.sendRawMessage(ChatColor.RED + "Challenge creation failed!");
-            return false;
-        }
-        user.sendRawMessage("Success");
-        return true;
-    }
-
-    /**
-     * Create a surrounding challenge
-     * @param challengeInfo - info on the challenge from the builder
-     * @return true if successful, false if not
-     */
-    public boolean createSurroundingChallenge(SurroundChallengeBuilder challengeInfo) {
-        if (challengeInfo.getReqBlocks().isEmpty() && challengeInfo.getReqEntities().isEmpty()) {
-            challengeInfo.getOwner().sendMessage("challenges.error.no-items-clicked");
-            return false;
-        }
-        Challenge newChallenge = new Challenge();
-        newChallenge.setChallengeType(ChallengeType.ISLAND);
-        newChallenge.setFriendlyName(challengeInfo.getName());
-        newChallenge.setDeployed(true);
-        newChallenge.setRequiredBlocks(challengeInfo.getReqBlocks());
-        newChallenge.setRequiredEntities(challengeInfo.getReqEntities());
-        newChallenge.setUniqueId(challengeInfo.getName());
-        newChallenge.setIcon(new ItemStack(Material.ARMOR_STAND));
-        newChallenge.setLevel(FREE);
-
-        // Save the challenge
-        if (!chConfig.saveConfigObject(newChallenge)) {
-            challengeInfo.getOwner().sendMessage("challenges.error.could-not-save");
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Get the list of all challenge unique names.
-     * @return List of challenge names
-     */
-    public List<String> getAllChallengesList() {
-        List<String> result = new ArrayList<>();
-        challengeMap.values().forEach(ch -> ch.forEach(c -> result.add(c.getUniqueId())));
-        return result;
-    }
-
-    /**
-     * Get the list of all challenge unique names for world.
-     * @param world - the world to check
-     * @return List of challenge names
-     */
-    public List<String> getAllChallengesList(World world) {
-        List<String> result = new ArrayList<>();
-        challengeMap.values().forEach(ch -> ch.stream().filter(c -> c.getUniqueId().startsWith(Util.getWorld(world).getName())).forEach(c -> result.add(c.getUniqueId())));
-        return result;
-    }
-
-    /**
-     * Get challenge by name
-     * @param name - unique name of challenge
-     * @param world - world to check
-     * @return - challenge or null if it does not exist
-     */
-    public Challenge getChallenge(String name, World world) {
-        String worldName = Util.getWorld(world).getName();
-        for (Set<Challenge> ch : challengeMap.values())  {
-            Optional<Challenge> challenge = ch.stream().filter(c -> c.getUniqueId().equalsIgnoreCase(worldName + name)).findFirst();
-            if (challenge.isPresent()) {
-                return challenge.get();
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Get the status on every level
-     * @param user - user
-     * @param world - world to check
-     * @return Level status - how many challenges still to do on which level
-     */
-    public List<LevelStatus> getChallengeLevelStatus(User user, World world)
-    {
-        this.addPlayer(user);
-        ChallengesPlayerData playerData = this.playerData.get(user.getUniqueId());
-        List<LevelStatus> result = new ArrayList<>();
-
-        // The first level is always unlocked
-        ChallengeLevel previousLevel = null;
-        int doneChallengeCount = Integer.MAX_VALUE;
-
-        // For each challenge level, check how many the user has done
-        for (Entry<ChallengeLevel, Set<Challenge>> entry : this.challengeMap.entrySet())
-        {
-            // Check how much challenges must be done in previous level.
-            int challengesToDo = Math.max(0, entry.getKey().getWaiverAmount() - doneChallengeCount);
-
-            doneChallengeCount = (int) entry.getValue().stream().filter(
-                ch -> playerData.isChallengeDone(ch.getUniqueId())).count();
-
-            // Create result class with the data
-            result.add(new LevelStatus(
-                entry.getKey(),
-                previousLevel,
-                challengesToDo,
-                entry.getValue().size() == doneChallengeCount,
-                challengesToDo <= 0));
-
-            // Set up the next level for the next loop
-            previousLevel = entry.getKey();
-        }
-
-        return result;
-    }
-
-    /**
-     * Get the challenge list
-     * @return the challengeList
-     */
-    public Map<ChallengeLevel, Set<Challenge>> getChallengeList() {
-        // TODO return the challenges for world
-        return challengeMap;
-    }
-
-    /**
-     * Get the set of challenges for this level for this world
-     * @param level - the level required
-     * @param world
-     * @return the set of challenges for this level, or the first set of challenges if level is blank, or a blank list if there are no challenges
-     */
-    public Set<Challenge> getChallenges(String level, World world) {
-        String worldName = Util.getWorld(world).getName();
-        Optional<ChallengeLevel> lv = challengeMap.keySet().stream().filter(l -> l.getUniqueId().equalsIgnoreCase(level)).findFirst();
-        // Get the challenges applicable to this world
-        return lv.isPresent() ? challengeMap.get(lv.get()).stream()
-                .filter(c -> c.getUniqueId().startsWith(worldName)).collect(Collectors.toSet())
-                : new HashSet<>();
-    }
-
-    /**
-     * @return the challengesPanels
-     */
-    public ChallengesPanels getChallengesPanels() {
-        return challengesPanels;
-    }
-
-    /**
-     * Get the previous level to the one supplied
-     * @param currentLevel - the current level
-     * @return the previous level, or null if there is none
-     */
-    public ChallengeLevel getPreviousLevel(ChallengeLevel currentLevel) {
-        ChallengeLevel result = null;
-        for (ChallengeLevel level : challengeMap.keySet()) {
-            if (level.equals(currentLevel)) {
-                return result;
-            }
-            result = level;
-        }
-        return result;
-    }
-
-    /**
-     * Check if a challenge exists - case insensitive
-     * @param name - name of challenge
-     * @return true if it exists, otherwise false
-     */
-    public boolean isChallenge(String name) {
-        for (Set<Challenge> ch : challengeMap.values())  {
-            if (ch.stream().anyMatch(c -> c.getUniqueId().equalsIgnoreCase(name))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Check if a challenge exists in world - case insensitive
-     * @param world - world to check
-     * @param name - name of challenge
-     * @return true if it exists, otherwise false
-     */
-    public boolean isChallenge(World world, String name) {
-        for (Set<Challenge> ch : challengeMap.values())  {
-            if (ch.stream().filter(c -> c.getUniqueId().startsWith(Util.getWorld(world).getName())).anyMatch(c -> c.getUniqueId().equalsIgnoreCase(name))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Checks if a challenge is complete or not
-     * @param challengeName - Challenge uniqueId
-     * @return - true if completed
-     */
-    public boolean isChallengeComplete(User user, String challengeName, World world) {
-        addPlayer(user);
-        return playerData.get(user.getUniqueId()).isChallengeDone(challengeName);
-    }
-
-    /**
-     * Check is user can see level
-     * @param user - user
-     * @param level - level unique id
-     * @return true if level is unlocked
-     */
-    public boolean isLevelUnlocked(User user, String level, World world) {
-        addPlayer(user);
-        return getChallengeLevelStatus(user, world).stream().filter(LevelStatus::isUnlocked).anyMatch(lv -> lv.getLevel().getUniqueId().equalsIgnoreCase(level));
-    }
-
-    /**
-     * Clear and reload all challenges
-     */
-    public void load() {
-        // Load the challenges
-        challengeMap.clear();
-        addon.getLogger().info("Loading challenges...");
-        chConfig.loadConfigObjects().forEach(this::storeChallenge);
-        sortChallenges();
-        players.loadObjects().forEach(pd -> {
-            try {
-                UUID uuid = UUID.fromString(pd.getUniqueId());
-                playerData.put(uuid,pd);
-            } catch (Exception e) {
-                addon.getLogger().severe("UUID for player in challenge data file is invalid!");
-            }
-        });
-    }
-
-    /**
-     * Save configs and player data
-     */
-    public void save() {
-        challengeMap.entrySet().forEach(en -> {
-            lvConfig.saveConfigObject(en.getKey());
-            en.getValue().forEach(chConfig::saveConfigObject);
-        });
-        savePlayers();
-    }
-
-    private void savePlayers() {
-        playerData.values().forEach(players :: saveObject);
-    }
-
-    private void savePlayer(UUID playerUUID) {
-        if (playerData.containsKey(playerUUID)) {
-            players.saveObject(playerData.get(playerUUID));
-        }
-    }
-
-    /**
-     * Sets the challenge as complete and increments the number of times it has been completed
-     * @param user - user
-     * @param challengeUniqueId - unique challenge id
-     * @param world - world to set
-     */
-    public void setChallengeComplete(User user, String challengeUniqueId, World world) {
-        addPlayer(user);
-        playerData.get(user.getUniqueId()).setChallengeDone(challengeUniqueId);
-        // Save
-        savePlayer(user.getUniqueId());
-    }
-
-    /**
-     * Reset the challenge to zero time / not done
-     * @param user - user
-     * @param challengeUniqueId - unique challenge id
-     * @param world - world to set
-     */
-    public void setResetChallenge(User user, String challengeUniqueId, World world) {
-        addPlayer(user);
-        playerData.get(user.getUniqueId()).setChallengeTimes(challengeUniqueId, 0);
-        // Save
-        savePlayer(user.getUniqueId());
-    }
-
-    /**
-     * @param challengeList the challengeList to set
-     */
-    public void setChallengeList(Map<ChallengeLevel, Set<Challenge>> challengeList) {
-        this.challengeMap = challengeList;
-    }
-
-    public void sortChallenges() {
-        // Sort the challenge list into level order
-        challengeMap = challengeMap.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
-                        (oldValue, newValue) -> oldValue, LinkedHashMap::new));
-    }
+	/**
+	 * This variable allows to access ChallengesAddon.
+	 */
+	private ChallengesAddon addon;
 
 
-    /**
-     * Store challenge silently. Used when loading.
-     * @param challenge
-     * @return true if successful
-     */
-    private boolean storeChallenge(Challenge challenge) {
-        return storeChallenge(challenge, true, null, true);
-    }
-
-    /**
-     * Stores the challenge.
-     * @param challenge - challenge
-     * @param overwrite - true if previous challenge should be overwritten
-     * @param user - user making the request
-     * @param silent - if true, no messages are sent to user
-     * @return - true if imported
-     */
-    public boolean storeChallenge(Challenge challenge, boolean overwrite, User user, boolean silent) {
-        // See if we have this level already
-        ChallengeLevel level;
-        if (lvConfig.configObjectExists(challenge.getLevel())) {
-            // Get it from the database
-            level = lvConfig.loadConfigObject(challenge.getLevel());
-        } else {
-            // Make it
-            level = new ChallengeLevel();
-            level.setUniqueId(challenge.getLevel());
-            lvConfig.saveConfigObject(level);
-        }
-        challengeMap.putIfAbsent(level, new HashSet<>());
-        if (challengeMap.get(level).contains(challenge)) {
-            if (!overwrite) {
-                if (!silent) {
-                    user.sendMessage("challenges.admin.import.skipping", "[challenge]", challenge.getFriendlyName());
-                }
-                return false;
-            } else {
-                if (!silent) {
-                    user.sendMessage("challenges.admin.import.overwriting", "[challenge]", challenge.getFriendlyName());
-                }
-                challengeMap.get(level).add(challenge);
-                return true;
-            }
-        }
-        if (!silent) {
-            user.sendMessage("challenges.admin.import.imported", "[challenge]", challenge.getFriendlyName());
-        }
-        challengeMap.get(level).add(challenge);
-        return true;
-    }
-
-    /**
-     * Store a challenge level
-     * @param level the challenge level
-     */
-    public void storeLevel(ChallengeLevel level) {
-        lvConfig.saveConfigObject(level);
-    }
-
-    /**
-     * Simple splitter
-     * @param string - string to be split
-     * @return list of split strings
-     */
-    public List<String> stringSplit(String string) {
-        string = ChatColor.translateAlternateColorCodes('&', string);
-        // Check length of lines
-        List<String> result = new ArrayList<>();
-        Arrays.asList(string.split("\\|")).forEach(line -> result.addAll(Arrays.asList(WordUtils.wrap(line,25).split("\\n"))));
-        return result;
-    }
-
-    /**
-     * Resets all the challenges for user in world
-     * @param uuid - island owner's UUID
-     * @param world - world
-     */
-    public void resetAllChallenges(UUID uuid, World world) {
-        User user = User.getInstance(uuid);
-        addPlayer(user);
-        playerData.get(user.getUniqueId()).reset(world);
-        // Save
-        savePlayer(user.getUniqueId());
-
-    }
+// ---------------------------------------------------------------------
+// Section: Constants
+// ---------------------------------------------------------------------
 
 
-    public Challenge createChallenge()
-    {
-        return new Challenge();
-    }
+	/**
+	 * String for free Challenge Level.
+	 */
+	public static final String FREE = "";
 
 
-    public List<Challenge> getChallenges(ChallengeLevel challengeLevel)
-    {
-        return new ArrayList<>(this.challengeMap.get(challengeLevel));
-    }
+// ---------------------------------------------------------------------
+// Section: Constructor
+// ---------------------------------------------------------------------
 
 
-    public List<ChallengeLevel> getChallengeLevelList()
-    {
-        return new ArrayList<>(this.challengeMap.keySet());
-    }
-
-
-    public List<Challenge> getChallengesList()
-    {
-        return new ArrayList<>();
-    }
-
-
-    public void deleteChallenge(Challenge selectedChallenge)
-    {
-
-    }
-
-
-    public void deleteChallengeLevel(ChallengeLevel valueObject)
-    {
-
-    }
-
-    public void resetAllChallenges(User uuid, World world)
-    {
-
-    }
-
-
-	public Challenge createChallenge(String reply)
+	/**
+	 * Initial constructor. Inits and loads all data.
+	 * @param addon challenges addon.
+	 */
+	public ChallengesManager(ChallengesAddon addon)
 	{
-		return new Challenge();
+		this.addon = addon;
+		// Set up the configs
+		this.challengeDatabase = new Database<>(addon, Challenge.class);
+		this.levelDatabase = new Database<>(addon, ChallengeLevel.class);
+		// Players is where all the player history will be stored
+		this.playersDatabase = new Database<>(addon, ChallengesPlayerData.class);
+
+		// Init all cache objects.
+		this.challengeCacheData = new HashMap<>();
+		this.levelCacheData = new HashMap<>();
+		this.playerCacheData = new HashMap<>();
+
+		this.load();
 	}
 
 
-	public boolean validateChallengeUniqueID(World world, String reply)
+// ---------------------------------------------------------------------
+// Section: Loading and storing methods
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * Clear and reload all challenges
+	 */
+	public void load()
 	{
+		this.challengeCacheData.clear();
+		this.levelCacheData.clear();
+		this.playerCacheData.clear();
+
+		this.addon.getLogger().info("Loading challenges...");
+
+		this.challengeDatabase.loadObjects().forEach(this::loadChallenge);
+		this.levelDatabase.loadObjects().forEach(this::loadLevel);
+		this.playersDatabase.loadObjects().forEach(this::loadPlayerData);
+	}
+
+
+	/**
+	 * Load challenge silently. Used when loading.
+	 *
+	 * @param challenge Challenge that must be loaded.
+	 * @return true if successful
+	 */
+	private void loadChallenge(Challenge challenge)
+	{
+		this.loadChallenge(challenge, true, null, true);
+	}
+
+
+	/**
+	 * Load the challenge.
+	 *
+	 * @param challenge - challenge
+	 * @param overwrite - true if previous challenge should be overwritten
+	 * @param user - user making the request
+	 * @param silent - if true, no messages are sent to user
+	 * @return - true if imported
+	 */
+	public boolean loadChallenge(Challenge challenge,
+		boolean overwrite,
+		User user,
+		boolean silent)
+	{
+		if (this.challengeCacheData.containsKey(challenge.getUniqueId()))
+		{
+			if (!overwrite)
+			{
+				if (!silent)
+				{
+					user.sendMessage("challenges.admin.import.skip",
+						"[object]", challenge.getFriendlyName());
+				}
+
+				return false;
+			}
+			else
+			{
+				if (!silent)
+				{
+					user.sendMessage("challenges.admin.import.overwriting",
+						"[object]", challenge.getFriendlyName());
+				}
+			}
+		}
+		else
+		{
+			if (!silent)
+			{
+				user.sendMessage("challenges.admin.import.add",
+					"[object]", challenge.getFriendlyName());
+			}
+		}
+
+		this.challengeCacheData.put(challenge.getUniqueId(), challenge);
 		return true;
 	}
 
 
-	public boolean validateLevelUniqueID(World world, String reply)
+	/**
+	 * Store a challenge level
+	 *
+	 * @param level the challenge level
+	 */
+	private void loadLevel(ChallengeLevel level)
 	{
-		return false;
+		this.loadLevel(level, true, null, true);
 	}
 
 
-	public ChallengeLevel createLevel(String reply)
+	/**
+	 * This method loads given level into local cache. It provides functionality to
+	 * overwrite local value with new one, and send message to given user.
+	 * @param level of type ChallengeLevel that must be loaded in local cache.
+	 * @param overwrite of type boolean that indicate if local element must be overwritten.
+	 * @param user of type User who will receive messages.
+	 * @param silent of type boolean that indicate if message to user must be sent.
+	 * @return boolean that indicate about load status.
+	 */
+	public boolean loadLevel(ChallengeLevel level, boolean overwrite, User user, boolean silent)
 	{
-		return new ChallengeLevel();
+		if (!this.isValidLevel(level))
+		{
+			user.sendMessage("challenges.admin.import.error",
+				"[object]", level.getFriendlyName());
+
+			return false;
+		}
+
+		if (this.levelCacheData.containsKey(level.getUniqueId()))
+		{
+			if (!overwrite)
+			{
+				if (!silent)
+				{
+					user.sendMessage("challenges.admin.import.skip",
+						"[object]", level.getFriendlyName());
+				}
+
+				return false;
+			}
+			else
+			{
+				if (!silent)
+				{
+					user.sendMessage("challenges.admin.import.overwriting",
+						"[object]", level.getFriendlyName());
+				}
+			}
+		}
+		else
+		{
+			if (!silent)
+			{
+				user.sendMessage("challenges.admin.import.add",
+					"[object]", level.getFriendlyName());
+			}
+		}
+
+		this.levelCacheData.put(level.getUniqueId(), level);
+		return true;
 	}
 
 
-	public void unlinkChallenge(ChallengeLevel challengeLevel, Challenge value)
+	/**
+	 * This method stores PlayerData into local cache.
+	 * @param playerData ChallengesPlayerData that must be loaded.
+	 */
+	private void loadPlayerData(ChallengesPlayerData playerData)
 	{
-
+		try
+		{
+			UUID uuid = UUID.fromString(playerData.getUniqueId());
+			this.playerCacheData.put(uuid, playerData);
+		}
+		catch (Exception e)
+		{
+			this.addon.getLogger().severe("UUID for player in challenge data file is invalid!");
+		}
 	}
 
 
-	public void linkChallenge(ChallengeLevel challengeLevel, Challenge value)
-	{
+// ---------------------------------------------------------------------
+// Section: Other storing related methods
+// ---------------------------------------------------------------------
 
+
+	/**
+	 * This method checks if given level all challenges exists in local cache or database.
+	 * It also checks if world where level must operate exists.
+	 * @param level that must be validated
+	 * @return true ir level is valid, otherwise false.
+	 */
+	private boolean isValidLevel(ChallengeLevel level)
+	{
+		if (!this.addon.getPlugin().getIWM().inWorld(Bukkit.getWorld(level.getWorld())))
+		{
+			return false;
+		}
+
+		for (String uniqueID : level.getChallenges())
+		{
+			if (!this.challengeCacheData.containsKey(uniqueID))
+			{
+				if (this.challengeDatabase.objectExists(uniqueID))
+				{
+					this.loadChallenge(this.challengeDatabase.loadObject(uniqueID));
+				}
+				else
+				{
+					return false;
+				}
+			}
+		}
+
+		return true;
 	}
 
 
-    public void resetChallenge(UUID uniqueId, Challenge value)
-    {
-
-    }
-
-
-    public void completeChallenge(UUID uniqueId, Challenge value)
-    {
-
-    }
-
-
-    public List<Challenge> getFreeChallenges(User user, World world)
-    {
-        return Collections.emptyList();
-    }
-
-
-    public String getChallengesLevel(Challenge challenge)
-    {
-        return "HERE NEED LEVEL NAME";
-    }
-
-
-    public boolean isChallengeComplete(User user, Challenge challenge)
-    {
-        return this.isChallengeComplete(user, challenge.getUniqueId(), user.getWorld());
-    }
-
-
-    public long checkChallengeTimes(User user, Challenge challenge)
-    {
-       return this.checkChallengeTimes(user, challenge, user.getWorld());
-    }
-
-
-    public List<Player> getPlayers(World world)
-    {
-        List<Player> playerList = new ArrayList<>();
-
-
-        return playerList;
-    }
-
-
-
-	public ChallengeLevel getLevel(String level)
+	/**
+	 * Load player from database into the cache or create new player data
+	 *
+	 * @param user - user to add
+	 */
+	private void addPlayer(User user)
 	{
+		if (this.playerCacheData.containsKey(user.getUniqueId()))
+		{
+			return;
+		}
+
+		// The player is not in the cache
+		// Check if the player exists in the database
+
+		if (this.playersDatabase.objectExists(user.getUniqueId().toString()))
+		{
+			// Load player from database
+			ChallengesPlayerData data = this.playersDatabase.loadObject(user.getUniqueId().toString());
+			// Store in cache
+			this.playerCacheData.put(user.getUniqueId(), data);
+		}
+		else
+		{
+			// Create the player data
+			ChallengesPlayerData pd = new ChallengesPlayerData(user.getUniqueId().toString());
+			this.playersDatabase.saveObject(pd);
+			// Add to cache
+			this.playerCacheData.put(user.getUniqueId(), pd);
+		}
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Saving methods
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * This method init all cached object saving to database.
+	 */
+	public void save()
+	{
+		this.saveChallenges();
+		this.saveLevels();
+		this.savePlayers();
+	}
+
+
+	/**
+	 * This method saves all challenges to database.
+	 */
+	private void saveChallenges()
+	{
+		this.challengeCacheData.values().forEach(this.challengeDatabase::saveObject);
+	}
+
+
+	/**
+	 * This method saves given challenge object to database.
+	 * @param challenge object that must be saved
+	 */
+	private void saveChallenge(Challenge challenge)
+	{
+		this.challengeDatabase.saveObject(challenge);
+	}
+
+
+	/**
+	 * This method saves all levels to database.
+	 */
+	private void saveLevels()
+	{
+		this.levelCacheData.values().forEach(this.levelDatabase::saveObject);
+	}
+
+
+	/**
+	 * This method saves given level into database.
+	 * @param level object that must be saved
+	 */
+	private void saveLevel(ChallengeLevel level)
+	{
+		this.levelDatabase.saveObject(level);
+	}
+
+
+	/**
+	 * This method saves all players to database.
+	 */
+	private void savePlayers()
+	{
+		this.playerCacheData.values().forEach(this.playersDatabase::saveObject);
+	}
+
+
+	/**
+	 * This method saves player with given UUID.
+	 * @param playerUUID users UUID.
+	 */
+	private void savePlayer(UUID playerUUID)
+	{
+		if (this.playerCacheData.containsKey(playerUUID))
+		{
+			this.playersDatabase.saveObject(this.playerCacheData.get(playerUUID));
+		}
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Player Data related methods
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * This method returns all players who have done at least one challenge in given world.
+	 * @param world World in which must search challenges.
+	 * @return List with players who have done at least on challenge.
+	 */
+	public List<Player> getPlayers(World world)
+	{
+		List<String> allChallengeList = this.getAllChallengesNames(world);
+
+		// This is using Database, as some users may not be in the cache.
+
+		return this.playersDatabase.loadObjects().stream().filter(playerData ->
+			allChallengeList.stream().anyMatch(playerData::isChallengeDone)).
+			map(playerData -> Bukkit.getPlayer(UUID.fromString(playerData.getUniqueId()))).
+			collect(Collectors.toList());
+	}
+
+
+	/**
+	 * This method returns how many times a player has done a challenge before
+	 * @param user - user
+	 * @param challenge - challenge
+	 * @return - number of times
+	 */
+	public long getChallengeTimes(User user, Challenge challenge)
+	{
+		this.addPlayer(user);
+		return this.playerCacheData.get(user.getUniqueId()).getTimes(challenge.getUniqueId());
+	}
+
+
+	/**
+	 * Checks if a challenge is complete or not
+	 *
+	 * @param user - User who must be checked.
+	 * @param challenge - Challenge
+	 * @return - true if completed
+	 */
+	public boolean isChallengeComplete(User user, Challenge challenge)
+	{
+		this.addPlayer(user);
+		return this.playerCacheData.get(user.getUniqueId()).isChallengeDone(challenge.getUniqueId());
+	}
+
+
+	/**
+	 * Get the status on every level
+	 *
+	 * @param user - user
+	 * @param world - world
+	 * @return Level status - how many challenges still to do on which level
+	 */
+	public List<LevelStatus> getChallengeLevelStatus(User user, World world)
+	{
+		this.addPlayer(user);
+		ChallengesPlayerData playerData = this.playerCacheData.get(user.getUniqueId());
+
+		List<ChallengeLevel> challengeLevelList = this.getLevels(world);
+
+		List<LevelStatus> result = new ArrayList<>();
+
+		// The first level is always unlocked and previous for it is null.
+		ChallengeLevel previousLevel = null;
+		int doneChallengeCount = 0;
+
+		// For each challenge level, check how many the user has done
+		for (ChallengeLevel level : challengeLevelList)
+		{
+			// To find how many challenges user still must do in previous level, we must
+			// know how many challenges there were and how many has been done. Then
+			// from waiver amount remove calculated value and you get count.
+
+			int challengesToDo = previousLevel == null ? 0 :
+				level.getWaiverAmount() - (previousLevel.getChallenges().size() - doneChallengeCount);
+
+			// As level already contains unique ids of challenges, just iterate through them.
+			doneChallengeCount = (int) level.getChallenges().stream().filter(playerData::isChallengeDone).count();
+
+			result.add(new LevelStatus(
+				level,
+				previousLevel,
+				challengesToDo,
+				level.getChallenges().size() == doneChallengeCount,
+				challengesToDo <= 0));
+
+			previousLevel = level;
+		}
+
+		return result;
+	}
+
+
+	/**
+	 * Check is user can see given level.
+	 *
+	 * @param user - user
+	 * @param world - world
+	 * @param level - level
+	 * @return true if level is unlocked
+	 */
+	public boolean isLevelUnlocked(User user, World world, ChallengeLevel level)
+	{
+		this.addPlayer(user);
+
+		return this.getChallengeLevelStatus(user, world).stream().
+			filter(LevelStatus::isUnlocked).
+			anyMatch(lv -> lv.getLevel().equals(level));
+	}
+
+
+	/**
+	 * Sets the challenge as complete and increments the number of times it has been
+	 * completed
+	 *
+	 * @param user - user
+	 * @param challenge - challenge
+	 */
+	public void setChallengeComplete(User user, Challenge challenge)
+	{
+		this.addPlayer(user);
+		this.playerCacheData.get(user.getUniqueId()).setChallengeDone(challenge.getUniqueId());
+		// Save
+		this.savePlayer(user.getUniqueId());
+	}
+
+
+	/**
+	 * Reset the challenge to zero time / not done
+	 *
+	 * @param user - user
+	 * @param challenge - challenge
+	 */
+	public void resetChallenge(User user, Challenge challenge)
+	{
+		this.addPlayer(user);
+		this.playerCacheData.get(user.getUniqueId()).setChallengeTimes(challenge.getUniqueId(), 0);
+		// Save
+		this.savePlayer(user.getUniqueId());
+	}
+
+
+
+	/**
+	 * Resets all the challenges for user in world
+	 *
+	 * @param user - island owner's UUID
+	 * @param world - world
+	 */
+	public void resetAllChallenges(User user, World world)
+	{
+		this.addPlayer(user);
+		this.playerCacheData.get(user.getUniqueId()).reset(world);
+		// Save
+		this.savePlayer(user.getUniqueId());
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Challenges related methods
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * Get the list of all challenge unique names for world.
+	 *
+	 * @param world - the world to check
+	 * @return List of challenge names
+	 */
+	public List<String> getAllChallengesNames(World world)
+	{
+		String worldName = Util.getWorld(world).getName();
+		// TODO: Probably need to check also database.
+		return this.challengeCacheData.values().stream().
+			sorted(Comparator.comparing(Challenge::getOrder)).
+			filter(challenge -> challenge.getUniqueId().startsWith(worldName)).
+			map(Challenge::getUniqueId).
+			collect(Collectors.toList());
+	}
+
+
+	/**
+	 * Get the list of all challenge for world.
+	 *
+	 * @param world - the world to check
+	 * @return List of challenges
+	 */
+	public List<Challenge> getAllChallenges(World world)
+	{
+		String worldName = Util.getWorld(world).getName();
+		// TODO: Probably need to check also database.
+		return this.challengeCacheData.values().stream().
+			sorted(Comparator.comparing(Challenge::getOrder)).
+			filter(challenge -> challenge.getUniqueId().startsWith(worldName)).
+			collect(Collectors.toList());
+	}
+
+
+	/**
+	 * Free challenges... Challenges without a level.
+	 * @param world World in which challenges must be searched.
+	 * @return List with free challenges in given world.
+	 */
+	public List<Challenge> getFreeChallenges(World world)
+	{
+		// Free Challenges hides under FREE level.
+		return this.getAllChallenges(world).stream().
+			filter(challenge -> challenge.getLevel().equals(FREE)).
+			collect(Collectors.toList());
+	}
+
+
+	/**
+	 * Level which challenges must be received
+	 * @param level Challenge level.
+	 * @return List with challenges in given level.
+	 */
+	public List<Challenge> getLevelChallenges(ChallengeLevel level)
+	{
+		return level.getChallenges().stream().
+			map(this::getChallenge).
+			filter(Objects::nonNull).
+			collect(Collectors.toList());
+	}
+
+
+	/**
+	 * Get challenge by name. Case sensitive
+	 *
+	 * @param name - unique name of challenge
+	 * @return - challenge or null if it does not exist
+	 */
+	public Challenge getChallenge(String name)
+	{
+		if (this.challengeCacheData.containsKey(name))
+		{
+			return this.challengeCacheData.get(name);
+		}
+		else
+		{
+			// check database.
+			if (this.challengeDatabase.objectExists(name))
+			{
+				Challenge challenge = this.challengeDatabase.loadObject(name);
+				this.challengeCacheData.put(name, challenge);
+				return challenge;
+			}
+		}
+
 		return null;
 	}
 
 
-	public void addChallengeToLevel(Challenge newChallenge, ChallengeLevel level)
+	/**
+	 * Check if a challenge exists - case insensitive
+	 *
+	 * @param name - name of challenge
+	 * @return true if it exists, otherwise false
+	 */
+	public boolean containsChallenge(String name)
 	{
+		if (this.challengeCacheData.containsKey(name))
+		{
+			return true;
+		}
+		else
+		{
+			// check database.
+			if (this.challengeDatabase.objectExists(name))
+			{
+				Challenge challenge = this.challengeDatabase.loadObject(name);
+				this.challengeCacheData.put(name, challenge);
+				return true;
+			}
+		}
 
+		return false;
+	}
+
+
+	/**
+	 * This method creates and returns new challenge with given uniqueID.
+	 * @param uniqueID - new ID for challenge.
+	 * @return Challenge that is currently created.
+	 */
+	public Challenge createChallenge(String uniqueID)
+	{
+		if (!this.containsChallenge(uniqueID))
+		{
+			Challenge challenge = new Challenge();
+			challenge.setUniqueId(uniqueID);
+
+			this.saveChallenge(challenge);
+			this.loadChallenge(challenge);
+
+			return challenge;
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+
+	/**
+	 * This method removes challenge from cache and memory.
+	 * @param challenge that must be removed.
+	 */
+	public void deleteChallenge(Challenge challenge)
+	{
+		if (this.challengeCacheData.containsKey(challenge.getUniqueId()))
+		{
+			this.challengeCacheData.remove(challenge.getUniqueId());
+			this.challengeDatabase.deleteObject(challenge);
+		}
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Level related methods
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * This method returns list of challenge levels in given world.
+	 * @param world for which levels must be searched.
+	 * @return List with challenges in given world.
+	 */
+	public List<ChallengeLevel> getLevels(World world)
+	{
+		String worldName = Util.getWorld(world).getName();
+		// TODO: Probably need to check also database.
+		return this.levelCacheData.values().stream().
+			sorted(ChallengeLevel::compareTo).
+			filter(challenge -> challenge.getUniqueId().startsWith(worldName)).
+			collect(Collectors.toList());
+	}
+
+
+	/**
+	 * Get challenge level by its challenge.
+	 *
+	 * @param challenge - challenge which level must be returned.
+	 * @return - challenge level or null if it does not exist
+	 */
+	public ChallengeLevel getLevel(Challenge challenge)
+	{
+		if (!challenge.getLevel().equals(FREE))
+		{
+			return this.getLevel(challenge.getLevel());
+		}
+
+		return new ChallengeLevel();
+	}
+
+
+	/**
+	 * Get challenge level by name. Case sensitive
+	 *
+	 * @param name - unique name of challenge level
+	 * @return - challenge level or null if it does not exist
+	 */
+	public ChallengeLevel getLevel(String name)
+	{
+		if (this.levelCacheData.containsKey(name))
+		{
+			return this.levelCacheData.get(name);
+		}
+		else
+		{
+			// check database.
+			if (this.levelDatabase.objectExists(name))
+			{
+				ChallengeLevel level = this.levelDatabase.loadObject(name);
+				this.levelCacheData.put(name, level);
+				return level;
+			}
+		}
+
+		return null;
+	}
+
+
+	/**
+	 * Check if a challenge level exists - case insensitive
+	 *
+	 * @param name - name of challenge level
+	 * @return true if it exists, otherwise false
+	 */
+	public boolean containsLevel(String name)
+	{
+		if (this.levelCacheData.containsKey(name))
+		{
+			return true;
+		}
+		else
+		{
+			// check database.
+			if (this.levelDatabase.objectExists(name))
+			{
+				ChallengeLevel level = this.levelDatabase.loadObject(name);
+				this.levelCacheData.put(name, level);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+
+	/**
+	 * This method adds given challenge to given challenge level.
+	 * @param newChallenge Challenge who must change owner.
+	 * @param newLevel Level who must add new challenge
+	 */
+	public void addChallengeToLevel(Challenge newChallenge, ChallengeLevel newLevel)
+	{
+		if (newChallenge.getLevel().equals(FREE))
+		{
+			newLevel.getChallenges().add(newChallenge.getUniqueId());
+			newChallenge.setLevel(newLevel.getUniqueId());
+
+			this.saveLevel(newLevel);
+			this.saveChallenge(newChallenge);
+		}
+		else
+		{
+			ChallengeLevel oldLevel = this.getLevel(newChallenge.getLevel());
+
+			if (!oldLevel.equals(newLevel))
+			{
+				this.removeChallengeFromLevel(newChallenge, newLevel);
+				newLevel.getChallenges().add(newChallenge.getUniqueId());
+				newChallenge.setLevel(newLevel.getUniqueId());
+
+				this.saveLevel(newLevel);
+				this.saveChallenge(newChallenge);
+			}
+		}
+	}
+
+
+	/**
+	 * This method removes given challenge from given challenge level.
+	 * @param challenge Challenge which must leave level.
+	 * @param level level which lost challenge
+	 */
+	public void removeChallengeFromLevel(Challenge challenge, ChallengeLevel level)
+	{
+		if (level.getChallenges().contains(challenge.getUniqueId()))
+		{
+			level.getChallenges().remove(challenge.getUniqueId());
+			challenge.setLevel(FREE);
+			this.saveLevel(level);
+			this.saveChallenge(challenge);
+		}
+	}
+
+
+	/**
+	 * This method creates and returns new challenges level with given uniqueID.
+	 * @param uniqueID - new ID for challenge level.
+	 * @return ChallengeLevel that is currently created.
+	 */
+	public ChallengeLevel createLevel(String uniqueID)
+	{
+		if (!this.containsLevel(uniqueID))
+		{
+			ChallengeLevel level = new ChallengeLevel();
+			level.setUniqueId(uniqueID);
+
+			this.saveLevel(level);
+			this.loadLevel(level);
+
+			return level;
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+
+	/**
+	 * This method removes challenge level from cache and memory.
+	 * @param challengeLevel Level that must be removed.
+	 */
+	public void deleteChallengeLevel(ChallengeLevel challengeLevel)
+	{
+		if (this.levelCacheData.containsKey(challengeLevel.getUniqueId()))
+		{
+			this.levelCacheData.remove(challengeLevel.getUniqueId());
+			this.levelDatabase.deleteObject(challengeLevel);
+		}
 	}
 }

--- a/src/main/java/world/bentobox/challenges/ChallengesManager.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesManager.java
@@ -22,6 +22,8 @@ import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.challenges.database.object.Challenge.ChallengeType;
 import world.bentobox.challenges.database.object.ChallengesPlayerData;
 import world.bentobox.challenges.panel.ChallengesPanels;
+import world.bentobox.challenges.utils.LevelStatus;
+
 
 public class ChallengesManager {
 

--- a/src/main/java/world/bentobox/challenges/LevelStatus.java
+++ b/src/main/java/world/bentobox/challenges/LevelStatus.java
@@ -1,6 +1,6 @@
 package world.bentobox.challenges;
 
-import world.bentobox.challenges.database.object.ChallengeLevels;
+import world.bentobox.challenges.database.object.ChallengeLevel;
 
 /**
  * Level status class
@@ -8,8 +8,8 @@ import world.bentobox.challenges.database.object.ChallengeLevels;
  *
  */
 public class LevelStatus {
-    private final ChallengeLevels level;
-    private final ChallengeLevels previousLevel;
+    private final ChallengeLevel level;
+    private final ChallengeLevel previousLevel;
     private final int numberOfChallengesStillToDo;
     private final boolean complete;
     private final boolean isUnlocked;
@@ -21,7 +21,7 @@ public class LevelStatus {
      * @param complete - whether complete or not
      * @param isUnlocked 
      */
-    public LevelStatus(ChallengeLevels level, ChallengeLevels previousLevel, int numberOfChallengesStillToDo, boolean complete, boolean isUnlocked) {
+    public LevelStatus(ChallengeLevel level, ChallengeLevel previousLevel, int numberOfChallengesStillToDo, boolean complete, boolean isUnlocked) {
         super();
         this.level = level;
         this.previousLevel = previousLevel;
@@ -32,7 +32,7 @@ public class LevelStatus {
     /**
      * @return the level
      */
-    public ChallengeLevels getLevel() {
+    public ChallengeLevel getLevel() {
         return level;
     }
     /**
@@ -44,7 +44,7 @@ public class LevelStatus {
     /**
      * @return the previousLevel
      */
-    public ChallengeLevels getPreviousLevel() {
+    public ChallengeLevel getPreviousLevel() {
         return previousLevel;
     }
     /**

--- a/src/main/java/world/bentobox/challenges/ParseItem.java
+++ b/src/main/java/world/bentobox/challenges/ParseItem.java
@@ -11,7 +11,10 @@ import org.bukkit.potion.PotionType;
  * Used for converting config file entries to objects
  * @author tastybento
  *
+ * @deprecated
+ * @see world.bentobox.bentobox.util.ItemParser#parse(String)
  */
+@Deprecated
 public class ParseItem {
 
     private final ItemStack item;

--- a/src/main/java/world/bentobox/challenges/Settings.java
+++ b/src/main/java/world/bentobox/challenges/Settings.java
@@ -38,6 +38,10 @@ public class Settings implements DataObject
 	private boolean addCompletedGlow = true;
 
 	@ConfigComment("")
+	@ConfigComment("This indicate if free challenges must be at the start (true) or at the end (false) of list.")
+	private boolean freeChallengesFirst = true;
+
+	@ConfigComment("")
 	@ConfigComment("This list stores GameModes in which Challenges addon should not work.")
 	@ConfigComment("To disable addon it is necessary to write its name in new line that starts with -. Example:")
 	@ConfigComment("disabled-gamemodes:")
@@ -109,6 +113,15 @@ public class Settings implements DataObject
 	}
 
 
+	/**
+	 * @return freeChallengesFirst value.
+	 */
+	public boolean isFreeChallengesFirst()
+	{
+		return this.freeChallengesFirst;
+	}
+
+
 	@Override
 	public void setUniqueId(String uniqueId)
 	{
@@ -158,5 +171,14 @@ public class Settings implements DataObject
 	public void setDisabledGameModes(Set<String> disabledGameModes)
 	{
 		this.disabledGameModes = disabledGameModes;
+	}
+
+
+	/**
+	 * @param freeChallengesFirst new freeChallengesFirst value.
+	 */
+	public void setFreeChallengesFirst(boolean freeChallengesFirst)
+	{
+		this.freeChallengesFirst = freeChallengesFirst;
 	}
 }

--- a/src/main/java/world/bentobox/challenges/commands/ChallengesCommand.java
+++ b/src/main/java/world/bentobox/challenges/commands/ChallengesCommand.java
@@ -3,10 +3,10 @@ package world.bentobox.challenges.commands;
 import java.util.List;
 
 import world.bentobox.challenges.ChallengesAddon;
-import world.bentobox.challenges.panel.ChallengesPanels2;
-import world.bentobox.challenges.panel.ChallengesPanels2.Mode;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.panel.user.ChallengesGUI;
+
 
 public class ChallengesCommand extends CompositeCommand {
     public static final String CHALLENGE_COMMAND = "challenges";
@@ -19,7 +19,11 @@ public class ChallengesCommand extends CompositeCommand {
     public boolean execute(User user, String label, List<String> args) {
         // Open up the challenges GUI
         if (user.isPlayer()) {
-            new ChallengesPanels2((ChallengesAddon) getAddon(), user, user, args.isEmpty() ? "" : args.get(0), getWorld(), getPermissionPrefix(), getTopLabel(), Mode.PLAYER);
+            new ChallengesGUI((ChallengesAddon) this.getAddon(),
+                this.getWorld(),
+                user,
+                this.getTopLabel(),
+                this.getPermissionPrefix()).build();
             return true;
         }
         // Show help

--- a/src/main/java/world/bentobox/challenges/commands/admin/Challenges.java
+++ b/src/main/java/world/bentobox/challenges/commands/admin/Challenges.java
@@ -3,10 +3,10 @@ package world.bentobox.challenges.commands.admin;
 import java.util.List;
 
 import world.bentobox.challenges.ChallengesAddon;
-import world.bentobox.challenges.panel.ChallengesPanels2;
-import world.bentobox.challenges.panel.ChallengesPanels2.Mode;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.panel.admin.AdminGUI;
+
 
 public class Challenges extends CompositeCommand {
 
@@ -25,7 +25,7 @@ public class Challenges extends CompositeCommand {
         this.setDescription("challenges.admin.description");
         // Register sub commands
         new ImportCommand(getAddon(), this);
-        new CompleteChallenge(getAddon(), this);
+        // new CompleteChallenge(getAddon(), this);
         new ReloadChallenges(getAddon(), this);
         new ResetChallenge(getAddon(), this);
         //new ShowChallenges(getAddon(), this);
@@ -37,7 +37,12 @@ public class Challenges extends CompositeCommand {
     public boolean execute(User user, String label, List<String> args) {
         // Open up the admin challenges GUI
         if (user.isPlayer()) {
-            new ChallengesPanels2((ChallengesAddon) getAddon(), user, user, args.isEmpty() ? "" : args.get(0), getWorld(), getPermissionPrefix(), getTopLabel(), Mode.ADMIN);
+            new AdminGUI((ChallengesAddon) this.getAddon(),
+                this.getWorld(),
+                user,
+                this.getTopLabel(),
+                this.getPermissionPrefix()).build();
+
             return true;
         }
         return false;

--- a/src/main/java/world/bentobox/challenges/commands/admin/CompleteChallenge.java
+++ b/src/main/java/world/bentobox/challenges/commands/admin/CompleteChallenge.java
@@ -51,13 +51,13 @@ public class CompleteChallenge extends CompositeCommand {
             return false;
         }
         // Check for valid challenge name
-        if (!manager.isChallenge(getWorld(), args.get(1))) {
+        if (!manager.containsChallenge(args.get(1))) {
             user.sendMessage("challenges.admin.complete.unknown-challenge");
             return false;
         }
         // Complete challenge
         User target = User.getInstance(targetUUID);
-        manager.setChallengeComplete(target, args.get(1), getWorld());
+        manager.setChallengeComplete(target, this.manager.getChallenge(args.get(1)));
         user.sendMessage("general.success");
         return true;
     }
@@ -70,7 +70,7 @@ public class CompleteChallenge extends CompositeCommand {
             return Optional.of(Util.tabLimit(new ArrayList<>(Util.getOnlinePlayerList(user)), lastArg));
         } else if (args.size() == 4) {
             // Challenges in this world
-            return Optional.of(Util.tabLimit(manager.getAllChallengesList(getWorld()), lastArg));
+            return Optional.of(Util.tabLimit(manager.getAllChallengesNames(getWorld()), lastArg));
         }
         return Optional.empty();
     }

--- a/src/main/java/world/bentobox/challenges/commands/admin/CreateChallenge.java
+++ b/src/main/java/world/bentobox/challenges/commands/admin/CreateChallenge.java
@@ -9,6 +9,11 @@ import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.user.User;
 
+
+/**
+ * @deprecated Challenges can be creaded via GUI.
+ */
+@Deprecated
 public class CreateChallenge extends CompositeCommand {
 
     /**

--- a/src/main/java/world/bentobox/challenges/commands/admin/CreateSurrounding.java
+++ b/src/main/java/world/bentobox/challenges/commands/admin/CreateSurrounding.java
@@ -25,8 +25,9 @@ import world.bentobox.bentobox.util.Util;
 /**
  * Command to create a surrounding type challenge
  * @author tastybento
- *
+ * @deprecated Required blocks can be added via GUI. Not necessary.
  */
+@Deprecated
 public class CreateSurrounding extends CompositeCommand implements Listener {
 
     HashMap<UUID,SurroundChallengeBuilder> inProgress = new HashMap<>();

--- a/src/main/java/world/bentobox/challenges/commands/admin/ResetChallenge.java
+++ b/src/main/java/world/bentobox/challenges/commands/admin/ResetChallenge.java
@@ -13,6 +13,11 @@ import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.util.Util;
 
+
+/**
+ * @deprecated Challenges can be reset via GUI.
+ */
+@Deprecated
 public class ResetChallenge extends CompositeCommand {
 
     private ChallengesManager manager;

--- a/src/main/java/world/bentobox/challenges/commands/admin/ResetChallenge.java
+++ b/src/main/java/world/bentobox/challenges/commands/admin/ResetChallenge.java
@@ -56,13 +56,13 @@ public class ResetChallenge extends CompositeCommand {
             return false;
         }
         // Check for valid challenge name
-        if (!manager.isChallenge(getWorld(), args.get(1))) {
+        if (!manager.containsChallenge(args.get(1))) {
             user.sendMessage("challenges.admin.complete.unknown-challenge");
             return false;
         }
         // Complete challenge
         User target = User.getInstance(targetUUID);
-        manager.setResetChallenge(target, args.get(1), getWorld());
+        manager.resetChallenge(target, manager.getChallenge(args.get(1)));
         user.sendMessage("general.success");
         return true;
     }
@@ -75,7 +75,7 @@ public class ResetChallenge extends CompositeCommand {
             return Optional.of(Util.tabLimit(new ArrayList<>(Util.getOnlinePlayerList(user)), lastArg));
         } else if (args.size() == 4) {
             // Challenges in this world
-            return Optional.of(Util.tabLimit(manager.getAllChallengesList(getWorld()), lastArg));
+            return Optional.of(Util.tabLimit(manager.getAllChallengesNames(getWorld()), lastArg));
         }
         return Optional.empty();
     }

--- a/src/main/java/world/bentobox/challenges/commands/admin/ShowChallenges.java
+++ b/src/main/java/world/bentobox/challenges/commands/admin/ShowChallenges.java
@@ -28,7 +28,7 @@ public class ShowChallenges extends CompositeCommand {
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        ((ChallengesAddon)getAddon()).getChallengesManager().getAllChallengesList().forEach(user::sendRawMessage);
+        ((ChallengesAddon)getAddon()).getChallengesManager().getAllChallengesNames(this.getWorld()).forEach(user::sendRawMessage);
         return true;
     }
 

--- a/src/main/java/world/bentobox/challenges/commands/admin/SurroundChallengeBuilder.java
+++ b/src/main/java/world/bentobox/challenges/commands/admin/SurroundChallengeBuilder.java
@@ -77,7 +77,7 @@ public class SurroundChallengeBuilder {
     }
 
     public boolean build() {
-        return addon.getChallengesManager().createSurroundingChallenge(this);
+        return false; //addon.getChallengesManager().createSurroundingChallenge(this);
         
     }
 

--- a/src/main/java/world/bentobox/challenges/commands/admin/SurroundChallengeBuilder.java
+++ b/src/main/java/world/bentobox/challenges/commands/admin/SurroundChallengeBuilder.java
@@ -12,8 +12,9 @@ import world.bentobox.bentobox.api.user.User;
 /**
  * Enables the state of a Surrounding Challenge to be stored as it is built
  * @author tastybento
- *
+ * @deprecated Levels and challenges can be created via GUI. Not necessary command.
  */
+@Deprecated
 public class SurroundChallengeBuilder {
     private ChallengesAddon addon;
     private String name;

--- a/src/main/java/world/bentobox/challenges/database/object/Challenge.java
+++ b/src/main/java/world/bentobox/challenges/database/object/Challenge.java
@@ -16,9 +16,9 @@ import world.bentobox.challenges.ChallengesManager;
  * @author tastybento
  *
  */
-public class Challenges implements DataObject {
+public class Challenge implements DataObject {
 
-    public Challenges() {}
+    public Challenge() {}
 
 
     public boolean isRemoveEntities()
@@ -649,10 +649,10 @@ public class Challenges implements DataObject {
         if (obj == null) {
             return false;
         }
-        if (!(obj instanceof Challenges)) {
+        if (!(obj instanceof Challenge)) {
             return false;
         }
-        Challenges other = (Challenges) obj;
+        Challenge other = (Challenge) obj;
         if (uniqueId == null) {
             if (other.uniqueId != null) {
                 return false;

--- a/src/main/java/world/bentobox/challenges/database/object/Challenge.java
+++ b/src/main/java/world/bentobox/challenges/database/object/Challenge.java
@@ -308,7 +308,7 @@ public class Challenge implements DataObject
      */
     public ItemStack getIcon()
     {
-        return icon;
+        return icon.clone();
     }
 
 

--- a/src/main/java/world/bentobox/challenges/database/object/Challenge.java
+++ b/src/main/java/world/bentobox/challenges/database/object/Challenge.java
@@ -1,6 +1,7 @@
 package world.bentobox.challenges.database.object;
 
 
+import com.google.gson.annotations.Expose;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.EntityType;
@@ -9,657 +10,1012 @@ import java.util.*;
 
 import world.bentobox.bentobox.api.configuration.ConfigComment;
 import world.bentobox.bentobox.database.objects.DataObject;
-import world.bentobox.challenges.ChallengesManager;
+
 
 /**
  * Data object for challenges
  * @author tastybento
  *
  */
-public class Challenge implements DataObject {
-
-    public Challenge() {}
-
-
-    public boolean isRemoveEntities()
+public class Challenge implements DataObject
+{
+    /**
+     * Empty constructor
+     */
+    public Challenge()
     {
-        return false;
     }
 
 
-    public void setRemoveEntities(boolean b)
+    /**
+     * This enum holds all Challenge Types.
+     */
+    public enum ChallengeType
     {
-
-    }
-
-
-    public boolean isRemoveBlocks()
-    {
-        return false;
-    }
-
-
-    public void setRemoveBlocks(boolean b)
-    {
-
-    }
-
-
-    public boolean isTakeExperience()
-    {
-        return false;
-    }
-
-
-    public void setTakeExperience(boolean b)
-    {
-
-    }
-
-
-    public enum ChallengeType {
-        /**
-         * This challenge only shows and icon in the GUI and doesn't do anything.
-         */
-        ICON,
         /**
          * The player must have the items on them.
          */
         INVENTORY,
-        /**
-         * The island level has to be equal or over this amount. Only works if there's an island level plugin installed.
-         */
-        LEVEL,
+
         /**
          * Items or required entities have to be within x blocks of the player.
          */
-        ISLAND
+        ISLAND,
+
+        /**
+         * Other type, like required money / experience or island level. This my request
+         * other plugins to be setup before it could work.
+         */
+        OTHER,
     }
 
-    // The order of the fields is the order shown in the YML files
-    @ConfigComment("Whether this challenge is deployed or not")
-    private boolean deployed;
 
-    // Description
-    @ConfigComment("Name of the icon and challenge. May include color codes. Single line.")
-    private String friendlyName = "";
-    @ConfigComment("Description of the challenge. Will become the lore on the icon. Can include & color codes. String List.")
-    private List<String> description = new ArrayList<>();
-    @ConfigComment("The icon in the GUI for this challenge. ItemStack.")
-    private ItemStack icon = new ItemStack(Material.PAPER);
-    @ConfigComment("Icon slot where this challenge should be placed. 0 to 49. A negative value means any slot")
-    private int slot = -1;
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
 
-    // Definition
-    @ConfigComment("Challenge level. Default is Free")
-    private String level = ChallengesManager.FREE;
-    @ConfigComment("Challenge type can be ICON, INVENTORY, LEVEL or ISLAND.")
-    private ChallengeType challengeType = ChallengeType.INVENTORY;
-    @ConfigComment("World where this challenge operates. List only overworld. Nether and end are automatically covered.")
-    private String world = "";
-    @ConfigComment("List of environments where this challenge will occur: NETHER, NORMAL, THE_END. Leave blank for all.")
-    private Set<World.Environment> environment = new HashSet<>();
-    @ConfigComment("The required permissions to see this challenge. String list.")
-    private Set<String> reqPerms = new HashSet<>();
-    @ConfigComment("The number of blocks around the player to search for items on an island")
-    private int searchRadius = 10;
-    @ConfigComment("If true, the challenge will disappear from the GUI when completed")
-    private boolean removeWhenCompleted;
-    @ConfigComment("Take the required items from the player")
-    private boolean takeItems = true;
-    @ConfigComment("Take the money from the player")
-    private boolean takeMoney = false;
-
-    // Requirements
-    @ConfigComment("This is a map of the blocks required in a ISLAND challenge. Material, Integer")
-    private Map<Material, Integer> requiredBlocks = new EnumMap<>(Material.class);
-    @ConfigComment("The items that must be in the inventory to complete the challenge. ItemStack List.")
-    private List<ItemStack> requiredItems = new ArrayList<>();
-    @ConfigComment("Any entities that must be in the area for ISLAND type challenges. Map EntityType, Number")
-    private Map<EntityType, Integer> requiredEntities = new EnumMap<>(EntityType.class);
-    @ConfigComment("Required experience")
-    private int reqExp;
-    @ConfigComment("Required island level for this challenge. Only works if Level Addon is being used.")
-    private long reqIslandlevel;
-    @ConfigComment("Required money")
-    private int reqMoney;
-
-    // Rewards
-    @ConfigComment("List of items the player will receive first time. ItemStack List.")
-    private List<ItemStack> rewardItems = new ArrayList<>();
-    @ConfigComment("If this is blank, the reward text will be auto-generated, otherwise this will be used.")
-    private String rewardText = "";
-    @ConfigComment("Experience point reward")
-    private int rewardExp;
-    @ConfigComment("Money reward")
-    private int rewardMoney;
-    @ConfigComment("Commands to run when the player completes the challenge for the first time. String List")
-    private List<String> rewardCommands = new ArrayList<>();
-
-    // Repeatable
-    @ConfigComment("True if the challenge is repeatable")
-    private boolean repeatable;
-    @ConfigComment("Maximum number of times the challenge can be repeated")
-    private int maxTimes = 1;
-    @ConfigComment("Repeat exp award")
-    private int repeatExpReward;
-    @ConfigComment("Reward items for repeating the challenge. List of ItemStacks.")
-    private List<ItemStack> repeatItemReward = new ArrayList<>();
-    @ConfigComment("Repeat money award")
-    private int repeatMoneyReward;
-    @ConfigComment("Commands to run when challenge is repeated. String List.")
-    private List<String> repeatRewardCommands = new ArrayList<>();
-    @ConfigComment("Description of the repeat rewards. If blank, it will be autogenerated.")
-    private String repeatRewardText = "";
-
-
+    @ConfigComment("")
     @ConfigComment("Unique name of the challenge")
+    @Expose
     private String uniqueId = "";
 
-    /*
-     * END OF SETTINGS
-     */
-
-    /**
-     * @return the challengeType
-     */
-    public ChallengeType getChallengeType() {
-        return challengeType;
-    }
-
-    /**
-     * @param challengeType the challengeType to set
-     */
-    public void setChallengeType(ChallengeType challengeType) {
-        this.challengeType = challengeType;
-    }
-
-    /**
-     * @return the deployed
-     */
-    public boolean isDeployed() {
-        return deployed;
-    }
-
-    /**
-     * @param deployed the deployed to set
-     */
-    public void setDeployed(boolean deployed) {
-        this.deployed = deployed;
-    }
-
-    /**
-     * @return the description
-     */
-    public List<String> getDescription() {
-        return description;
-    }
-
-    /**
-     * @param description the description to set
-     */
-    public void setDescription(List<String> description) {
-        this.description = description;
-    }
-
-    /**
-     * @return the expReward
-     */
-    public int getRewardExp() {
-        return rewardExp;
-    }
-
-    /**
-     * @param expReward the expReward to set
-     */
-    public void setRewardExp(int expReward) {
-        this.rewardExp = expReward;
-    }
-
-    /**
-     * @return the friendlyName
-     */
-    public String getFriendlyName() {
-        return friendlyName;
-    }
-
-    /**
-     * @param friendlyName the friendlyName to set
-     */
-    public void setFriendlyName(String friendlyName) {
-        this.friendlyName = friendlyName;
-    }
-
-    /**
-     * @return the icon
-     */
-    public ItemStack getIcon() {
-        return icon != null ? icon.clone() : new ItemStack(Material.MAP);
-    }
-
-    /**
-     * @param icon the icon to set
-     */
-    public void setIcon(ItemStack icon) {
-        this.icon = icon;
-    }
-
-    /**
-     * @return the level
-     */
-    public String getLevel() {
-        return level;
-    }
-
-    /**
-     * @param level the level to set
-     */
-    public void setLevel(String level) {
-        if (level.isEmpty()) {
-            level = ChallengesManager.FREE;
-        }
-        this.level = level;
-    }
-
-    /**
-     * @return the maxTimes
-     */
-    public int getMaxTimes() {
-        return maxTimes;
-    }
-
-    /**
-     * @param maxTimes the maxTimes to set
-     */
-    public void setMaxTimes(int maxTimes) {
-        this.maxTimes = maxTimes;
-    }
-
-    /**
-     * @return the moneyReward
-     */
-    public int getRewardMoney() {
-        return rewardMoney;
-    }
-
-    /**
-     * @param moneyReward the moneyReward to set
-     */
-    public void setRewardMoney(int moneyReward) {
-        this.rewardMoney = moneyReward;
-    }
-
-    /**
-     * @return the removeWhenCompleted
-     */
-    public boolean isRemoveWhenCompleted() {
-        return removeWhenCompleted;
-    }
-
-    /**
-     * @param removeWhenCompleted the removeWhenCompleted to set
-     */
-    public void setRemoveWhenCompleted(boolean removeWhenCompleted) {
-        this.removeWhenCompleted = removeWhenCompleted;
-    }
-
-    /**
-     * @return the repeatable
-     */
-    public boolean isRepeatable() {
-        return repeatable;
-    }
-
-    /**
-     * @param repeatable the repeatable to set
-     */
-    public void setRepeatable(boolean repeatable) {
-        this.repeatable = repeatable;
-    }
-
-    /**
-     * @return the repeatExpReward
-     */
-    public int getRepeatExpReward() {
-        return repeatExpReward;
-    }
-
-    /**
-     * @param repeatExpReward the repeatExpReward to set
-     */
-    public void setRepeatExpReward(int repeatExpReward) {
-        this.repeatExpReward = repeatExpReward;
-    }
-
-    /**
-     * @return the repeatItemReward
-     */
-    public List<ItemStack> getRepeatItemReward() {
-        return repeatItemReward;
-    }
-
-    /**
-     * @param repeatItemReward the repeatItemReward to set
-     */
-    public void setRepeatItemReward(List<ItemStack> repeatItemReward) {
-        this.repeatItemReward = repeatItemReward;
-    }
-
-    /**
-     * @return the repeatMoneyReward
-     */
-    public int getRepeatMoneyReward() {
-        return repeatMoneyReward;
-    }
-
-    /**
-     * @param repeatMoneyReward the repeatMoneyReward to set
-     */
-    public void setRepeatMoneyReward(int repeatMoneyReward) {
-        this.repeatMoneyReward = repeatMoneyReward;
-    }
-
-    /**
-     * @return the repeatRewardCommands
-     */
-    public List<String> getRepeatRewardCommands() {
-        return repeatRewardCommands;
-    }
-
-    /**
-     * @param repeatRewardCommands the repeatRewardCommands to set
-     */
-    public void setRepeatRewardCommands(List<String> repeatRewardCommands) {
-        this.repeatRewardCommands = repeatRewardCommands;
-    }
-
-    /**
-     * @return the repeatRewardText
-     */
-    public String getRepeatRewardText() {
-        return repeatRewardText;
-    }
-
-    /**
-     * @param repeatRewardText the repeatRewardText to set
-     */
-    public void setRepeatRewardText(String repeatRewardText) {
-        this.repeatRewardText = repeatRewardText;
-    }
-
-    /**
-     * @return the reqExp
-     */
-    public int getReqExp() {
-        return reqExp;
-    }
-
-    /**
-     * @param reqExp the reqExp to set
-     */
-    public void setReqExp(int reqExp) {
-        this.reqExp = reqExp;
-    }
-
-    /**
-     * @return the reqIslandlevel
-     */
-    public long getReqIslandlevel() {
-        return reqIslandlevel;
-    }
-
-    /**
-     * @param reqIslandlevel the reqIslandlevel to set
-     */
-    public void setReqIslandlevel(long reqIslandlevel) {
-        this.reqIslandlevel = reqIslandlevel;
-    }
-
-    /**
-     * @return the reqMoney
-     */
-    public int getReqMoney() {
-        return reqMoney;
-    }
-
-    /**
-     * @param reqMoney the reqMoney to set
-     */
-    public void setReqMoney(int reqMoney) {
-        this.reqMoney = reqMoney;
-    }
-
-    /**
-     * @return the reqPerms
-     */
-    public Set<String> getReqPerms() {
-        return reqPerms;
-    }
-
-    /**
-     * @param reqPerms the reqPerms to set
-     */
-    public void setReqPerms(Set<String> reqPerms) {
-        this.reqPerms = reqPerms;
-    }
-
-    /**
-     * @return the requiredItems
-     */
-    public List<ItemStack> getRequiredItems() {
-        return requiredItems;
-    }
-
-    /**
-     * @param requiredItems the requiredItems to set
-     */
-    public void setRequiredItems(List<ItemStack> requiredItems) {
-        this.requiredItems = requiredItems;
-    }
-
-    /**
-     * @return requiredEntities
-     */
-    public Map<EntityType, Integer> getRequiredEntities() {
-        return requiredEntities;
-    }
-
-    /**
-     * @param requiredEntities the requiredEntities to set
-     */
-    public void setRequiredEntities(Map<EntityType, Integer> requiredEntities) {
-        this.requiredEntities = requiredEntities;
-    }
-
-    /**
-     * @return the requiredBlocks
-     */
-    public Map<Material, Integer> getRequiredBlocks() {
-        return requiredBlocks;
-    }
-
-    /**
-     * @param map the requiredBlocks to set
-     */
-    public void setRequiredBlocks(Map<Material, Integer> map) {
-        this.requiredBlocks = map;
-    }
-
-    /**
-     * @return the rewardCommands
-     */
-    public List<String> getRewardCommands() {
-        return rewardCommands;
-    }
-
-    /**
-     * @param rewardCommands the rewardCommands to set
-     */
-    public void setRewardCommands(List<String> rewardCommands) {
-        this.rewardCommands = rewardCommands;
-    }
-
-    /**
-     * @return the itemReward
-     */
-    public List<ItemStack> getRewardItems() {
-        return rewardItems;
-    }
-
-    /**
-     * @param itemReward the itemReward to set
-     */
-    public void setRewardItems(List<ItemStack> itemReward) {
-        this.rewardItems = itemReward;
-    }
-
-    /**
-     * @return the rewardText
-     */
-    public String getRewardText() {
-        return rewardText;
-    }
-
-    /**
-     * @param rewardText the rewardText to set
-     */
-    public void setRewardText(String rewardText) {
-        this.rewardText = rewardText;
-    }
-
-    /**
-     * @return the searchRadius
-     */
-    public int getSearchRadius() {
-        return searchRadius;
-    }
-
-    /**
-     * @param searchRadius the searchRadius to set
-     */
-    public void setSearchRadius(int searchRadius) {
-        this.searchRadius = searchRadius;
-    }
-
-    /**
-     * @return the slot
-     */
-    public int getSlot() {
-        return slot;
-    }
-
-    /**
-     * @param slot the slot to set
-     */
-    public void setSlot(int slot) {
-        this.slot = slot;
-    }
-
-    /**
-     * @return the takeItems
-     */
-    public boolean isTakeItems() {
-        return takeItems;
-    }
-
-    /**
-     * @param takeItems the takeItems to set
-     */
-    public void setTakeItems(boolean takeItems) {
-        this.takeItems = takeItems;
-    }
-
-    /**
-     * @return the takeMoney
-     */
-    public boolean isTakeMoney() {
-        return takeMoney;
-    }
-
-    /**
-     * @param takeMoney the takeMoney to set
-     */
-    public void setTakeMoney(boolean takeMoney) {
-        this.takeMoney = takeMoney;
-    }
-
-    /**
-     * @return the environment
-     */
-    public Set<World.Environment> getEnvironment() {
-        return environment;
-    }
-
-    /**
-     * @param environment the environment to set
-     */
-    public void setEnvironment(Set<World.Environment> environment) {
-        this.environment = environment;
-    }
-
-    /**
-     * @return the worlds
-     */
-    public String getWorld() {
-        return world;
-    }
-
-    /**
-     * @param worlds the worlds to set
-     */
-    public void setWorld(String world) {
-        this.world = world;
-    }
+    @ConfigComment("")
+    @ConfigComment("The name of the challenge. May include color codes. Single line.")
+    @Expose
+    private String friendlyName = "";
+
+    @ConfigComment("")
+    @ConfigComment("Whether this challenge is deployed or not.")
+    @Expose
+    private boolean deployed;
+
+    @ConfigComment("")
+    @ConfigComment("Description of the challenge. Will become the lore on the icon. Can ")
+    @ConfigComment("include & color codes. String List.")
+    @Expose
+    private List<String> description = new ArrayList<>();
+
+    @ConfigComment("")
+    @ConfigComment("The icon in the GUI for this challenge. ItemStack.")
+    @Expose
+    private ItemStack icon = new ItemStack(Material.PAPER);
+
+    @ConfigComment("")
+    @ConfigComment("Order of this challenge. It allows define order for challenges in")
+    @ConfigComment("single level. If order for challenges are equal, it will order by")
+    @ConfigComment("challenge unique id.")
+    @Expose
+    private int order = -1;
+
+    @ConfigComment("")
+    @ConfigComment("Challenge type can be INVENTORY, OTHER or ISLAND.")
+    @Expose
+    private ChallengeType challengeType = ChallengeType.INVENTORY;
+
+    @ConfigComment("")
+    @ConfigComment("List of environments where this challenge will occur: NETHER, NORMAL,")
+    @ConfigComment("THE_END. Leave blank for all.")
+    @Expose
+    private Set<World.Environment> environment = new HashSet<>();
+
+    @ConfigComment("")
+    @ConfigComment("If true, the challenge will disappear from the GUI when completed")
+    @Expose
+    private boolean removeWhenCompleted;
+
+    @ConfigComment("")
+    @ConfigComment("Unique challenge ID. Empty means that challenge is in free challenge list.")
+    @Expose
+    private String level = "";
+
+// ---------------------------------------------------------------------
+// Section: Requirement related
+// ---------------------------------------------------------------------
+
+    @ConfigComment("")
+    @ConfigComment("")
+    @ConfigComment("The required permissions to see this challenge. String list.")
+    @Expose
+    private Set<String> requiredPermissions = new HashSet<>();
+
+    @ConfigComment("")
+    @ConfigComment("This is a map of the blocks required in a ISLAND challenge. Material,")
+    @ConfigComment("Integer")
+    @Expose
+    private Map<Material, Integer> requiredBlocks = new EnumMap<>(Material.class);
+
+    @ConfigComment("")
+    @ConfigComment("Remove the required blocks from the island")
+    @Expose
+    private boolean removeBlocks;
+
+    @ConfigComment("")
+    @ConfigComment("Any entities that must be in the area for ISLAND type challenges. ")
+    @ConfigComment("Map EntityType, Number")
+    @Expose
+    private Map<EntityType, Integer> requiredEntities = new EnumMap<>(EntityType.class);
+
+    @ConfigComment("")
+    @ConfigComment("Remove the entities from the island")
+    @Expose
+    private boolean removeEntities;
+
+    @ConfigComment("")
+    @ConfigComment("The items that must be in the inventory to complete the challenge. ")
+    @ConfigComment("ItemStack List.")
+    @Expose
+    private List<ItemStack> requiredItems = new ArrayList<>();
+
+    @ConfigComment("")
+    @ConfigComment("Take the required items from the player")
+    @Expose
+    private boolean takeItems = true;
+
+    @ConfigComment("")
+    @ConfigComment("Required experience for challenge completion.")
+    @Expose
+    private int requiredExperience = 0;
+
+    @ConfigComment("")
+    @ConfigComment("Take the experience from the player")
+    @Expose
+    private boolean takeExperience;
+
+    @ConfigComment("")
+    @ConfigComment("Required money for challenge completion. Economy plugins or addons")
+    @ConfigComment("is required for this option.")
+    @Expose
+    private int requiredMoney = 0;
+
+    @ConfigComment("")
+    @ConfigComment("Take the money from the player")
+    @Expose
+    private boolean takeMoney;
+
+    @ConfigComment("")
+    @ConfigComment("Required island level for challenge completion. Plugin or Addon that")
+    @ConfigComment("calculates island level is required for this option.")
+    @Expose
+    private long requiredIslandLevel;
+
+    @ConfigComment("")
+    @ConfigComment("The number of blocks around the player to search for items on an island")
+    @Expose
+    private int searchRadius = 10;
+
+
+// ---------------------------------------------------------------------
+// Section: Rewards
+// ---------------------------------------------------------------------
+
+    @ConfigComment("")
+    @ConfigComment("")
+    @ConfigComment("If this is blank, the reward text will be auto-generated, otherwise")
+    @ConfigComment("this will be used.")
+    @Expose
+    private String rewardText = "";
+
+
+    @ConfigComment("")
+    @ConfigComment("List of items the player will receive first time. ItemStack List.")
+    @Expose
+    private List<ItemStack> rewardItems = new ArrayList<>();
+
+    @ConfigComment("")
+    @ConfigComment("Experience point reward")
+    @Expose
+    private int rewardExperience = 0;
+
+    @ConfigComment("")
+    @ConfigComment("Money reward. Economy plugin or addon required for this option.")
+    @Expose
+    private int rewardMoney = 0;
+
+    @ConfigComment("")
+    @ConfigComment("Commands to run when the player completes the challenge for the first")
+    @ConfigComment("time. String List")
+    @Expose
+    private List<String> rewardCommands = new ArrayList<>();
+
+
+// ---------------------------------------------------------------------
+// Section: Repeat Rewards
+// ---------------------------------------------------------------------
+
+
+    @ConfigComment("")
+    @ConfigComment("")
+    @ConfigComment("True if the challenge is repeatable")
+    @Expose
+    private boolean repeatable;
+
+    @ConfigComment("")
+    @ConfigComment("Description of the repeat rewards. If blank, it will be autogenerated.")
+    @Expose
+    private String repeatRewardText = "";
+
+    @ConfigComment("")
+    @ConfigComment("Maximum number of times the challenge can be repeated. 0 or less")
+    @ConfigComment("will mean infinite times.")
+    @Expose
+    private int maxTimes = 1;
+
+    @ConfigComment("")
+    @ConfigComment("Repeat experience reward")
+    @Expose
+    private int repeatExperienceReward = 0;
+
+    @ConfigComment("")
+    @ConfigComment("Reward items for repeating the challenge. List of ItemStacks.")
+    @Expose
+    private List<ItemStack> repeatItemReward = new ArrayList<>();
+
+    @ConfigComment("")
+    @ConfigComment("Repeat money reward. Economy plugin or addon required for this option.")
+    @Expose
+    private int repeatMoneyReward;
+
+    @ConfigComment("")
+    @ConfigComment("Commands to run when challenge is repeated. String List.")
+    @Expose
+    private List<String> repeatRewardCommands = new ArrayList<>();
+
+
+// ---------------------------------------------------------------------
+// Section: Getters
+// ---------------------------------------------------------------------
+
 
     /**
      * @return the uniqueId
      */
     @Override
-    public String getUniqueId() {
+    public String getUniqueId()
+    {
         return uniqueId;
     }
+
+
+    /**
+     * @return the friendlyName
+     */
+    public String getFriendlyName()
+    {
+        return friendlyName;
+    }
+
+
+    /**
+     * @return the deployed
+     */
+    public boolean isDeployed()
+    {
+        return deployed;
+    }
+
+
+    /**
+     * @return the description
+     */
+    public List<String> getDescription()
+    {
+        return description;
+    }
+
+
+    /**
+     * @return the icon
+     */
+    public ItemStack getIcon()
+    {
+        return icon;
+    }
+
+
+    /**
+     * @return the order
+     */
+    public int getOrder()
+    {
+        return order;
+    }
+
+
+    /**
+     * @return the challengeType
+     */
+    public ChallengeType getChallengeType()
+    {
+        return challengeType;
+    }
+
+
+    /**
+     * @return the environment
+     */
+    public Set<World.Environment> getEnvironment()
+    {
+        return environment;
+    }
+
+
+    /**
+     * @return the level
+     */
+    public String getLevel()
+    {
+        return level;
+    }
+
+
+    /**
+     * @return the removeWhenCompleted
+     */
+    public boolean isRemoveWhenCompleted()
+    {
+        return removeWhenCompleted;
+    }
+
+
+    /**
+     * @return the requiredPermissions
+     */
+    public Set<String> getRequiredPermissions()
+    {
+        return requiredPermissions;
+    }
+
+
+    /**
+     * @return the requiredBlocks
+     */
+    public Map<Material, Integer> getRequiredBlocks()
+    {
+        return requiredBlocks;
+    }
+
+
+    /**
+     * @return the removeBlocks
+     */
+    public boolean isRemoveBlocks()
+    {
+        return removeBlocks;
+    }
+
+
+    /**
+     * @return the requiredEntities
+     */
+    public Map<EntityType, Integer> getRequiredEntities()
+    {
+        return requiredEntities;
+    }
+
+
+    /**
+     * @return the removeEntities
+     */
+    public boolean isRemoveEntities()
+    {
+        return removeEntities;
+    }
+
+
+    /**
+     * @return the requiredItems
+     */
+    public List<ItemStack> getRequiredItems()
+    {
+        return requiredItems;
+    }
+
+
+    /**
+     * @return the takeItems
+     */
+    public boolean isTakeItems()
+    {
+        return takeItems;
+    }
+
+
+    /**
+     * @return the requiredExperience
+     */
+    public int getRequiredExperience()
+    {
+        return requiredExperience;
+    }
+
+
+    /**
+     * @return the takeExperience
+     */
+    public boolean isTakeExperience()
+    {
+        return takeExperience;
+    }
+
+
+    /**
+     * @return the requiredMoney
+     */
+    public int getRequiredMoney()
+    {
+        return requiredMoney;
+    }
+
+
+    /**
+     * @return the takeMoney
+     */
+    public boolean isTakeMoney()
+    {
+        return takeMoney;
+    }
+
+
+    /**
+     * @return the requiredIslandLevel
+     */
+    public long getRequiredIslandLevel()
+    {
+        return requiredIslandLevel;
+    }
+
+
+    /**
+     * @return the searchRadius
+     */
+    public int getSearchRadius()
+    {
+        return searchRadius;
+    }
+
+
+    /**
+     * @return the rewardText
+     */
+    public String getRewardText()
+    {
+        return rewardText;
+    }
+
+
+    /**
+     * @return the rewardItems
+     */
+    public List<ItemStack> getRewardItems()
+    {
+        return rewardItems;
+    }
+
+
+    /**
+     * @return the rewardExperience
+     */
+    public int getRewardExperience()
+    {
+        return rewardExperience;
+    }
+
+
+    /**
+     * @return the rewardMoney
+     */
+    public int getRewardMoney()
+    {
+        return rewardMoney;
+    }
+
+
+    /**
+     * @return the rewardCommands
+     */
+    public List<String> getRewardCommands()
+    {
+        return rewardCommands;
+    }
+
+
+    /**
+     * @return the repeatable
+     */
+    public boolean isRepeatable()
+    {
+        return repeatable;
+    }
+
+
+    /**
+     * @return the repeatRewardText
+     */
+    public String getRepeatRewardText()
+    {
+        return repeatRewardText;
+    }
+
+
+    /**
+     * @return the maxTimes
+     */
+    public int getMaxTimes()
+    {
+        return maxTimes;
+    }
+
+
+    /**
+     * @return the repeatExperienceReward
+     */
+    public int getRepeatExperienceReward()
+    {
+        return repeatExperienceReward;
+    }
+
+
+    /**
+     * @return the repeatItemReward
+     */
+    public List<ItemStack> getRepeatItemReward()
+    {
+        return repeatItemReward;
+    }
+
+
+    /**
+     * @return the repeatMoneyReward
+     */
+    public int getRepeatMoneyReward()
+    {
+        return repeatMoneyReward;
+    }
+
+
+    /**
+     * @return the repeatRewardCommands
+     */
+    public List<String> getRepeatRewardCommands()
+    {
+        return repeatRewardCommands;
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Setters
+// ---------------------------------------------------------------------
+
 
     /**
      * @param uniqueId the uniqueId to set
      */
     @Override
-    public void setUniqueId(String uniqueId) {
+    public void setUniqueId(String uniqueId)
+    {
         this.uniqueId = uniqueId;
     }
 
-    /* (non-Javadoc)
+
+    /**
+     * This method sets the friendlyName value.
+     * @param friendlyName the friendlyName new value.
+     *
+     */
+    public void setFriendlyName(String friendlyName)
+    {
+        this.friendlyName = friendlyName;
+    }
+
+
+    /**
+     * This method sets the deployed value.
+     * @param deployed the deployed new value.
+     *
+     */
+    public void setDeployed(boolean deployed)
+    {
+        this.deployed = deployed;
+    }
+
+
+    /**
+     * This method sets the description value.
+     * @param description the description new value.
+     *
+     */
+    public void setDescription(List<String> description)
+    {
+        this.description = description;
+    }
+
+
+    /**
+     * This method sets the icon value.
+     * @param icon the icon new value.
+     *
+     */
+    public void setIcon(ItemStack icon)
+    {
+        this.icon = icon;
+    }
+
+
+    /**
+     * This method sets the order value.
+     * @param order the order new value.
+     *
+     */
+    public void setOrder(int order)
+    {
+        this.order = order;
+    }
+
+
+    /**
+     * This method sets the challengeType value.
+     * @param challengeType the challengeType new value.
+     *
+     */
+    public void setChallengeType(ChallengeType challengeType)
+    {
+        this.challengeType = challengeType;
+    }
+
+
+    /**
+     * This method sets the environment value.
+     * @param environment the environment new value.
+     *
+     */
+    public void setEnvironment(Set<World.Environment> environment)
+    {
+        this.environment = environment;
+    }
+
+
+    /**
+     * This method sets the level value.
+     * @param level the level new value.
+     */
+    public void setLevel(String level)
+    {
+        this.level = level;
+    }
+
+
+    /**
+     * This method sets the removeWhenCompleted value.
+     * @param removeWhenCompleted the removeWhenCompleted new value.
+     *
+     */
+    public void setRemoveWhenCompleted(boolean removeWhenCompleted)
+    {
+        this.removeWhenCompleted = removeWhenCompleted;
+    }
+
+
+    /**
+     * This method sets the requiredPermissions value.
+     * @param requiredPermissions the requiredPermissions new value.
+     *
+     */
+    public void setRequiredPermissions(Set<String> requiredPermissions)
+    {
+        this.requiredPermissions = requiredPermissions;
+    }
+
+
+    /**
+     * This method sets the requiredBlocks value.
+     * @param requiredBlocks the requiredBlocks new value.
+     *
+     */
+    public void setRequiredBlocks(Map<Material, Integer> requiredBlocks)
+    {
+        this.requiredBlocks = requiredBlocks;
+    }
+
+
+    /**
+     * This method sets the removeBlocks value.
+     * @param removeBlocks the removeBlocks new value.
+     *
+     */
+    public void setRemoveBlocks(boolean removeBlocks)
+    {
+        this.removeBlocks = removeBlocks;
+    }
+
+
+    /**
+     * This method sets the requiredEntities value.
+     * @param requiredEntities the requiredEntities new value.
+     *
+     */
+    public void setRequiredEntities(Map<EntityType, Integer> requiredEntities)
+    {
+        this.requiredEntities = requiredEntities;
+    }
+
+
+    /**
+     * This method sets the removeEntities value.
+     * @param removeEntities the removeEntities new value.
+     *
+     */
+    public void setRemoveEntities(boolean removeEntities)
+    {
+        this.removeEntities = removeEntities;
+    }
+
+
+    /**
+     * This method sets the requiredItems value.
+     * @param requiredItems the requiredItems new value.
+     *
+     */
+    public void setRequiredItems(List<ItemStack> requiredItems)
+    {
+        this.requiredItems = requiredItems;
+    }
+
+
+    /**
+     * This method sets the takeItems value.
+     * @param takeItems the takeItems new value.
+     *
+     */
+    public void setTakeItems(boolean takeItems)
+    {
+        this.takeItems = takeItems;
+    }
+
+
+    /**
+     * This method sets the requiredExperience value.
+     * @param requiredExperience the requiredExperience new value.
+     *
+     */
+    public void setRequiredExperience(int requiredExperience)
+    {
+        this.requiredExperience = requiredExperience;
+    }
+
+
+    /**
+     * This method sets the takeExperience value.
+     * @param takeExperience the takeExperience new value.
+     *
+     */
+    public void setTakeExperience(boolean takeExperience)
+    {
+        this.takeExperience = takeExperience;
+    }
+
+
+    /**
+     * This method sets the requiredMoney value.
+     * @param requiredMoney the requiredMoney new value.
+     *
+     */
+    public void setRequiredMoney(int requiredMoney)
+    {
+        this.requiredMoney = requiredMoney;
+    }
+
+
+    /**
+     * This method sets the takeMoney value.
+     * @param takeMoney the takeMoney new value.
+     *
+     */
+    public void setTakeMoney(boolean takeMoney)
+    {
+        this.takeMoney = takeMoney;
+    }
+
+
+    /**
+     * This method sets the requiredIslandLevel value.
+     * @param requiredIslandLevel the requiredIslandLevel new value.
+     *
+     */
+    public void setRequiredIslandLevel(long requiredIslandLevel)
+    {
+        this.requiredIslandLevel = requiredIslandLevel;
+    }
+
+
+    /**
+     * This method sets the searchRadius value.
+     * @param searchRadius the searchRadius new value.
+     *
+     */
+    public void setSearchRadius(int searchRadius)
+    {
+        this.searchRadius = searchRadius;
+    }
+
+
+    /**
+     * This method sets the rewardText value.
+     * @param rewardText the rewardText new value.
+     *
+     */
+    public void setRewardText(String rewardText)
+    {
+        this.rewardText = rewardText;
+    }
+
+
+    /**
+     * This method sets the rewardItems value.
+     * @param rewardItems the rewardItems new value.
+     *
+     */
+    public void setRewardItems(List<ItemStack> rewardItems)
+    {
+        this.rewardItems = rewardItems;
+    }
+
+
+    /**
+     * This method sets the rewardExperience value.
+     * @param rewardExperience the rewardExperience new value.
+     *
+     */
+    public void setRewardExperience(int rewardExperience)
+    {
+        this.rewardExperience = rewardExperience;
+    }
+
+
+    /**
+     * This method sets the rewardMoney value.
+     * @param rewardMoney the rewardMoney new value.
+     *
+     */
+    public void setRewardMoney(int rewardMoney)
+    {
+        this.rewardMoney = rewardMoney;
+    }
+
+
+    /**
+     * This method sets the rewardCommands value.
+     * @param rewardCommands the rewardCommands new value.
+     *
+     */
+    public void setRewardCommands(List<String> rewardCommands)
+    {
+        this.rewardCommands = rewardCommands;
+    }
+
+
+    /**
+     * This method sets the repeatable value.
+     * @param repeatable the repeatable new value.
+     *
+     */
+    public void setRepeatable(boolean repeatable)
+    {
+        this.repeatable = repeatable;
+    }
+
+
+    /**
+     * This method sets the repeatRewardText value.
+     * @param repeatRewardText the repeatRewardText new value.
+     *
+     */
+    public void setRepeatRewardText(String repeatRewardText)
+    {
+        this.repeatRewardText = repeatRewardText;
+    }
+
+
+    /**
+     * This method sets the maxTimes value.
+     * @param maxTimes the maxTimes new value.
+     *
+     */
+    public void setMaxTimes(int maxTimes)
+    {
+        this.maxTimes = maxTimes;
+    }
+
+
+    /**
+     * This method sets the repeatExperienceReward value.
+     * @param repeatExperienceReward the repeatExperienceReward new value.
+     *
+     */
+    public void setRepeatExperienceReward(int repeatExperienceReward)
+    {
+        this.repeatExperienceReward = repeatExperienceReward;
+    }
+
+
+    /**
+     * This method sets the repeatItemReward value.
+     * @param repeatItemReward the repeatItemReward new value.
+     *
+     */
+    public void setRepeatItemReward(List<ItemStack> repeatItemReward)
+    {
+        this.repeatItemReward = repeatItemReward;
+    }
+
+
+    /**
+     * This method sets the repeatMoneyReward value.
+     * @param repeatMoneyReward the repeatMoneyReward new value.
+     *
+     */
+    public void setRepeatMoneyReward(int repeatMoneyReward)
+    {
+        this.repeatMoneyReward = repeatMoneyReward;
+    }
+
+
+    /**
+     * This method sets the repeatRewardCommands value.
+     * @param repeatRewardCommands the repeatRewardCommands new value.
+     *
+     */
+    public void setRepeatRewardCommands(List<String> repeatRewardCommands)
+    {
+        this.repeatRewardCommands = repeatRewardCommands;
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Other methods
+// ---------------------------------------------------------------------
+
+
+    /**
      * @see java.lang.Object#hashCode()
+     * @return int
      */
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((uniqueId == null) ? 0 : uniqueId.hashCode());
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
+
+    /**
+     * @see java.lang.Object#equals(Object) ()
+     * @param obj of type Object
+     * @return boolean
      */
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+        {
             return true;
         }
-        if (obj == null) {
+
+        if (!(obj instanceof Challenge))
+        {
             return false;
         }
-        if (!(obj instanceof Challenge)) {
-            return false;
-        }
+
         Challenge other = (Challenge) obj;
-        if (uniqueId == null) {
-            if (other.uniqueId != null) {
-                return false;
-            }
-        } else if (!uniqueId.equals(other.uniqueId)) {
-            return false;
+
+        if (uniqueId == null)
+        {
+            return other.uniqueId == null;
         }
-        return true;
+        else
+        {
+            return uniqueId.equals(other.uniqueId);
+        }
     }
 }

--- a/src/main/java/world/bentobox/challenges/database/object/ChallengeLevel.java
+++ b/src/main/java/world/bentobox/challenges/database/object/ChallengeLevel.java
@@ -14,9 +14,9 @@ import world.bentobox.challenges.ChallengesManager;
  * @author tastybento
  *
  */
-public class ChallengeLevels implements DataObject, Comparable<ChallengeLevels> {
+public class ChallengeLevel implements DataObject, Comparable<ChallengeLevel> {
 
-    public ChallengeLevels() {}
+    public ChallengeLevel() {}
 
     @ConfigComment("A friendly name for the level. If blank, level name is used.")
     private String friendlyName = "";
@@ -98,7 +98,7 @@ public class ChallengeLevels implements DataObject, Comparable<ChallengeLevels> 
     }
 
     @Override
-    public int compareTo(ChallengeLevels o) {
+    public int compareTo(ChallengeLevel o) {
         return Integer.compare(this.order, o.order);
     }
     
@@ -208,10 +208,10 @@ public class ChallengeLevels implements DataObject, Comparable<ChallengeLevels> 
         if (obj == null) {
             return false;
         }
-        if (!(obj instanceof ChallengeLevels)) {
+        if (!(obj instanceof ChallengeLevel)) {
             return false;
         }
-        ChallengeLevels other = (ChallengeLevels) obj;
+        ChallengeLevel other = (ChallengeLevel) obj;
         if (uniqueId == null) {
             if (other.uniqueId != null) {
                 return false;

--- a/src/main/java/world/bentobox/challenges/database/object/ChallengeLevel.java
+++ b/src/main/java/world/bentobox/challenges/database/object/ChallengeLevel.java
@@ -1,9 +1,13 @@
 package world.bentobox.challenges.database.object;
 
 
+import com.google.gson.annotations.Expose;
+import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import world.bentobox.bentobox.api.configuration.ConfigComment;
 import world.bentobox.bentobox.database.objects.DataObject;
@@ -14,223 +18,455 @@ import world.bentobox.challenges.ChallengesManager;
  * @author tastybento
  *
  */
-public class ChallengeLevel implements DataObject, Comparable<ChallengeLevel> {
+public class ChallengeLevel implements DataObject, Comparable<ChallengeLevel>
+{
+    /**
+     * Constructor ChallengeLevel creates a new ChallengeLevel instance.
+     */
+    public ChallengeLevel()
+    {
+    }
 
-    public ChallengeLevel() {}
 
-    @ConfigComment("A friendly name for the level. If blank, level name is used.")
-    private String friendlyName = "";
-    
-    @ConfigComment("Worlds that this level applies in. String list.")
-    private List<String> worlds = new ArrayList<>();
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
 
-    @ConfigComment("Commands to run when this level is completed")
-    private List<String> rewardCommands = new ArrayList<>();
-    
+    @ConfigComment("")
     @ConfigComment("Level name")
+    @Expose
     private String uniqueId = ChallengesManager.FREE;
-    
-    @ConfigComment("The number of undone challenges that can be left on this level before unlocking next level")
-    private int waiveramount = 1;
-    
-    @ConfigComment("The ordering of the levels, lowest to highest")
-    private int order = 0;
-    
-    @ConfigComment("The message shown when unlocking this level")
+
+    @ConfigComment("")
+    @ConfigComment("A friendly name for the level. If blank, level name is used.")
+    @Expose
+    private String friendlyName = "";
+
+    @ConfigComment("")
+    @ConfigComment("ItemStack that represents current level. Will be used as icon in GUIs.")
+    @Expose
+    private ItemStack icon = new ItemStack(Material.BOOK);
+
+    @ConfigComment("")
+    @ConfigComment("World that this level applies in. String.")
+    @Expose
+    private String world = "";
+
+    @ConfigComment("")
+    @ConfigComment("The ordering of the level, lowest to highest")
+    @Expose
+    private int order;
+
+    @ConfigComment("")
+    @ConfigComment("The number of undone challenges that can be left on this level before")
+    @ConfigComment("unlocking next level.")
+    @Expose
+    private int waiverAmount = 1;
+
+    @ConfigComment("")
+    @ConfigComment("The message shown when unlocking this level. Single line string.")
+    @Expose
     private String unlockMessage = "";
-    
-    @ConfigComment("Unlock reward description")
-    private String rewardDescription = "";
-    
-    @ConfigComment("List of reward itemstacks")
-    private List<ItemStack> rewardItems;
-    
-    @ConfigComment("Unlock experience reward")
-    private int expReward;
-    
-    @ConfigComment("Unlock money reward")
-    private int moneyReward;
-    
-    public String getFriendlyName() {
-        return friendlyName;
-    }
 
-    public List<String> getRewardCommands() {
-        return rewardCommands = new ArrayList<>();
-    }
+    @ConfigComment("")
+    @ConfigComment("")
+    @ConfigComment("If this is blank, the reward text will be auto-generated, otherwise")
+    @ConfigComment("this will be used.")
+    @Expose
+    private String rewardText = "";
 
+
+    @ConfigComment("")
+    @ConfigComment("List of items the player will receive on completing level.")
+    @ConfigComment("ItemStack List.")
+    @Expose
+    private List<ItemStack> rewardItems = new ArrayList<>();
+
+    @ConfigComment("")
+    @ConfigComment("Experience point reward on completing level.")
+    @Expose
+    private int rewardExperience = 0;
+
+    @ConfigComment("")
+    @ConfigComment("Money reward. Economy plugin or addon required for this option.")
+    @Expose
+    private int rewardMoney = 0;
+
+    @ConfigComment("")
+    @ConfigComment("Commands to run when the player completes all challenges in current")
+    @ConfigComment("level. String List")
+    @Expose
+    private List<String> rewardCommands = new ArrayList<>();
+
+    @ConfigComment("")
+    @ConfigComment("Set of all challenges that is linked with current level.")
+    @ConfigComment("String Set")
+    @Expose
+    private Set<String> challenges = new HashSet<>();
+
+
+// ---------------------------------------------------------------------
+// Section: Getters
+// ---------------------------------------------------------------------
+
+
+    /**
+     * This method returns the uniqueId value.
+     * @return the value of uniqueId.
+     * @see DataObject#getUniqueId()
+     */
     @Override
-    public String getUniqueId() {
+    public String getUniqueId()
+    {
         return uniqueId;
     }
 
+
     /**
-     * Get the number of undone tasks that can be left on a level before unlocking next level
-     * @return
+     * This method returns the friendlyName value.
+     * @return the value of friendlyName.
      */
-    public int getWaiveramount() {
-        return waiveramount;
+    public String getFriendlyName()
+    {
+        return friendlyName;
     }
 
-    public void setFriendlyName(String friendlyName) {
-        this.friendlyName = friendlyName;
+
+    /**
+     * This method returns the icon value.
+     * @return the value of icon.
+     */
+    public ItemStack getIcon()
+    {
+        return icon;
     }
 
-    public void setRewardCommands(List<String> rewardCommands) {
-        this.rewardCommands = rewardCommands;
+
+    /**
+     * This method returns the world value.
+     * @return the value of world.
+     */
+    public String getWorld()
+    {
+        return world;
     }
 
-    @Override
-    public void setUniqueId(String uniqueId) {
-        this.uniqueId = uniqueId;
-    }
 
-    public void setWaiveramount(int waiveramount) {
-        this.waiveramount = waiveramount;
-    }
-
-    public int getOrder() {
+    /**
+     * This method returns the order value.
+     * @return the value of order.
+     */
+    public int getOrder()
+    {
         return order;
     }
 
-    public void setOrder(int order) {
-        this.order = order;
-    }
-
-    @Override
-    public int compareTo(ChallengeLevel o) {
-        return Integer.compare(this.order, o.order);
-    }
-    
-    /**
-     * @return the rewardDescription
-     */
-    public String getRewardDescription() {
-        return rewardDescription;
-    }
 
     /**
-     * @param rewardDescription the rewardDescription to set
+     * This method returns the waiverAmount value.
+     * @return the value of waiverAmount.
      */
-    public void setRewardDescription(String rewardDescription) {
-        this.rewardDescription = rewardDescription;
+    public int getWaiverAmount()
+    {
+        return waiverAmount;
     }
 
-    /**
-     * @return the rewardItems
-     */
-    public List<ItemStack> getRewardItems() {
-        return rewardItems;
-    }
 
     /**
-     * @param rewardItems the rewardItems to set
+     * This method returns the unlockMessage value.
+     * @return the value of unlockMessage.
      */
-    public void setRewardItems(List<ItemStack> rewardItems) {
-        this.rewardItems = rewardItems;
-    }
-
-    /**
-     * @return the expReward
-     */
-    public int getExpReward() {
-        return expReward;
-    }
-
-    /**
-     * @param expReward the expReward to set
-     */
-    public void setExpReward(int expReward) {
-        this.expReward = expReward;
-    }
-
-    /**
-     * @return the moneyReward
-     */
-    public int getMoneyReward() {
-        return moneyReward;
-    }
-
-    /**
-     * @param moneyReward the moneyReward to set
-     */
-    public void setMoneyReward(int moneyReward) {
-        this.moneyReward = moneyReward;
-    }
-
-    /**
-     * @return the unlockMessage
-     */
-    public String getUnlockMessage() {
+    public String getUnlockMessage()
+    {
         return unlockMessage;
     }
 
+
     /**
-     * @param unlockMessage the unlockMessage to set
+     * This method returns the rewardText value.
+     * @return the value of rewardText.
      */
-    public void setUnlockMessage(String unlockMessage) {
+    public String getRewardText()
+    {
+        return rewardText;
+    }
+
+
+    /**
+     * This method returns the rewardItems value.
+     * @return the value of rewardItems.
+     */
+    public List<ItemStack> getRewardItems()
+    {
+        return rewardItems;
+    }
+
+
+    /**
+     * This method returns the rewardExperience value.
+     * @return the value of rewardExperience.
+     */
+    public int getRewardExperience()
+    {
+        return rewardExperience;
+    }
+
+
+    /**
+     * This method returns the rewardMoney value.
+     * @return the value of rewardMoney.
+     */
+    public int getRewardMoney()
+    {
+        return rewardMoney;
+    }
+
+
+    /**
+     * This method returns the rewardCommands value.
+     * @return the value of rewardCommands.
+     */
+    public List<String> getRewardCommands()
+    {
+        return rewardCommands;
+    }
+
+
+    /**
+     * This method returns the challenges value.
+     * @return the value of challenges.
+     */
+    public Set<String> getChallenges()
+    {
+        return challenges;
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Setters
+// ---------------------------------------------------------------------
+
+
+    /**
+     * This method sets the uniqueId value.
+     * @param uniqueId the uniqueId new value.
+     *
+     * @see DataObject#setUniqueId(String)
+     */
+    @Override
+    public void setUniqueId(String uniqueId)
+    {
+        this.uniqueId = uniqueId;
+    }
+
+
+    /**
+     * This method sets the friendlyName value.
+     * @param friendlyName the friendlyName new value.
+     *
+     */
+    public void setFriendlyName(String friendlyName)
+    {
+        this.friendlyName = friendlyName;
+    }
+
+
+    /**
+     * This method sets the icon value.
+     * @param icon the icon new value.
+     *
+     */
+    public void setIcon(ItemStack icon)
+    {
+        this.icon = icon;
+    }
+
+
+    /**
+     * This method sets the world value.
+     * @param world the world new value.
+     *
+     */
+    public void setWorld(String world)
+    {
+        this.world = world;
+    }
+
+
+    /**
+     * This method sets the order value.
+     * @param order the order new value.
+     *
+     */
+    public void setOrder(int order)
+    {
+        this.order = order;
+    }
+
+
+    /**
+     * This method sets the waiverAmount value.
+     * @param waiverAmount the waiverAmount new value.
+     *
+     */
+    public void setWaiverAmount(int waiverAmount)
+    {
+        this.waiverAmount = waiverAmount;
+    }
+
+
+    /**
+     * This method sets the unlockMessage value.
+     * @param unlockMessage the unlockMessage new value.
+     *
+     */
+    public void setUnlockMessage(String unlockMessage)
+    {
         this.unlockMessage = unlockMessage;
     }
 
-    /**
-     * @return the worlds
-     */
-    public List<String> getWorlds() {
-        return worlds;
-    }
 
     /**
-     * @param worlds the worlds to set
+     * This method sets the rewardText value.
+     * @param rewardText the rewardText new value.
+     *
      */
-    public void setWorlds(List<String> worlds) {
-        this.worlds = worlds;
+    public void setRewardText(String rewardText)
+    {
+        this.rewardText = rewardText;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
+
+    /**
+     * This method sets the rewardItems value.
+     * @param rewardItems the rewardItems new value.
+     *
+     */
+    public void setRewardItems(List<ItemStack> rewardItems)
+    {
+        this.rewardItems = rewardItems;
+    }
+
+
+    /**
+     * This method sets the rewardExperience value.
+     * @param rewardExperience the rewardExperience new value.
+     *
+     */
+    public void setRewardExperience(int rewardExperience)
+    {
+        this.rewardExperience = rewardExperience;
+    }
+
+
+    /**
+     * This method sets the rewardMoney value.
+     * @param rewardMoney the rewardMoney new value.
+     *
+     */
+    public void setRewardMoney(int rewardMoney)
+    {
+        this.rewardMoney = rewardMoney;
+    }
+
+
+    /**
+     * This method sets the rewardCommands value.
+     * @param rewardCommands the rewardCommands new value.
+     *
+     */
+    public void setRewardCommands(List<String> rewardCommands)
+    {
+        this.rewardCommands = rewardCommands;
+    }
+
+
+    /**
+     * This method sets the challenges value.
+     * @param challenges the challenges new value.
+     *
+     */
+    public void setChallenges(Set<String> challenges)
+    {
+        this.challenges = challenges;
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Other methods
+// ---------------------------------------------------------------------
+
+
+    /**
+     * {@inheritDoc}
      */
     @Override
-    public int hashCode() {
+    public int compareTo(ChallengeLevel o)
+    {
+        if (this.equals(o))
+        {
+            return 0;
+        }
+        else
+        {
+            if (this.getWorld().equals(o.getWorld()))
+            {
+                if (this.order == o.getOrder())
+                {
+                    return this.getUniqueId().compareTo(o.getUniqueId());
+                }
+                else
+                {
+                    return Integer.compare(this.order, o.getOrder());
+                }
+            }
+            else
+            {
+                return this.getWorld().compareTo(o.getWorld());
+            }
+        }
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode()
+    {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((uniqueId == null) ? 0 : uniqueId.hashCode());
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
+
+
+    /**
+     * {@inheritDoc}
      */
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+        {
             return true;
         }
-        if (obj == null) {
+
+        if (!(obj instanceof ChallengeLevel))
+        {
             return false;
         }
-        if (!(obj instanceof ChallengeLevel)) {
-            return false;
-        }
+
         ChallengeLevel other = (ChallengeLevel) obj;
-        if (uniqueId == null) {
-            if (other.uniqueId != null) {
-                return false;
-            }
-        } else if (!uniqueId.equals(other.uniqueId)) {
-            return false;
+
+        if (uniqueId == null)
+        {
+            return other.uniqueId == null;
         }
-        return true;
-    }
-
-
-    public ItemStack getIcon()
-    {
-        return null;
-    }
-
-
-    public void setIcon(ItemStack newIcon)
-    {
-
+        else
+        {
+            return uniqueId.equals(other.uniqueId);
+        }
     }
 }

--- a/src/main/java/world/bentobox/challenges/database/object/ChallengeLevel.java
+++ b/src/main/java/world/bentobox/challenges/database/object/ChallengeLevel.java
@@ -138,7 +138,7 @@ public class ChallengeLevel implements DataObject, Comparable<ChallengeLevel>
      */
     public ItemStack getIcon()
     {
-        return icon;
+        return icon.clone();
     }
 
 

--- a/src/main/java/world/bentobox/challenges/database/object/ChallengeLevels.java
+++ b/src/main/java/world/bentobox/challenges/database/object/ChallengeLevels.java
@@ -227,4 +227,10 @@ public class ChallengeLevels implements DataObject, Comparable<ChallengeLevels> 
     {
         return null;
     }
+
+
+    public void setIcon(ItemStack newIcon)
+    {
+
+    }
 }

--- a/src/main/java/world/bentobox/challenges/database/object/Challenges.java
+++ b/src/main/java/world/bentobox/challenges/database/object/Challenges.java
@@ -1,20 +1,15 @@
 package world.bentobox.challenges.database.object;
 
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
+import java.util.*;
 
-import world.bentobox.challenges.ChallengesManager;
 import world.bentobox.bentobox.api.configuration.ConfigComment;
 import world.bentobox.bentobox.database.objects.DataObject;
+import world.bentobox.challenges.ChallengesManager;
 
 /**
  * Data object for challenges
@@ -103,7 +98,7 @@ public class Challenges implements DataObject {
     @ConfigComment("World where this challenge operates. List only overworld. Nether and end are automatically covered.")
     private String world = "";
     @ConfigComment("List of environments where this challenge will occur: NETHER, NORMAL, THE_END. Leave blank for all.")
-    private List<World.Environment> environment = new ArrayList<>();
+    private Set<World.Environment> environment = new HashSet<>();
     @ConfigComment("The required permissions to see this challenge. String list.")
     private Set<String> reqPerms = new HashSet<>();
     @ConfigComment("The number of blocks around the player to search for items on an island")
@@ -591,14 +586,14 @@ public class Challenges implements DataObject {
     /**
      * @return the environment
      */
-    public List<World.Environment> getEnvironment() {
+    public Set<World.Environment> getEnvironment() {
         return environment;
     }
 
     /**
      * @param environment the environment to set
      */
-    public void setEnvironment(List<World.Environment> environment) {
+    public void setEnvironment(Set<World.Environment> environment) {
         this.environment = environment;
     }
 

--- a/src/main/java/world/bentobox/challenges/database/object/ChallengesPlayerData.java
+++ b/src/main/java/world/bentobox/challenges/database/object/ChallengesPlayerData.java
@@ -1,13 +1,12 @@
 package world.bentobox.challenges.database.object;
 
+
+import com.google.gson.annotations.Expose;
+import org.bukkit.World;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import org.bukkit.World;
-
-import com.google.gson.annotations.Expose;
 
 import world.bentobox.bentobox.database.objects.DataObject;
 import world.bentobox.bentobox.util.Util;
@@ -232,6 +231,27 @@ public class ChallengesPlayerData implements DataObject
 	public int getTimes(String challengeName)
 	{
 		return challengeStatus.getOrDefault(challengeName, 0);
+	}
+
+
+	/**
+	 * This method adds given level id to completed level set.
+	 * @param uniqueId from ChallengeLevel object.
+	 */
+	public void addCompletedLevel(String uniqueId)
+	{
+		this.levelsDone.add(uniqueId);
+	}
+
+
+	/**
+	 * This method returns if given level is done.
+	 * @param uniqueId  of ChallengeLevel object.
+	 * @return <code>true</code> if level is completed, otherwise <code>false</code>
+	 */
+	public boolean isLevelDone(String uniqueId)
+	{
+		return !this.levelsDone.isEmpty() && this.levelsDone.contains(uniqueId);
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/database/object/ChallengesPlayerData.java
+++ b/src/main/java/world/bentobox/challenges/database/object/ChallengesPlayerData.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package world.bentobox.challenges.database.object;
 
 import java.util.HashMap;
@@ -20,173 +17,265 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class ChallengesPlayerData implements DataObject {
+public class ChallengesPlayerData implements DataObject
+{
+	/**
+	 * Constructor ChallengesPlayerData creates a new ChallengesPlayerData instance.
+	 */
+	public ChallengesPlayerData()
+	{
+	}
 
-    @Expose
-    private String uniqueId = "";
-    /**
-     * Challenge map, where key = unique challenge name and Value = number of times completed
-     */
-    @Expose
-    private Map<String, Integer> challengeStatus = new HashMap<>();
-    @Expose
-    private Map<String, Long> challengesTimestamp = new HashMap<>();
-    @Expose
-    private Set<String> levelsDone = new HashSet<>();
 
-    // Required for bean instantiation
-    public ChallengesPlayerData() {}
+	/**
+	 * Creates a player data entry
+	 *
+	 * @param uniqueId - the player's UUID in string format
+	 */
+	public ChallengesPlayerData(String uniqueId)
+	{
+		this.uniqueId = uniqueId;
+	}
 
-    /**
-     * Mark a challenge as having been completed. Will increment the number of times and timestamp
-     * @param world - world of challenge
-     * @param challengeName - unique challenge name
-     */
-    public void setChallengeDone(World world, String challengeName) {
-        String name = Util.getWorld(world).getName() + challengeName;
-        int times = challengeStatus.getOrDefault(name, 0) + 1;
-        challengeStatus.put(name, times);
-        challengesTimestamp.put(name, System.currentTimeMillis());
-    }
 
-    /**
-     * Set the number of times a challenge has been done
-     * @param world - world of challenge
-     * @param challengeName - unique challenge name
-     * @param times - the number of times to set
-     *
-     */
-    public void setChallengeTimes(World world, String challengeName, int times) {
-        String name = Util.getWorld(world).getName() + challengeName;
-        challengeStatus.put(name, times);
-        challengesTimestamp.put(name, System.currentTimeMillis());
-    }
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
 
-    /**
-     * Check if a challenge has been done
-     * @param challengeName - unique challenge name
-     * @return true if done at least once
-     */
-    public boolean isChallengeDone(World world, String challengeName) {
-        return getTimes(world, challengeName) > 0;
-    }
 
-    /**
-     * Check how many times a challenge has been done
-     * @param challengeName - unique challenge name
-     * @return - number of times
-     */
-    public int getTimes(World world, String challengeName) {
-        return challengeStatus.getOrDefault(Util.getWorld(world).getName() + challengeName, 0);
-    }
+	/**
+	 * This variable stores each player UUID as string.
+	 */
+	@Expose
+	private String uniqueId = "";
 
-    /**
-     * Creates a player data entry
-     * @param uniqueId - the player's UUID in string format
-     */
-    public ChallengesPlayerData(String uniqueId) {
-        this.uniqueId = uniqueId;
-    }
+	/**
+	 * Challenge map, where key = unique challenge name and Value = number of times
+	 * completed
+	 */
+	@Expose
+	private Map<String, Integer> challengeStatus = new HashMap<>();
 
-    /* (non-Javadoc)
-     * @see world.bentobox.bbox.database.objects.DataObject#getUniqueId()
-     */
-    @Override
-    public String getUniqueId() {
-        return uniqueId;
-    }
+	/**
+	 * Map of challenges completion time where key is challenges unique id and value is
+	 * timestamp when challenge was completed last time.
+	 */
+	@Expose
+	private Map<String, Long> challengesTimestamp = new HashMap<>();
 
-    /* (non-Javadoc)
-     * @see world.bentobox.bbox.database.objects.DataObject#setUniqueId(java.lang.String)
-     */
-    @Override
-    public void setUniqueId(String uniqueId) {
-        this.uniqueId = uniqueId;
-    }
+	/**
+	 * Set of Strings that contains all challenge levels that are completed.
+	 */
+	@Expose
+	private Set<String> levelsDone = new HashSet<>();
 
-    /**
-     * @return the challengeStatus
-     */
-    public Map<String, Integer> getChallengeStatus() {
-        return challengeStatus;
-    }
-    /**
-     * @param challengeStatus the challengeStatus to set
-     */
-    public void setChallengeStatus(Map<String, Integer> challengeStatus) {
-        this.challengeStatus = challengeStatus;
-    }
-    /**
-     * @return the challengesTimestamp
-     */
-    public Map<String, Long> getChallengesTimestamp() {
-        return challengesTimestamp;
-    }
-    /**
-     * @param challengesTimestamp the challengesTimestamp to set
-     */
-    public void setChallengesTimestamp(Map<String, Long> challengesTimestamp) {
-        this.challengesTimestamp = challengesTimestamp;
-    }
-    /**
-     * @return the levelsDone
-     */
-    public Set<String> getLevelsDone() {
-        return levelsDone;
-    }
 
-    /**
-     * @param levelsDone the levelsDone to set
-     */
-    public void setLevelsDone(Set<String> levelsDone) {
-        this.levelsDone = levelsDone;
-    }
+// ---------------------------------------------------------------------
+// Section: Getters
+// ---------------------------------------------------------------------
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((uniqueId == null) ? 0 : uniqueId.hashCode());
-        return result;
-    }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (!(obj instanceof ChallengesPlayerData)) {
-            return false;
-        }
-        ChallengesPlayerData other = (ChallengesPlayerData) obj;
-        if (uniqueId == null) {
-            if (other.uniqueId != null) {
-                return false;
-            }
-        } else if (!uniqueId.equals(other.uniqueId)) {
-            return false;
-        }
-        return true;
-    }
+	/**
+	 * @return uniqueID
+	 * @see DataObject#getUniqueId()
+	 */
+	@Override
+	public String getUniqueId()
+	{
+		return uniqueId;
+	}
 
-    /**
-     * Resets all challenges and levels in world for this player
-     * @param world
-     */
-    public void reset(World world) {
-        String worldName = Util.getWorld(world).getName();
-        challengeStatus.keySet().removeIf(n -> n.startsWith(worldName));
-        challengesTimestamp.keySet().removeIf(n -> n.startsWith(worldName));
-        levelsDone.removeIf(n -> n.startsWith(worldName));
-    }
 
+	/**
+	 * This method returns the challengeStatus value.
+	 * @return the value of challengeStatus.
+	 */
+	public Map<String, Integer> getChallengeStatus()
+	{
+		return challengeStatus;
+	}
+
+
+	/**
+	 * This method returns the challengesTimestamp value.
+	 * @return the value of challengesTimestamp.
+	 */
+	public Map<String, Long> getChallengesTimestamp()
+	{
+		return challengesTimestamp;
+	}
+
+
+	/**
+	 * This method returns the levelsDone value.
+	 * @return the value of levelsDone.
+	 */
+	public Set<String> getLevelsDone()
+	{
+		return levelsDone;
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Setters
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * @param uniqueId - unique ID the uniqueId to set
+	 * @see DataObject#setUniqueId(String)
+	 */
+	@Override
+	public void setUniqueId(String uniqueId)
+	{
+		this.uniqueId = uniqueId;
+	}
+
+
+	/**
+	 * This method sets the challengeStatus value.
+	 * @param challengeStatus the challengeStatus new value.
+	 *
+	 */
+	public void setChallengeStatus(Map<String, Integer> challengeStatus)
+	{
+		this.challengeStatus = challengeStatus;
+	}
+
+
+	/**
+	 * This method sets the challengesTimestamp value.
+	 * @param challengesTimestamp the challengesTimestamp new value.
+	 *
+	 */
+	public void setChallengesTimestamp(Map<String, Long> challengesTimestamp)
+	{
+		this.challengesTimestamp = challengesTimestamp;
+	}
+
+
+	/**
+	 * This method sets the levelsDone value.
+	 * @param levelsDone the levelsDone new value.
+	 *
+	 */
+	public void setLevelsDone(Set<String> levelsDone)
+	{
+		this.levelsDone = levelsDone;
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Other Methods
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * Resets all challenges and levels in world for this player
+	 *
+	 * @param world world which challenges must be reset.
+	 */
+	public void reset(World world)
+	{
+		String worldName = Util.getWorld(world).getName();
+		challengeStatus.keySet().removeIf(n -> n.startsWith(worldName));
+		challengesTimestamp.keySet().removeIf(n -> n.startsWith(worldName));
+		levelsDone.removeIf(n -> n.startsWith(worldName));
+	}
+
+
+	/**
+	 * Mark a challenge as having been completed. Will increment the number of times and
+	 * timestamp
+	 *
+	 * @param challengeName - unique challenge name
+	 */
+	public void setChallengeDone(String challengeName)
+	{
+		int times = challengeStatus.getOrDefault(challengeName, 0) + 1;
+		challengeStatus.put(challengeName, times);
+		challengesTimestamp.put(challengeName, System.currentTimeMillis());
+	}
+
+
+	/**
+	 * Set the number of times a challenge has been done
+	 *
+	 * @param challengeName - unique challenge name
+	 * @param times - the number of times to set
+	 */
+	public void setChallengeTimes(String challengeName, int times)
+	{
+		challengeStatus.put(challengeName, times);
+		challengesTimestamp.put(challengeName, System.currentTimeMillis());
+	}
+
+
+	/**
+	 * Check if a challenge has been done
+	 *
+	 * @param challengeName - unique challenge name
+	 * @return true if done at least once
+	 */
+	public boolean isChallengeDone(String challengeName)
+	{
+		return this.getTimes(challengeName) > 0;
+	}
+
+
+	/**
+	 * Check how many times a challenge has been done
+	 *
+	 * @param challengeName - unique challenge name
+	 * @return - number of times
+	 */
+	public int getTimes(String challengeName)
+	{
+		return challengeStatus.getOrDefault(challengeName, 0);
+	}
+
+
+	/**
+	 * @see Object#hashCode()
+	 * @return object hashCode value.
+	 */
+	@Override
+	public int hashCode()
+	{
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((uniqueId == null) ? 0 : uniqueId.hashCode());
+		return result;
+	}
+
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 * @param obj Other object.
+	 * @return boolean that indicate if objects are equals.
+	 */
+	@Override
+	public boolean equals(Object obj)
+	{
+		if (this == obj)
+		{
+			return true;
+		}
+
+		if (!(obj instanceof ChallengesPlayerData))
+		{
+			return false;
+		}
+
+		ChallengesPlayerData other = (ChallengesPlayerData) obj;
+
+		if (uniqueId == null)
+		{
+			return other.uniqueId == null;
+		}
+		else
+		{
+			return uniqueId.equals(other.uniqueId);
+		}
+	}
 }

--- a/src/main/java/world/bentobox/challenges/listeners/ResetListener.java
+++ b/src/main/java/world/bentobox/challenges/listeners/ResetListener.java
@@ -7,6 +7,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
+import world.bentobox.bentobox.api.user.User;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.bentobox.api.events.island.IslandEvent;
 import world.bentobox.bentobox.api.events.island.IslandEvent.Reason;
@@ -27,7 +28,7 @@ public class ResetListener implements Listener {
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onIslandReset(IslandEvent e) {
         if (e.getReason().equals(Reason.CREATED) || (addon.getChallengesSettings().isResetChallenges() && e.getReason().equals(Reason.RESETTED))) {
-            addon.getChallengesManager().resetAllChallenges(e.getOwner(), e.getLocation().getWorld());
+            addon.getChallengesManager().resetAllChallenges(User.getInstance(e.getOwner()), e.getLocation().getWorld());
         }
     }
 }

--- a/src/main/java/world/bentobox/challenges/listeners/SaveListener.java
+++ b/src/main/java/world/bentobox/challenges/listeners/SaveListener.java
@@ -23,7 +23,7 @@ public class SaveListener implements Listener
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onWorldSave(WorldSaveEvent e)
     {
-        if (!this.addon.getChallengesManager().getAllChallengesList(e.getWorld()).isEmpty())
+        if (!this.addon.getChallengesManager().getAllChallenges(e.getWorld()).isEmpty())
         {
             this.addon.getChallengesManager().save();
         }

--- a/src/main/java/world/bentobox/challenges/panel/AdminEditGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/AdminEditGUI.java
@@ -6,7 +6,7 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
 
 import world.bentobox.challenges.ChallengesAddon;
-import world.bentobox.challenges.database.object.Challenges;
+import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.bentobox.api.panels.Panel;
 import world.bentobox.bentobox.api.panels.PanelItem.ClickHandler;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
@@ -22,7 +22,7 @@ public class AdminEditGUI implements ClickHandler {
 
     private ChallengesAddon addon;
     private User requester;
-    private Challenges challenge;
+    private Challenge challenge;
     private World world;
     private String permPrefix;
     private String label;
@@ -38,7 +38,7 @@ public class AdminEditGUI implements ClickHandler {
      * @param permPrefix permission prefix for world
      * @param label command label
      */
-    public AdminEditGUI(ChallengesAddon addon, User requester, User target, Challenges challenge, World world,
+    public AdminEditGUI(ChallengesAddon addon, User requester, User target, Challenge challenge, World world,
             String permPrefix, String label) {
         super();
         this.addon = addon;

--- a/src/main/java/world/bentobox/challenges/panel/AdminEditGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/AdminEditGUI.java
@@ -13,6 +13,11 @@ import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 
+
+/**
+ * @deprecated All panels are reworked.
+ */
+@Deprecated
 public class AdminEditGUI implements ClickHandler {
 
     private ChallengesAddon addon;

--- a/src/main/java/world/bentobox/challenges/panel/AdminGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/AdminGUI.java
@@ -13,6 +13,11 @@ import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 
+
+/**
+ * @deprecated All panels are reworked.
+ */
+@Deprecated
 public class AdminGUI implements ClickHandler {
 
     private ChallengesAddon addon;

--- a/src/main/java/world/bentobox/challenges/panel/AdminGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/AdminGUI.java
@@ -6,7 +6,7 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
 
 import world.bentobox.challenges.ChallengesAddon;
-import world.bentobox.challenges.database.object.Challenges;
+import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.bentobox.api.panels.Panel;
 import world.bentobox.bentobox.api.panels.PanelItem.ClickHandler;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
@@ -22,7 +22,7 @@ public class AdminGUI implements ClickHandler {
 
     private ChallengesAddon addon;
     private User player;
-    private Challenges challenge;
+    private Challenge challenge;
     private World world;
     private String permPrefix;
     private String label;
@@ -36,7 +36,7 @@ public class AdminGUI implements ClickHandler {
      * @param permPrefix
      * @param label
      */
-    public AdminGUI(ChallengesAddon addon, User player, Challenges challenge, World world,
+    public AdminGUI(ChallengesAddon addon, User player, Challenge challenge, World world,
             String permPrefix, String label) {
         super();
         this.addon = addon;

--- a/src/main/java/world/bentobox/challenges/panel/ChallengesPanels.java
+++ b/src/main/java/world/bentobox/challenges/panel/ChallengesPanels.java
@@ -13,8 +13,8 @@ import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.ChallengesManager;
 import world.bentobox.challenges.LevelStatus;
 import world.bentobox.challenges.commands.ChallengesCommand;
-import world.bentobox.challenges.database.object.Challenges;
-import world.bentobox.challenges.database.object.Challenges.ChallengeType;
+import world.bentobox.challenges.database.object.Challenge;
+import world.bentobox.challenges.database.object.Challenge.ChallengeType;
 import world.bentobox.bentobox.api.panels.Panel;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
@@ -69,9 +69,9 @@ public class ChallengesPanels {
     }
 
     private void addChallengeItems(PanelBuilder panelBuilder) {
-        Set<Challenges> levelChallenges = manager.getChallenges(level, world);
+        Set<Challenge> levelChallenges = manager.getChallenges(level, world);
         // Only show a control panel for the level requested.
-        for (Challenges challenge : levelChallenges) {
+        for (Challenge challenge : levelChallenges) {
             createItem(panelBuilder, challenge);
         }
     }
@@ -87,7 +87,7 @@ public class ChallengesPanels {
      * @param challenge
      * @param user
      */
-    private void createItem(PanelBuilder panelBuilder, Challenges challenge) {
+    private void createItem(PanelBuilder panelBuilder, Challenge challenge) {
         // Check completion
         boolean completed = manager.isChallengeComplete(user, challenge.getUniqueId(), world);
         // If challenge is removed after completion, remove it
@@ -164,7 +164,7 @@ public class ChallengesPanels {
      * @param player
      * @return List of strings splitting challenge string into 25 chars long
      */
-    private List<String> challengeDescription(Challenges challenge) {
+    private List<String> challengeDescription(Challenge challenge) {
         List<String> result = new ArrayList<String>();
         String level = challenge.getLevel();
         if (!level.isEmpty()) {

--- a/src/main/java/world/bentobox/challenges/panel/ChallengesPanels.java
+++ b/src/main/java/world/bentobox/challenges/panel/ChallengesPanels.java
@@ -11,7 +11,7 @@ import org.bukkit.inventory.ItemStack;
 
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.ChallengesManager;
-import world.bentobox.challenges.LevelStatus;
+import world.bentobox.challenges.utils.LevelStatus;
 import world.bentobox.challenges.commands.ChallengesCommand;
 import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.challenges.database.object.Challenge.ChallengeType;

--- a/src/main/java/world/bentobox/challenges/panel/ChallengesPanels.java
+++ b/src/main/java/world/bentobox/challenges/panel/ChallengesPanels.java
@@ -85,7 +85,6 @@ public class ChallengesPanels {
      * Creates a panel item for challenge if appropriate and adds it to panelBuilder
      * @param panelBuilder
      * @param challenge
-     * @param user
      */
     private void createItem(PanelBuilder panelBuilder, Challenge challenge) {
         // Check completion
@@ -100,16 +99,13 @@ public class ChallengesPanels {
                 .description(challengeDescription(challenge))
                 .glow(completed)
                 .clickHandler((panel, player, c, s) -> {
-                    if (!challenge.getChallengeType().equals(ChallengeType.ICON)) {
-                        new TryToComplete(addon).user(player).manager(manager).challenge(challenge)
+                    new TryToComplete(addon).user(player).manager(manager).challenge(challenge)
                         .world(world).permPrefix(permPrefix).label(label).build();
-                        //new TryToComplete(addon, player, manager, challenge, world, permPrefix, label);
-                    }
                     return true;
                 })
                 .build();
-        if (challenge.getSlot() >= 0) {
-            panelBuilder.item(challenge.getSlot(),item);
+        if (challenge.getOrder() >= 0) {
+            panelBuilder.item(challenge.getOrder(),item);
         } else {
             panelBuilder.item(item);
         }
@@ -161,7 +157,6 @@ public class ChallengesPanels {
      * Creates the challenge description for the "item" in the inventory
      *
      * @param challenge
-     * @param player
      * @return List of strings splitting challenge string into 25 chars long
      */
     private List<String> challengeDescription(Challenge challenge) {
@@ -210,7 +205,7 @@ public class ChallengesPanels {
             // First time
             moneyReward = challenge.getRewardMoney();
             rewardText = challenge.getRewardText();
-            expReward = challenge.getRewardExp();
+            expReward = challenge.getRewardExperience();
             if (!rewardText.isEmpty()) {
                 result.addAll(splitTrans(user, "challenges.first-time-rewards"));
             }
@@ -218,7 +213,7 @@ public class ChallengesPanels {
             // Repeat challenge
             moneyReward = challenge.getRepeatMoneyReward();
             rewardText = challenge.getRepeatRewardText();
-            expReward = challenge.getRepeatExpReward();
+            expReward = challenge.getRepeatExperienceReward();
             if (!rewardText.isEmpty()) {
                 result.addAll(splitTrans(user, "challenges.repeat-rewards"));
             }

--- a/src/main/java/world/bentobox/challenges/panel/ChallengesPanels.java
+++ b/src/main/java/world/bentobox/challenges/panel/ChallengesPanels.java
@@ -22,6 +22,10 @@ import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 
 
+/**
+ * @deprecated All panels are reworked.
+ */
+@Deprecated
 public class ChallengesPanels {
     private ChallengesAddon addon;
     private ChallengesManager manager;

--- a/src/main/java/world/bentobox/challenges/panel/ChallengesPanels2.java
+++ b/src/main/java/world/bentobox/challenges/panel/ChallengesPanels2.java
@@ -1,26 +1,26 @@
 package world.bentobox.challenges.panel;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.inventory.ItemStack;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
-import world.bentobox.challenges.ChallengesAddon;
-import world.bentobox.challenges.ChallengesManager;
-import world.bentobox.challenges.database.object.ChallengeLevel;
-import world.bentobox.challenges.utils.GuiUtils;
-import world.bentobox.challenges.utils.LevelStatus;
-import world.bentobox.challenges.commands.ChallengesCommand;
-import world.bentobox.challenges.database.object.Challenge;
-import world.bentobox.challenges.database.object.Challenge.ChallengeType;
 import world.bentobox.bentobox.api.panels.Panel;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.ChallengesAddon;
+import world.bentobox.challenges.ChallengesManager;
+import world.bentobox.challenges.commands.ChallengesCommand;
+import world.bentobox.challenges.database.object.Challenge;
+import world.bentobox.challenges.database.object.Challenge.ChallengeType;
+import world.bentobox.challenges.database.object.ChallengeLevel;
+import world.bentobox.challenges.utils.GuiUtils;
+import world.bentobox.challenges.utils.LevelStatus;
 
 
 /**
@@ -152,7 +152,7 @@ public class ChallengesPanels2 {
         } else {
             // Player click
             itemBuilder.clickHandler((panel, player, c, s) -> {
-                new TryToComplete(addon, player, manager, challenge, world, permPrefix, label);
+                new TryToComplete(addon, player, challenge, world, label, permPrefix);
                 return true;
             });
         }

--- a/src/main/java/world/bentobox/challenges/panel/ChallengesPanels2.java
+++ b/src/main/java/world/bentobox/challenges/panel/ChallengesPanels2.java
@@ -10,7 +10,7 @@ import org.bukkit.inventory.ItemStack;
 
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.ChallengesManager;
-import world.bentobox.challenges.LevelStatus;
+import world.bentobox.challenges.utils.LevelStatus;
 import world.bentobox.challenges.commands.ChallengesCommand;
 import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.challenges.database.object.Challenge.ChallengeType;

--- a/src/main/java/world/bentobox/challenges/panel/ChallengesPanels2.java
+++ b/src/main/java/world/bentobox/challenges/panel/ChallengesPanels2.java
@@ -107,7 +107,6 @@ public class ChallengesPanels2 {
      * Creates a panel item for challenge if appropriate and adds it to panelBuilder
      * @param panelBuilder
      * @param challenge
-     * @param requester
      */
     private void createItem(PanelBuilder panelBuilder, Challenge challenge) {
         // For admin, glow means activated. For user, glow means done
@@ -138,33 +137,27 @@ public class ChallengesPanels2 {
         if (mode.equals(Mode.ADMIN)) {
             // Admin click
             itemBuilder.clickHandler((panel, player, c, s) -> {
-                if (!challenge.getChallengeType().equals(ChallengeType.ICON)) {
-                    new AdminGUI(addon, player, challenge, world, permPrefix, label);
-                }
+                new AdminGUI(addon, player, challenge, world, permPrefix, label);
                 return true;
             });
 
         } else if (mode.equals(Mode.EDIT)) {
             // Admin edit click
             itemBuilder.clickHandler((panel, player, c, s) -> {
-                if (!challenge.getChallengeType().equals(ChallengeType.ICON)) {
-                    new AdminEditGUI(addon, player, target, challenge, world, permPrefix, label);
-                }
+                new AdminEditGUI(addon, player, target, challenge, world, permPrefix, label);
                 return true;
             });
         } else {
             // Player click
             itemBuilder.clickHandler((panel, player, c, s) -> {
-                if (!challenge.getChallengeType().equals(ChallengeType.ICON)) {
-                    new TryToComplete(addon, player, manager, challenge, world, permPrefix, label);
-                }
+                new TryToComplete(addon, player, manager, challenge, world, permPrefix, label);
                 return true;
             });
         }
 
         // If the challenge has a specific slot allocated, use it
-        if (challenge.getSlot() >= 0) {
-            panelBuilder.item(challenge.getSlot(),itemBuilder.build());
+        if (challenge.getOrder() >= 0) {
+            panelBuilder.item(challenge.getOrder(),itemBuilder.build());
         } else {
             panelBuilder.item(itemBuilder.build());
         }
@@ -216,7 +209,6 @@ public class ChallengesPanels2 {
      * Creates the challenge description for the "item" in the inventory
      *
      * @param challenge
-     * @param player
      * @return List of strings splitting challenge string into 25 chars long
      */
     private List<String> challengeDescription(Challenge challenge) {
@@ -287,7 +279,7 @@ public class ChallengesPanels2 {
             // First time
             moneyReward = challenge.getRewardMoney();
             rewardText = challenge.getRewardText();
-            expReward = challenge.getRewardExp();
+            expReward = challenge.getRewardExperience();
             if (!rewardText.isEmpty()) {
                 result.addAll(splitTrans(requester, "challenges.first-time-rewards"));
             }
@@ -296,7 +288,7 @@ public class ChallengesPanels2 {
             // Repeat challenge
             moneyReward = challenge.getRepeatMoneyReward();
             rewardText = challenge.getRepeatRewardText();
-            expReward = challenge.getRepeatExpReward();
+            expReward = challenge.getRepeatExperienceReward();
             if (!rewardText.isEmpty()) {
                 result.addAll(splitTrans(requester, "challenges.repeat-rewards"));
             }

--- a/src/main/java/world/bentobox/challenges/panel/ChallengesPanels2.java
+++ b/src/main/java/world/bentobox/challenges/panel/ChallengesPanels2.java
@@ -21,6 +21,10 @@ import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 
 
+/**
+ * @deprecated All panels are reworked.
+ */
+@Deprecated
 public class ChallengesPanels2 {
 
     public enum Mode {

--- a/src/main/java/world/bentobox/challenges/panel/ChallengesPanels2.java
+++ b/src/main/java/world/bentobox/challenges/panel/ChallengesPanels2.java
@@ -12,8 +12,8 @@ import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.ChallengesManager;
 import world.bentobox.challenges.LevelStatus;
 import world.bentobox.challenges.commands.ChallengesCommand;
-import world.bentobox.challenges.database.object.Challenges;
-import world.bentobox.challenges.database.object.Challenges.ChallengeType;
+import world.bentobox.challenges.database.object.Challenge;
+import world.bentobox.challenges.database.object.Challenge.ChallengeType;
 import world.bentobox.bentobox.api.panels.Panel;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
@@ -93,7 +93,7 @@ public class ChallengesPanels2 {
 
     private void addChallengeItems(PanelBuilder panelBuilder) {
         // Only show a control panel for the level requested.
-        for (Challenges challenge : manager.getChallenges(level, world)) {
+        for (Challenge challenge : manager.getChallenges(level, world)) {
             createItem(panelBuilder, challenge);
         }
     }
@@ -109,7 +109,7 @@ public class ChallengesPanels2 {
      * @param challenge
      * @param requester
      */
-    private void createItem(PanelBuilder panelBuilder, Challenges challenge) {
+    private void createItem(PanelBuilder panelBuilder, Challenge challenge) {
         // For admin, glow means activated. For user, glow means done
         boolean glow = false;
         switch (mode) {
@@ -219,7 +219,7 @@ public class ChallengesPanels2 {
      * @param player
      * @return List of strings splitting challenge string into 25 chars long
      */
-    private List<String> challengeDescription(Challenges challenge) {
+    private List<String> challengeDescription(Challenge challenge) {
         List<String> result = new ArrayList<String>();
         String level = challenge.getLevel();
         if (!level.isEmpty()) {
@@ -278,7 +278,7 @@ public class ChallengesPanels2 {
         return result;
     }
 
-    private List<String> addRewards(Challenges challenge, boolean complete, boolean admin) {
+    private List<String> addRewards(Challenge challenge, boolean complete, boolean admin) {
         List<String> result = new ArrayList<>();
         double moneyReward = 0;
         int expReward = 0;

--- a/src/main/java/world/bentobox/challenges/panel/CommonGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/CommonGUI.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.List;
 
 import world.bentobox.bentobox.api.panels.PanelItem;
-import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.challenges.ChallengesAddon;
@@ -231,65 +230,6 @@ public abstract class CommonGUI
 		}
 
 		return new PanelItem(icon, name, description, false, clickHandler, false);
-	}
-
-
-	/**
-	 * This method creates border of black panes around given panel with 5 rows.
-	 * @param panelBuilder PanelBuilder which must be filled with border blocks.
-	 */
-	protected void fillBorder(PanelBuilder panelBuilder)
-	{
-		this.fillBorder(panelBuilder, 5, Material.BLACK_STAINED_GLASS_PANE);
-	}
-
-
-	/**
-	 * This method sets black stained glass pane around Panel with given row count.
-	 * @param panelBuilder object that builds Panel.
-	 * @param rowCount in Panel.
-	 */
-	protected void fillBorder(PanelBuilder panelBuilder, int rowCount)
-	{
-		this.fillBorder(panelBuilder, rowCount, Material.BLACK_STAINED_GLASS_PANE);
-	}
-
-
-	/**
-	 * This method sets blocks with given Material around Panel with 5 rows.
-	 * @param panelBuilder object that builds Panel.
-	 * @param material that will be around Panel.
-	 */
-	protected void fillBorder(PanelBuilder panelBuilder, Material material)
-	{
-		this.fillBorder(panelBuilder, 5, material);
-	}
-
-
-	/**
-	 * This method sets blocks with given Material around Panel with given row count.
-	 * @param panelBuilder object that builds Panel.
-	 * @param rowCount in Panel.
-	 * @param material that will be around Panel.
-	 */
-	protected void fillBorder(PanelBuilder panelBuilder, int rowCount, Material material)
-	{
-		// Only for useful filling.
-		if (rowCount < 3)
-		{
-			return;
-		}
-
-		for (int i = 0; i < 9 * rowCount; i++)
-		{
-			// First (i < 9) and last (i > 35) rows must be filled
-			// First column (i % 9 == 0) and last column (i % 9 == 8) also must be filled.
-
-			if (i < 9 || i > 9 * (rowCount - 1) || i % 9 == 0 || i % 9 == 8)
-			{
-				panelBuilder.item(i, new PanelItemBuilder().name("&2").icon(material).build());
-			}
-		}
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/panel/CommonGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/CommonGUI.java
@@ -235,20 +235,59 @@ public abstract class CommonGUI
 
 
 	/**
-	 * This method creates border of black panes around given panel.
+	 * This method creates border of black panes around given panel with 5 rows.
 	 * @param panelBuilder PanelBuilder which must be filled with border blocks.
 	 */
 	protected void fillBorder(PanelBuilder panelBuilder)
 	{
-		for (int i = 0; i < 45; i++)
+		this.fillBorder(panelBuilder, 5, Material.BLACK_STAINED_GLASS_PANE);
+	}
+
+
+	/**
+	 * This method sets black stained glass pane around Panel with given row count.
+	 * @param panelBuilder object that builds Panel.
+	 * @param rowCount in Panel.
+	 */
+	protected void fillBorder(PanelBuilder panelBuilder, int rowCount)
+	{
+		this.fillBorder(panelBuilder, rowCount, Material.BLACK_STAINED_GLASS_PANE);
+	}
+
+
+	/**
+	 * This method sets blocks with given Material around Panel with 5 rows.
+	 * @param panelBuilder object that builds Panel.
+	 * @param material that will be around Panel.
+	 */
+	protected void fillBorder(PanelBuilder panelBuilder, Material material)
+	{
+		this.fillBorder(panelBuilder, 5, material);
+	}
+
+
+	/**
+	 * This method sets blocks with given Material around Panel with given row count.
+	 * @param panelBuilder object that builds Panel.
+	 * @param rowCount in Panel.
+	 * @param material that will be around Panel.
+	 */
+	protected void fillBorder(PanelBuilder panelBuilder, int rowCount, Material material)
+	{
+		// Only for useful filling.
+		if (rowCount < 3)
+		{
+			return;
+		}
+
+		for (int i = 0; i < 9 * rowCount; i++)
 		{
 			// First (i < 9) and last (i > 35) rows must be filled
 			// First column (i % 9 == 0) and last column (i % 9 == 8) also must be filled.
 
-			if (i < 9 || i > 35 || i % 9 == 0 || i % 9 == 8)
+			if (i < 9 || i > 9 * (rowCount - 1) || i % 9 == 0 || i % 9 == 8)
 			{
-				panelBuilder.item(i,
-					new PanelItemBuilder().name("").icon(Material.BLACK_STAINED_GLASS_PANE).build());
+				panelBuilder.item(i, new PanelItemBuilder().name("&2").icon(material).build());
 			}
 		}
 	}

--- a/src/main/java/world/bentobox/challenges/panel/CommonGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/CommonGUI.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 
 import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.challenges.ChallengesAddon;
@@ -230,6 +231,26 @@ public abstract class CommonGUI
 		}
 
 		return new PanelItem(icon, name, description, false, clickHandler, false);
+	}
+
+
+	/**
+	 * This method creates border of black panes around given panel.
+	 * @param panelBuilder PanelBuilder which must be filled with border blocks.
+	 */
+	protected void fillBorder(PanelBuilder panelBuilder)
+	{
+		for (int i = 0; i < 45; i++)
+		{
+			// First (i < 9) and last (i > 35) rows must be filled
+			// First column (i % 9 == 0) and last column (i % 9 == 8) also must be filled.
+
+			if (i < 9 || i > 35 || i % 9 == 0 || i % 9 == 8)
+			{
+				panelBuilder.item(i,
+					new PanelItemBuilder().name("").icon(Material.BLACK_STAINED_GLASS_PANE).build());
+			}
+		}
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/panel/CreateChallengeListener.java
+++ b/src/main/java/world/bentobox/challenges/panel/CreateChallengeListener.java
@@ -7,6 +7,11 @@ import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.bentobox.api.panels.PanelListener;
 import world.bentobox.bentobox.api.user.User;
 
+
+/**
+ * @deprecated All panels are reworked.
+ */
+@Deprecated
 public class CreateChallengeListener implements PanelListener {
 
     private ChallengesAddon addon;

--- a/src/main/java/world/bentobox/challenges/panel/CreateChallengeListener.java
+++ b/src/main/java/world/bentobox/challenges/panel/CreateChallengeListener.java
@@ -29,7 +29,7 @@ public class CreateChallengeListener implements PanelListener {
 
     @Override
     public void onInventoryClose(InventoryCloseEvent event) {
-        addon.getChallengesManager().createInvChallenge(user, event.getInventory());    
+        addon.getChallengesManager().createChallenge("uniqueID");
     }
 
     @Override

--- a/src/main/java/world/bentobox/challenges/panel/CreateChallengePanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/CreateChallengePanel.java
@@ -4,6 +4,11 @@ import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.user.User;
 
+
+/**
+ * @deprecated All panels are reworked.
+ */
+@Deprecated
 public class CreateChallengePanel {
 
     public CreateChallengePanel(ChallengesAddon addon, User user) {

--- a/src/main/java/world/bentobox/challenges/panel/RequiredPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/RequiredPanel.java
@@ -12,7 +12,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.ItemStack;
 
-import world.bentobox.challenges.database.object.Challenges;
+import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.bentobox.api.panels.Panel;
 import world.bentobox.bentobox.api.panels.PanelItem.ClickHandler;
 import world.bentobox.bentobox.api.panels.PanelListener;
@@ -30,7 +30,7 @@ import world.bentobox.bentobox.util.Util;
 @Deprecated
 public class RequiredPanel implements ClickHandler, PanelListener {
     private static final int CONTROL_NUMBER = 4;
-    private Challenges challenge;
+    private Challenge challenge;
     private User user;
     private Panel panel;
     private Panel referringPanel;
@@ -39,7 +39,7 @@ public class RequiredPanel implements ClickHandler, PanelListener {
      * @param challenge
      * @param user
      */
-    public RequiredPanel(Challenges challenge, User user, Panel referringPanel) {
+    public RequiredPanel(Challenge challenge, User user, Panel referringPanel) {
         this.challenge = challenge;
         this.user = user;
         this.panel = openPanel();

--- a/src/main/java/world/bentobox/challenges/panel/RequiredPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/RequiredPanel.java
@@ -25,8 +25,9 @@ import world.bentobox.bentobox.util.Util;
  * Handles the requirements for a challenge
  * Items, blocks, entities
  * @author tastybento
- *
+ * @deprecated All panels are reworked.
  */
+@Deprecated
 public class RequiredPanel implements ClickHandler, PanelListener {
     private static final int CONTROL_NUMBER = 4;
     private Challenges challenge;

--- a/src/main/java/world/bentobox/challenges/panel/RequiredPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/RequiredPanel.java
@@ -73,7 +73,7 @@ public class RequiredPanel implements ClickHandler, PanelListener {
                     .clickHandler(this)
                     .build()).forEach(pb::item);
             return pb.user(user).build();
-        case LEVEL:
+        case OTHER:
 
             break;
         default:
@@ -137,8 +137,6 @@ public class RequiredPanel implements ClickHandler, PanelListener {
         }
         // Save changes
         switch (challenge.getChallengeType()) {
-        case ICON:
-            break;
         case INVENTORY:
             List<ItemStack> reqItems = new ArrayList<>();
             // Skip first item
@@ -154,7 +152,7 @@ public class RequiredPanel implements ClickHandler, PanelListener {
             break;
         case ISLAND:
             break;
-        case LEVEL:
+            case OTHER:
             break;
         default:
             break;

--- a/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
@@ -124,7 +124,7 @@ public class TryToComplete {
             user.sendMessage("challenges.you-repeated", "[challenge]", challenge.getFriendlyName());
         }
         // Mark as complete
-        manager.setChallengeComplete(user, challenge.getUniqueId(), world);
+        manager.setChallengeComplete(user, challenge);
         user.closeInventory();
         user.getPlayer().performCommand(label + " " + ChallengesCommand.CHALLENGE_COMMAND + " " + challenge.getLevel());
         return result;
@@ -189,7 +189,7 @@ public class TryToComplete {
             user.sendMessage("challenges.you-repeated", "[challenge]", challenge.getFriendlyName());
         }
         // Mark as complete
-        manager.setChallengeComplete(user, challenge.getUniqueId(), world);
+        manager.setChallengeComplete(user, challenge);
         user.closeInventory();
         user.getPlayer().performCommand(label + " " + ChallengesCommand.CHALLENGE_COMMAND + " " + challenge.getLevel());
     }
@@ -204,17 +204,17 @@ public class TryToComplete {
             return new ChallengeResult();
         }
         // Check if user has the
-        if (!challenge.getLevel().equals(ChallengesManager.FREE) && !manager.isLevelUnlocked(user, challenge.getLevel(), world)) {
+        if (!challenge.getLevel().equals(ChallengesManager.FREE) && !manager.isLevelUnlocked(user, world, manager.getLevel(challenge.getLevel()))) {
             user.sendMessage("challenges.errors.challenge-level-not-available");
             return new ChallengeResult();
         }
         // Check max times
-        if (challenge.isRepeatable() && challenge.getMaxTimes() > 0 && manager.checkChallengeTimes(user, challenge, world) >= challenge.getMaxTimes()) {
+        if (challenge.isRepeatable() && challenge.getMaxTimes() > 0 && manager.getChallengeTimes(user, challenge) >= challenge.getMaxTimes()) {
             user.sendMessage("challenges.not-repeatable");
             return new ChallengeResult();
         }
         // Check repeatability
-        if (manager.isChallengeComplete(user, challenge.getUniqueId(), world)
+        if (manager.isChallengeComplete(user, challenge)
                 && (!challenge.isRepeatable() || challenge.getChallengeType().equals(ChallengeType.OTHER)
                         || challenge.getChallengeType().equals(ChallengeType.ISLAND))) {
             user.sendMessage("challenges.not-repeatable");
@@ -288,7 +288,7 @@ public class TryToComplete {
         this.removeMoney();
 
         // Return the result
-        return new ChallengeResult().setMeetsRequirements().setRepeat(manager.isChallengeComplete(user, challenge.getUniqueId(), world));
+        return new ChallengeResult().setMeetsRequirements().setRepeat(manager.isChallengeComplete(user, challenge));
     }
 
 

--- a/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
@@ -274,6 +274,12 @@ public class TryToComplete
         {
             this.user.sendMessage("challenges.not-repeatable");
         }
+        // Check environment
+        else if (!this.challenge.getEnvironment().isEmpty() &&
+            !this.challenge.getEnvironment().contains(this.user.getWorld().getEnvironment()))
+        {
+            this.user.sendMessage("general.errors.wrong-environment");
+        }
         else if (type.equals(ChallengeType.INVENTORY))
         {
             return this.checkInventory();

--- a/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
@@ -302,7 +302,12 @@ public class TryToComplete
         ChallengeType type = this.challenge.getChallengeType();
 
         // Check the world
-        if (Util.getWorld(this.world) != Util.getWorld(this.user.getWorld()) ||
+        if (!this.challenge.isDeployed())
+        {
+            this.user.sendMessage("challenges.error.not-deployed");
+            result = EMPTY_RESULT;
+        }
+        else if (Util.getWorld(this.world) != Util.getWorld(this.user.getWorld()) ||
             !this.challenge.getUniqueId().startsWith(Util.getWorld(this.world).getName()))
         {
             this.user.sendMessage("general.errors.wrong-world");

--- a/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
@@ -3,387 +3,532 @@
  */
 package world.bentobox.challenges.panel;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
+import java.util.*;
+import java.util.stream.Collectors;
 
-import world.bentobox.challenges.ChallengesAddon;
-import world.bentobox.challenges.ChallengesManager;
-import world.bentobox.challenges.commands.ChallengesCommand;
-import world.bentobox.challenges.database.object.Challenge;
-import world.bentobox.challenges.database.object.Challenge.ChallengeType;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
-import world.bentobox.bentobox.hooks.VaultHook;
 import world.bentobox.bentobox.util.Util;
-import world.bentobox.level.Level;
+import world.bentobox.challenges.ChallengesAddon;
+import world.bentobox.challenges.ChallengesManager;
+import world.bentobox.challenges.database.object.Challenge;
+import world.bentobox.challenges.database.object.Challenge.ChallengeType;
+
 
 /**
  * Run when a user tries to complete a challenge
  * @author tastybento
  *
  */
-public class TryToComplete {
+public class TryToComplete
+{
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
 
+    /**
+     * Challenges addon variable.
+     */
     private ChallengesAddon addon;
-    private World world;
-    private String permPrefix;
-    private User user;
-    private ChallengesManager manager;
-    private Challenge challenge;
-    private String label;
 
-    public TryToComplete label(String label) {
-        this.label = label;
+    /**
+     * Challenges manager for addon.
+     */
+    private ChallengesManager manager;
+
+    /**
+     * World where all checks are necessary.
+     */
+    private World world;
+
+    /**
+     * User who is completing challenge.
+     */
+    private User user;
+
+    /**
+     * Permission prefix string.
+     */
+    private String permissionPrefix;
+
+    /**
+     * Top command first label.
+     */
+    private String topLabel;
+
+    /**
+     * Challenge that should be completed.
+     */
+    private Challenge challenge;
+
+
+// ---------------------------------------------------------------------
+// Section: Builder
+// ---------------------------------------------------------------------
+
+    @Deprecated
+    public TryToComplete label(String label)
+    {
+        this.topLabel = label;
         return this;
     }
 
-    public TryToComplete user(User user) {
+
+    @Deprecated
+    public TryToComplete user(User user)
+    {
         this.user = user;
         return this;
     }
 
-    public TryToComplete manager(ChallengesManager manager) {
+
+    @Deprecated
+    public TryToComplete manager(ChallengesManager manager)
+    {
         this.manager = manager;
         return this;
     }
 
-    public TryToComplete challenge(Challenge challenge) {
+
+    @Deprecated
+    public TryToComplete challenge(Challenge challenge)
+    {
         this.challenge = challenge;
         return this;
     }
 
-    public TryToComplete world(World world) {
+
+    @Deprecated
+    public TryToComplete world(World world)
+    {
         this.world = world;
         return this;
     }
 
-    public TryToComplete permPrefix(String prefix) {
-        this.permPrefix = prefix;
+
+    @Deprecated
+    public TryToComplete permPrefix(String prefix)
+    {
+        this.permissionPrefix = prefix;
         return this;
     }
 
-    public TryToComplete(ChallengesAddon addon) {
+
+    @Deprecated
+    public TryToComplete(ChallengesAddon addon)
+    {
         this.addon = addon;
     }
 
-    public ChallengeResult build() {
+
+// ---------------------------------------------------------------------
+// Section: Constructor
+// ---------------------------------------------------------------------
+
+
+    /**
+     * @param addon - Challenges Addon.
+     * @param user - User who performs challenge.
+     * @param challenge - Challenge that should be completed.
+     * @param world - World where completion may occur.
+     * @param topLabel - Label of the top command.
+     * @param permissionPrefix - Permission prefix for GameMode addon.
+     */
+    public TryToComplete(ChallengesAddon addon,
+        User user,
+        Challenge challenge,
+        World world,
+        String topLabel,
+        String permissionPrefix)
+    {
+        this.addon = addon;
+        this.world = world;
+        this.permissionPrefix = permissionPrefix;
+        this.user = user;
+        this.manager = addon.getChallengesManager();
+        this.challenge = challenge;
+        this.topLabel = topLabel;
+
+        this.build();
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Methods
+// ---------------------------------------------------------------------
+
+
+    /**
+     * This method checks if challenge can be done, and complete it, if it is possible.
+     * @return ChallengeResult object, that contains completion status.
+     */
+    public ChallengeResult build()
+    {
         // Check if can complete challenge
-        ChallengeResult result = checkIfCanCompleteChallenge();
-        if (!result.meetsRequirements) {
+        ChallengeResult result = this.checkIfCanCompleteChallenge();
+
+        if (!result.meetsRequirements)
+        {
             return result;
         }
-        if (!result.repeat) {
-            // Give rewards
-            for (ItemStack reward : challenge.getRewardItems()) {
-                user.getInventory().addItem(reward).forEach((k,v) -> user.getWorld().dropItem(user.getLocation(), v));
+
+        if (!result.repeat)
+        {
+            // Item rewards
+            for (ItemStack reward : this.challenge.getRewardItems())
+            {
+                this.user.getInventory().addItem(reward).forEach((k, v) ->
+                    this.user.getWorld().dropItem(this.user.getLocation(), v));
             }
 
-            // Give money
-            this.addon.getPlugin().getVault().ifPresent(
-                vaultHook -> vaultHook.deposit(this.user, this.challenge.getRewardMoney()));
+            // Money Reward
+            if (this.addon.isEconomyProvided())
+            {
+                this.addon.getEconomyProvider().deposit(this.user, this.challenge.getRewardMoney());
+            }
 
-            // Give exp
-            user.getPlayer().giveExp(challenge.getRewardExperience());
+            // Experience Reward
+            this.user.getPlayer().giveExp(this.challenge.getRewardExperience());
+
             // Run commands
-            runCommands(challenge.getRewardCommands());
-            user.sendMessage("challenges.you-completed", "[challenge]", challenge.getFriendlyName());
-            if (addon.getChallengesSettings().isBroadcastMessages()) {
-                for (Player p : addon.getServer().getOnlinePlayers()) {
+            this.runCommands(this.challenge.getRewardCommands());
+
+            this.user.sendMessage("challenges.you-completed", "[challenge]", this.challenge.getFriendlyName());
+
+            if (this.addon.getChallengesSettings().isBroadcastMessages())
+            {
+                for (Player p : this.addon.getServer().getOnlinePlayers())
+                {
                     User.getInstance(p).sendMessage("challenges.name-has-completed",
-                            "[name]", user.getName(), "[challenge]", challenge.getFriendlyName());
+                        "[name]", this.user.getName(), "[challenge]", this.challenge.getFriendlyName());
                 }
             }
-        } else {
-            // Give rewards
-            for (ItemStack reward : challenge.getRepeatItemReward()) {
-                user.getInventory().addItem(reward).forEach((k,v) -> user.getWorld().dropItem(user.getLocation(), v));
+        }
+        else
+        {
+            // Item Repeat Rewards
+            for (ItemStack reward : this.challenge.getRepeatItemReward())
+            {
+                this.user.getInventory().addItem(reward).forEach((k, v) ->
+                    this.user.getWorld().dropItem(this.user.getLocation(), v));
             }
 
-            // Give money
-            this.addon.getPlugin().getVault().ifPresent(
-                vaultHook -> vaultHook.deposit(this.user, this.challenge.getRepeatMoneyReward()));
+            // Money Repeat Reward
+            if (this.addon.isEconomyProvided())
+            {
+                this.addon.getEconomyProvider().deposit(this.user, this.challenge.getRepeatMoneyReward());
+            }
 
-            // Give exp
-            user.getPlayer().giveExp(challenge.getRepeatExperienceReward());
+            // Experience Repeat Reward
+            this.user.getPlayer().giveExp(this.challenge.getRepeatExperienceReward());
+
             // Run commands
-            runCommands(challenge.getRepeatRewardCommands());
-            user.sendMessage("challenges.you-repeated", "[challenge]", challenge.getFriendlyName());
+            this.runCommands(this.challenge.getRepeatRewardCommands());
+
+            this.user.sendMessage("challenges.you-repeated", "[challenge]", this.challenge.getFriendlyName());
         }
+
         // Mark as complete
-        manager.setChallengeComplete(user, challenge);
-        user.closeInventory();
-        user.getPlayer().performCommand(label + " " + ChallengesCommand.CHALLENGE_COMMAND + " " + challenge.getLevel());
+        this.manager.setChallengeComplete(this.user, this.challenge);
+
         return result;
     }
 
-    /**
-     * @param addon
-     * @param user
-     * @param manager
-     * @param challenge
-     * @param world
-     * @param permPrefix
-     */
-    public TryToComplete(ChallengesAddon addon, User user, ChallengesManager manager, Challenge challenge, World world, String permPrefix, String label) {
-        this.addon = addon;
-        this.world = world;
-        this.permPrefix = permPrefix;
-        this.user = user;
-        this.manager = manager;
-        this.challenge = challenge;
-
-        // Check if can complete challenge
-        ChallengeResult result = checkIfCanCompleteChallenge();
-        if (!result.meetsRequirements) {
-            return;
-        }
-        if (!result.repeat) {
-            // Give rewards
-            for (ItemStack reward : challenge.getRewardItems()) {
-                user.getInventory().addItem(reward).forEach((k,v) -> user.getWorld().dropItem(user.getLocation(), v));
-            }
-
-            // Give money
-            this.addon.getPlugin().getVault().ifPresent(
-                vaultHook -> vaultHook.deposit(this.user, this.challenge.getRewardMoney()));
-
-            // Give exp
-            user.getPlayer().giveExp(challenge.getRewardExperience());
-            // Run commands
-            runCommands(challenge.getRewardCommands());
-            user.sendMessage("challenges.you-completed", "[challenge]", challenge.getFriendlyName());
-            if (addon.getChallengesSettings().isBroadcastMessages()) {
-                for (Player p : addon.getServer().getOnlinePlayers()) {
-                    User.getInstance(p).sendMessage("challenges.name-has-completed",
-                            "[name]", user.getName(), "[challenge]", challenge.getFriendlyName());
-                }
-            }
-        } else {
-            // Give rewards
-            for (ItemStack reward : challenge.getRepeatItemReward()) {
-                user.getInventory().addItem(reward).forEach((k,v) -> user.getWorld().dropItem(user.getLocation(), v));
-            }
-
-            // Give money
-            this.addon.getPlugin().getVault().ifPresent(
-                vaultHook -> vaultHook.deposit(this.user, this.challenge.getRepeatMoneyReward()));
-
-            // Give exp
-            user.getPlayer().giveExp(challenge.getRepeatExperienceReward());
-            // Run commands
-            runCommands(challenge.getRepeatRewardCommands());
-            user.sendMessage("challenges.you-repeated", "[challenge]", challenge.getFriendlyName());
-        }
-        // Mark as complete
-        manager.setChallengeComplete(user, challenge);
-        user.closeInventory();
-        user.getPlayer().performCommand(label + " " + ChallengesCommand.CHALLENGE_COMMAND + " " + challenge.getLevel());
-    }
 
     /**
      * Checks if a challenge can be completed or not
+     * It returns ChallengeResult.
      */
-    private ChallengeResult checkIfCanCompleteChallenge() {
+    private ChallengeResult checkIfCanCompleteChallenge()
+    {
+        ChallengeType type = this.challenge.getChallengeType();
+
         // Check the world
-        if (!challenge.getUniqueId().startsWith(Util.getWorld(world).getName())) {
-            user.sendMessage("general.errors.wrong-world");
-            return new ChallengeResult();
+        if (!this.challenge.getUniqueId().startsWith(Util.getWorld(this.world).getName()))
+        {
+            this.user.sendMessage("general.errors.wrong-world");
         }
-        // Check if user has the
-        if (!challenge.getLevel().equals(ChallengesManager.FREE) && !manager.isLevelUnlocked(user, world, manager.getLevel(challenge.getLevel()))) {
-            user.sendMessage("challenges.errors.challenge-level-not-available");
-            return new ChallengeResult();
+        // Check if user has unlocked challenges level.
+        else if (!this.challenge.getLevel().equals(ChallengesManager.FREE) &&
+            !this.manager.isLevelUnlocked(this.user, this.world, this.manager.getLevel(this.challenge.getLevel())))
+        {
+            this.user.sendMessage("challenges.errors.challenge-level-not-available");
         }
         // Check max times
-        if (challenge.isRepeatable() && challenge.getMaxTimes() > 0 && manager.getChallengeTimes(user, challenge) >= challenge.getMaxTimes()) {
-            user.sendMessage("challenges.not-repeatable");
-            return new ChallengeResult();
+        else if (this.challenge.isRepeatable() && this.challenge.getMaxTimes() > 0 &&
+            this.manager.getChallengeTimes(this.user, this.challenge) >= this.challenge.getMaxTimes())
+        {
+            this.user.sendMessage("challenges.not-repeatable");
         }
         // Check repeatability
-        if (manager.isChallengeComplete(user, challenge)
-                && (!challenge.isRepeatable() || challenge.getChallengeType().equals(ChallengeType.OTHER)
-                        || challenge.getChallengeType().equals(ChallengeType.ISLAND))) {
-            user.sendMessage("challenges.not-repeatable");
-            return new ChallengeResult();
-        }
-
-        // Check money
-        Optional<VaultHook> vaultHook = this.addon.getPlugin().getVault();
-
-        if (vaultHook.isPresent())
+        else if (this.manager.isChallengeComplete(this.user, this.challenge)
+            && (!this.challenge.isRepeatable() || type.equals(ChallengeType.ISLAND)))
         {
-            if (!vaultHook.get().has(this.user, this.challenge.getRequiredMoney()))
-            {
-                this.user.sendMessage("challenges.not-enough-money", "[money]", Integer.toString(this.challenge.getRequiredMoney()));
-                return new ChallengeResult();
-            }
+            this.user.sendMessage("challenges.not-repeatable");
         }
-
-        // Check exp
-        if (this.user.getPlayer().getTotalExperience() < this.challenge.getRequiredExperience())
+        else if (type.equals(ChallengeType.INVENTORY))
         {
-            this.user.sendMessage("challenges.not-enough-exp", "[xp]", Integer.toString(this.challenge.getRequiredExperience()));
-            return new ChallengeResult();
+            return this.checkInventory();
+        }
+        else if (type.equals(ChallengeType.ISLAND))
+        {
+            return this.checkSurrounding();
+        }
+        else if (type.equals(ChallengeType.OTHER))
+        {
+            return this.checkOthers();
         }
 
-        switch (challenge.getChallengeType()) {
-        case INVENTORY:
-            return checkInventory();
-        case OTHER:
-            return checkLevel();
-        case ISLAND:
-            return checkSurrounding();
-        default:
-            return new ChallengeResult();
-        }
-    }
-
-    private ChallengeResult checkInventory() {
-        // Run through inventory
-        List<ItemStack> required = new ArrayList<>(challenge.getRequiredItems());
-        for (ItemStack req : required) {
-            // Check for FIREWORK_ROCKET, ENCHANTED_BOOK, WRITTEN_BOOK, POTION and FILLED_MAP because these have unique meta when created
-            switch (req.getType()) {
-            case FIREWORK_ROCKET:
-            case ENCHANTED_BOOK:
-            case WRITTEN_BOOK:
-            case FILLED_MAP:
-                // Get how many items are in the inventory. Item stacks amounts need to be summed
-                int numInInventory = Arrays.stream(user.getInventory().getContents()).filter(Objects::nonNull).filter(i -> i.getType().equals(req.getType())).mapToInt(i -> i.getAmount()).sum();
-                if (numInInventory < req.getAmount()) {
-                    user.sendMessage("challenges.error.not-enough-items", "[items]", Util.prettifyText(req.getType().toString()));
-                    return new ChallengeResult();
-                }
-                break;
-            default:
-                // General checking
-                if (!user.getInventory().containsAtLeast(req, req.getAmount())) {
-                    user.sendMessage("challenges.error.not-enough-items", "[items]", Util.prettifyText(req.getType().toString()));
-                    return new ChallengeResult();
-                }
-            }
-
-        }
-        // If remove items, then remove them
-        if (challenge.isTakeItems()) {
-            removeItems(required);
-
-        }
-
-        // process money removal
-        this.removeMoney();
-
-        // Return the result
-        return new ChallengeResult().setMeetsRequirements().setRepeat(manager.isChallengeComplete(user, challenge));
+        // Everything fails till this point.
+        return new ChallengeResult();
     }
 
 
     /**
-     * This method withdraw user money, if challenge Required Money is larger then 0, and
-     * it is set to removal.
-     * This works only if vaultHook is enabled.
-      */
-    private void removeMoney()
+     * This method runs all commands from command list.
+     * @param commands List of commands that must be performed.
+     */
+    private void runCommands(List<String> commands)
     {
-        Optional<VaultHook> vaultHook = this.addon.getPlugin().getVault();
-
-        if (vaultHook.isPresent() &&
-            this.challenge.isTakeMoney() &&
-            this.challenge.getRequiredMoney() > 0)
+        // Ignore commands with this perm
+        if (user.hasPermission(this.permissionPrefix + "command.challengeexempt") && !user.isOp())
         {
-            vaultHook.get().withdraw(this.user, this.challenge.getRequiredMoney());
+            return;
         }
+        for (String cmd : commands)
+        {
+            if (cmd.startsWith("[SELF]"))
+            {
+                String alert = "Running command '" + cmd + "' as " + this.user.getName();
+                this.addon.getLogger().info(alert);
+                cmd = cmd.substring(6, cmd.length()).replace("[player]", this.user.getName()).trim();
+                try
+                {
+                    if (!user.performCommand(cmd))
+                    {
+                        this.showError(cmd);
+                    }
+                }
+                catch (Exception e)
+                {
+                    this.showError(cmd);
+                }
+
+                continue;
+            }
+            // Substitute in any references to player
+            try
+            {
+                if (!this.addon.getServer().dispatchCommand(this.addon.getServer().getConsoleSender(),
+                    cmd.replace("[player]", this.user.getName())))
+                {
+                    this.showError(cmd);
+                }
+            }
+            catch (Exception e)
+            {
+                this.showError(cmd);
+            }
+        }
+    }
+
+
+    /**
+     * Throws error message.
+     * @param cmd Error message that appear after failing some command.
+     */
+    private void showError(final String cmd)
+    {
+        this.addon.getLogger().severe("Problem executing command executed by player - skipping!");
+        this.addon.getLogger().severe(() -> "Command was : " + cmd);
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Inventory Challenge
+// ---------------------------------------------------------------------
+
+
+    /**
+     * Checks if a inventory challenge can be completed or not
+     * It returns ChallengeResult.
+     */
+    private ChallengeResult checkInventory()
+    {
+        // Run through inventory
+        List<ItemStack> required = new ArrayList<>(this.challenge.getRequiredItems());
+        for (ItemStack req : required)
+        {
+            // Check for FIREWORK_ROCKET, ENCHANTED_BOOK, WRITTEN_BOOK, POTION and FILLED_MAP because these have unique meta when created
+            switch (req.getType())
+            {
+                case FIREWORK_ROCKET:
+                case ENCHANTED_BOOK:
+                case WRITTEN_BOOK:
+                case FILLED_MAP:
+                    // Get how many items are in the inventory. Item stacks amounts need to be summed
+                    int numInInventory =
+                        Arrays.stream(this.user.getInventory().getContents()).filter(Objects::nonNull).
+                            filter(i -> i.getType().equals(req.getType())).
+                            mapToInt(ItemStack::getAmount).
+                            sum();
+
+                    if (numInInventory < req.getAmount())
+                    {
+                        this.user.sendMessage("challenges.error.not-enough-items",
+                            "[items]",
+                            Util.prettifyText(req.getType().toString()));
+                        return new ChallengeResult();
+                    }
+                    break;
+                default:
+                    // General checking
+                    if (!this.user.getInventory().containsAtLeast(req, req.getAmount()))
+                    {
+                        this.user.sendMessage("challenges.error.not-enough-items",
+                            "[items]",
+                            Util.prettifyText(req.getType().toString()));
+                        return new ChallengeResult();
+                    }
+            }
+        }
+
+        // If remove items, then remove them
+
+        if (this.challenge.isTakeItems())
+        {
+            this.removeItems(required);
+        }
+
+
+        // Return the result
+        return new ChallengeResult().setMeetsRequirements().setRepeat(
+            this.manager.isChallengeComplete(this.user, this.challenge));
     }
 
 
     /**
      * Removes items from a user's inventory
      * @param required - a list of item stacks to be removed
-     * @return Map of item type and quantity that were successfully removed from the user's inventory
      */
-    public Map<Material, Integer> removeItems(List<ItemStack> required) {
+    Map<Material, Integer> removeItems(List<ItemStack> required)
+    {
         Map<Material, Integer> removed = new HashMap<>();
-        for (ItemStack req : required) {
+
+        for (ItemStack req : required)
+        {
             int amountToBeRemoved = req.getAmount();
-            List<ItemStack> itemsInInv = Arrays.stream(user.getInventory().getContents()).filter(Objects::nonNull).filter(i -> i.getType().equals(req.getType())).collect(Collectors.toList());
-            for (ItemStack i : itemsInInv) {
-                if (amountToBeRemoved > 0) {
+            List<ItemStack> itemsInInv = Arrays.stream(user.getInventory().getContents()).
+                filter(Objects::nonNull).
+                filter(i -> i.getType().equals(req.getType())).
+                collect(Collectors.toList());
+
+            for (ItemStack i : itemsInInv)
+            {
+                if (amountToBeRemoved > 0)
+                {
                     // Remove either the full amount or the remaining amount
-                    if (i.getAmount() >= amountToBeRemoved) {
+                    if (i.getAmount() >= amountToBeRemoved)
+                    {
                         i.setAmount(i.getAmount() - amountToBeRemoved);
                         removed.merge(i.getType(), amountToBeRemoved, Integer::sum);
                         amountToBeRemoved = 0;
-                    } else {
+                    }
+                    else
+                    {
                         removed.merge(i.getType(), i.getAmount(), Integer::sum);
                         amountToBeRemoved -= i.getAmount();
                         i.setAmount(0);
-
                     }
                 }
             }
-            if (amountToBeRemoved > 0) {
-                addon.logError("Could not remove " + amountToBeRemoved + " of " + req.getType() + " from player's inventory!");
+
+            if (amountToBeRemoved > 0)
+            {
+                this.addon.logError("Could not remove " + amountToBeRemoved + " of " + req.getType() +
+                    " from player's inventory!");
             }
         }
+
         return removed;
     }
 
-    private ChallengeResult checkLevel() {
-        // Check if the level addon is installed or not
-        long level = addon.getAddonByName("Level")
-                .map(l -> ((Level)l).getIslandLevel(world, user.getUniqueId())).orElse(0L);
-        if (level >= challenge.getRequiredIslandLevel()) {
-            // process money removal
-            this.removeMoney();
-            return new ChallengeResult().setMeetsRequirements();
-        } else {
-            user.sendMessage("challenges.error.island-level", TextVariables.NUMBER, String.valueOf(challenge.getRequiredIslandLevel()));
-            return new ChallengeResult();
-        }
-    }
 
-    private ChallengeResult checkSurrounding() {
-        if (!addon.getIslands().userIsOnIsland(world, user)) {
-            // Player is not on island
-            user.sendMessage("challenges.error.not-on-island");
-            return new ChallengeResult();
-        }
-        // Check for items or entities in the area
-        ChallengeResult result = searchForEntities(challenge.getRequiredEntities(), challenge.getSearchRadius());
-        if (result.meetsRequirements && !challenge.getRequiredBlocks().isEmpty()) {
-            // Search for items only if entities found
-            result = searchForBlocks(challenge.getRequiredBlocks(), challenge.getSearchRadius());
-        }
+// ---------------------------------------------------------------------
+// Section: Island Challenge
+// ---------------------------------------------------------------------
 
-        if (result.meetsRequirements && this.challenge.isTakeMoney())
+
+    /**
+     * Checks if a island challenge can be completed or not
+     * It returns ChallengeResult.
+     */
+    private ChallengeResult checkSurrounding()
+    {
+        ChallengeResult result;
+
+        if (!this.addon.getIslands().userIsOnIsland(this.world, this.user))
         {
-            // process money removal
-            this.removeMoney();
+            // Player is not on island
+            this.user.sendMessage("challenges.error.not-on-island");
+            result = new ChallengeResult();
+        }
+        else
+        {
+            // Check for items or entities in the area
+
+            result = this.searchForEntities(this.challenge.getRequiredEntities(), this.challenge.getSearchRadius());
+
+            if (result.meetsRequirements && !this.challenge.getRequiredBlocks().isEmpty())
+            {
+                // Search for items only if entities found
+                result = this.searchForBlocks(this.challenge.getRequiredBlocks(), this.challenge.getSearchRadius());
+            }
+
+            if (result.meetsRequirements &&
+                this.challenge.isRemoveEntities() &&
+                !this.challenge.getRequiredEntities().isEmpty())
+            {
+                this.removeEntities();
+            }
+
+            if (result.meetsRequirements &&
+                this.challenge.isRemoveBlocks() &&
+                !this.challenge.getRequiredBlocks().isEmpty())
+            {
+                this.removeBlocks();
+            }
         }
 
         return result;
     }
 
-    private ChallengeResult searchForBlocks(Map<Material, Integer> map, int searchRadius) {
+
+    /**
+     * This method search required blocks in given radius from user position.
+     * @param map RequiredBlock Map.
+     * @param searchRadius Search distance
+     * @return ChallengeResult
+     */
+    private ChallengeResult searchForBlocks(Map<Material, Integer> map, int searchRadius)
+    {
         Map<Material, Integer> blocks = new EnumMap<>(map);
-        for (int x = -searchRadius; x <= searchRadius; x++) {
-            for (int y = -searchRadius; y <= searchRadius; y++) {
-                for (int z = -searchRadius; z <= searchRadius; z++) {
-                    Material mat = user.getWorld().getBlockAt(user.getLocation().add(new Vector(x,y,z))).getType();
+
+        for (int x = -searchRadius; x <= searchRadius; x++)
+        {
+            for (int y = -searchRadius; y <= searchRadius; y++)
+            {
+                for (int z = -searchRadius; z <= searchRadius; z++)
+                {
+                    Material mat = this.user.getWorld().getBlockAt(this.user.getLocation().add(new Vector(x, y, z))).getType();
                     // Remove one
                     blocks.computeIfPresent(mat, (b, amount) -> amount - 1);
                     // Remove any that have an amount of 0
@@ -391,92 +536,189 @@ public class TryToComplete {
                 }
             }
         }
-        if (blocks.isEmpty()) {
+
+        if (blocks.isEmpty())
+        {
             return new ChallengeResult().setMeetsRequirements();
         }
-        user.sendMessage("challenges.error.not-close-enough", "[number]", String.valueOf(searchRadius));
-        blocks.forEach((k,v) -> user.sendMessage("challenges.error.you-still-need",
-                "[amount]", String.valueOf(v),
-                "[item]", Util.prettifyText(k.toString())));
 
-        return new ChallengeResult();
-    }
+        this.user.sendMessage("challenges.error.not-close-enough", "[number]", String.valueOf(searchRadius));
 
-    private ChallengeResult searchForEntities(Map<EntityType, Integer> map, int searchRadius) {
-        Map<EntityType, Integer> entities = map.isEmpty() ? new EnumMap<>(EntityType.class) : new EnumMap<>(map);
-        user.getPlayer().getNearbyEntities(searchRadius, searchRadius, searchRadius).forEach(entity -> {
-            // Look through all the nearby Entities, filtering by type
-            entities.computeIfPresent(entity.getType(), (reqEntity, amount) -> amount - 1);
-            entities.entrySet().removeIf(e -> e.getValue() == 0);
-        });
-        if (entities.isEmpty()) {
-            return new ChallengeResult().setMeetsRequirements();
-        }
-        entities.forEach((reqEnt, amount) -> user.sendMessage("challenges.error.you-still-need",
-                "[amount]", String.valueOf(amount),
-                "[item]", Util.prettifyText(reqEnt.toString())));
+        blocks.forEach((k, v) -> user.sendMessage("challenges.error.you-still-need",
+            "[amount]", String.valueOf(v),
+            "[item]", Util.prettifyText(k.toString())));
+
         return new ChallengeResult();
     }
 
 
     /**
-     * Contains flags on completion of challenge
-     * @author tastybento
-     *
+     * This method search required entities in given radius from user position.
+     * @param map RequiredEntities Map.
+     * @param searchRadius Search distance
+     * @return ChallengeResult
      */
-    public class ChallengeResult {
+    private ChallengeResult searchForEntities(Map<EntityType, Integer> map, int searchRadius)
+    {
+        Map<EntityType, Integer> entities = map.isEmpty() ? new EnumMap<>(EntityType.class) : new EnumMap<>(map);
+
+        this.user.getPlayer().getNearbyEntities(searchRadius, searchRadius, searchRadius).forEach(entity -> {
+            // Look through all the nearby Entities, filtering by type
+            entities.computeIfPresent(entity.getType(), (reqEntity, amount) -> amount - 1);
+            entities.entrySet().removeIf(e -> e.getValue() == 0);
+        });
+
+        if (entities.isEmpty())
+        {
+            return new ChallengeResult().setMeetsRequirements();
+        }
+
+        entities.forEach((reqEnt, amount) -> this.user.sendMessage("challenges.error.you-still-need",
+            "[amount]", String.valueOf(amount),
+            "[item]", Util.prettifyText(reqEnt.toString())));
+
+        return new ChallengeResult();
+    }
+
+
+    /**
+     * This method removes required block and set air instead of it.
+     */
+    private void removeBlocks()
+    {
+        Map<Material, Integer> blocks = new EnumMap<>(this.challenge.getRequiredBlocks());
+        int searchRadius = this.challenge.getSearchRadius();
+
+        for (int x = -searchRadius; x <= searchRadius; x++)
+        {
+            for (int y = -searchRadius; y <= searchRadius; y++)
+            {
+                for (int z = -searchRadius; z <= searchRadius; z++)
+                {
+                    Block block = this.user.getWorld().getBlockAt(this.user.getLocation().add(new Vector(x, y, z)));
+
+                    if (blocks.containsKey(block.getType()))
+                    {
+                        blocks.computeIfPresent(block.getType(), (b, amount) -> amount - 1);
+                        blocks.entrySet().removeIf(en -> en.getValue() <= 0);
+
+                        block.setType(Material.AIR);
+                    }
+                }
+            }
+        }
+    }
+
+
+    /**
+     * This method removes required entities.
+     */
+    private void removeEntities()
+    {
+        Map<EntityType, Integer> entities = this.challenge.getRequiredEntities().isEmpty() ?
+            new EnumMap<>(EntityType.class) : new EnumMap<>(this.challenge.getRequiredEntities());
+
+        int searchRadius = this.challenge.getSearchRadius();
+
+        this.user.getPlayer().getNearbyEntities(searchRadius, searchRadius, searchRadius).forEach(entity -> {
+            // Look through all the nearby Entities, filtering by type
+
+            if (entities.containsKey(entity.getType()))
+            {
+                entities.computeIfPresent(entity.getType(), (reqEntity, amount) -> amount - 1);
+                entities.entrySet().removeIf(e -> e.getValue() == 0);
+                entity.remove();
+            }
+        });
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Other challenge
+// ---------------------------------------------------------------------
+
+
+    /**
+     * Checks if a other challenge can be completed or not
+     * It returns ChallengeResult.
+     */
+    private ChallengeResult checkOthers()
+    {
+        if (!this.addon.isEconomyProvided() ||
+            this.challenge.getRequiredMoney() <= 0 ||
+            !this.addon.getEconomyProvider().has(this.user, this.challenge.getRequiredMoney()))
+        {
+            this.user.sendMessage("challenges.not-enough-money",
+                "[money]",
+                Integer.toString(this.challenge.getRequiredMoney()));
+        }
+        else if (this.challenge.getRequiredExperience() <= 0 ||
+            this.user.getPlayer().getTotalExperience() < this.challenge.getRequiredExperience())
+        {
+            this.user.sendMessage("challenges.not-enough-exp",
+                "[xp]",
+                Integer.toString(this.challenge.getRequiredExperience()));
+        }
+        else if (!this.addon.isLevelProvided() ||
+            this.addon.getLevelAddon().getIslandLevel(this.world, this.user.getUniqueId()) < this.challenge.getRequiredIslandLevel())
+        {
+            this.user.sendMessage("challenges.error.island-level",
+                TextVariables.NUMBER,
+                String.valueOf(this.challenge.getRequiredIslandLevel()));
+        }
+        else
+        {
+            if (this.addon.isEconomyProvided() && this.challenge.isTakeMoney())
+            {
+                this.addon.getEconomyProvider().withdraw(this.user, this.challenge.getRequiredMoney());
+            }
+
+            if (this.challenge.isTakeExperience())
+            {
+                this.user.getPlayer().setTotalExperience(
+                    this.user.getPlayer().getTotalExperience() - this.challenge.getRequiredExperience());
+            }
+
+            return new ChallengeResult().setMeetsRequirements();
+        }
+
+        return new ChallengeResult();
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Private classes
+// ---------------------------------------------------------------------
+
+
+    /**
+     * Contains flags on completion of challenge
+     *
+     * @author tastybento
+     */
+    private class ChallengeResult
+    {
         private boolean meetsRequirements;
+
         private boolean repeat;
+
+
         /**
          */
-        public ChallengeResult setMeetsRequirements() {
+        ChallengeResult setMeetsRequirements()
+        {
             this.meetsRequirements = true;
             return this;
         }
+
+
         /**
          * @param repeat the repeat to set
          */
-        public ChallengeResult setRepeat(boolean repeat) {
+        ChallengeResult setRepeat(boolean repeat)
+        {
             this.repeat = repeat;
             return this;
         }
-
-    }
-
-    private void runCommands(List<String> commands) {
-        // Ignore commands with this perm
-        if (user.hasPermission(permPrefix + "command.challengeexempt") && !user.isOp()) {
-            return;
-        }
-        for (String cmd : commands) {
-            if (cmd.startsWith("[SELF]")) {
-                String alert = "Running command '" + cmd + "' as " + user.getName();
-                addon.getLogger().info(alert);
-                cmd = cmd.substring(6,cmd.length()).replace("[player]", user.getName()).trim();
-                try {
-                    if (!user.performCommand(cmd)) {
-                        showError(cmd);
-                    }
-                } catch (Exception e) {
-                    showError(cmd);
-                }
-
-                continue;
-            }
-            // Substitute in any references to player
-            try {
-                if (!addon.getServer().dispatchCommand(addon.getServer().getConsoleSender(), cmd.replace("[player]", user.getName()))) {
-                    showError(cmd);
-                }
-            } catch (Exception e) {
-                showError(cmd);
-            }
-        }
-    }
-
-    private void showError(final String cmd) {
-        addon.getLogger().severe("Problem executing command executed by player - skipping!");
-        addon.getLogger().severe(() -> "Command was : " + cmd);
-
     }
 }

--- a/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
@@ -302,9 +302,16 @@ public class TryToComplete
         ChallengeType type = this.challenge.getChallengeType();
 
         // Check the world
-        if (!this.challenge.getUniqueId().startsWith(Util.getWorld(this.world).getName()))
+        if (Util.getWorld(this.world) != Util.getWorld(this.user.getWorld()) ||
+            !this.challenge.getUniqueId().startsWith(Util.getWorld(this.world).getName()))
         {
             this.user.sendMessage("general.errors.wrong-world");
+            result = EMPTY_RESULT;
+        }
+        // Player is not on island
+        else if (!this.addon.getIslands().userIsOnIsland(this.user.getWorld(), this.user))
+        {
+            this.user.sendMessage("challenges.error.not-on-island");
             result = EMPTY_RESULT;
         }
         // Check if user has unlocked challenges level.
@@ -556,7 +563,7 @@ public class TryToComplete
     {
         ChallengeResult result;
 
-        if (!this.addon.getIslands().userIsOnIsland(this.world, this.user))
+        if (!this.addon.getIslands().userIsOnIsland(this.user.getWorld(), this.user))
         {
             // Player is not on island
             this.user.sendMessage("challenges.error.not-on-island");

--- a/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
@@ -97,7 +97,7 @@ public class TryToComplete {
                 vaultHook -> vaultHook.deposit(this.user, this.challenge.getRewardMoney()));
 
             // Give exp
-            user.getPlayer().giveExp(challenge.getRewardExp());
+            user.getPlayer().giveExp(challenge.getRewardExperience());
             // Run commands
             runCommands(challenge.getRewardCommands());
             user.sendMessage("challenges.you-completed", "[challenge]", challenge.getFriendlyName());
@@ -118,7 +118,7 @@ public class TryToComplete {
                 vaultHook -> vaultHook.deposit(this.user, this.challenge.getRepeatMoneyReward()));
 
             // Give exp
-            user.getPlayer().giveExp(challenge.getRepeatExpReward());
+            user.getPlayer().giveExp(challenge.getRepeatExperienceReward());
             // Run commands
             runCommands(challenge.getRepeatRewardCommands());
             user.sendMessage("challenges.you-repeated", "[challenge]", challenge.getFriendlyName());
@@ -162,7 +162,7 @@ public class TryToComplete {
                 vaultHook -> vaultHook.deposit(this.user, this.challenge.getRewardMoney()));
 
             // Give exp
-            user.getPlayer().giveExp(challenge.getRewardExp());
+            user.getPlayer().giveExp(challenge.getRewardExperience());
             // Run commands
             runCommands(challenge.getRewardCommands());
             user.sendMessage("challenges.you-completed", "[challenge]", challenge.getFriendlyName());
@@ -183,7 +183,7 @@ public class TryToComplete {
                 vaultHook -> vaultHook.deposit(this.user, this.challenge.getRepeatMoneyReward()));
 
             // Give exp
-            user.getPlayer().giveExp(challenge.getRepeatExpReward());
+            user.getPlayer().giveExp(challenge.getRepeatExperienceReward());
             // Run commands
             runCommands(challenge.getRepeatRewardCommands());
             user.sendMessage("challenges.you-repeated", "[challenge]", challenge.getFriendlyName());
@@ -199,7 +199,7 @@ public class TryToComplete {
      */
     private ChallengeResult checkIfCanCompleteChallenge() {
         // Check the world
-        if (!Util.getWorld(user.getWorld()).getName().equalsIgnoreCase(challenge.getWorld())) {
+        if (!challenge.getUniqueId().startsWith(Util.getWorld(world).getName())) {
             user.sendMessage("general.errors.wrong-world");
             return new ChallengeResult();
         }
@@ -215,7 +215,7 @@ public class TryToComplete {
         }
         // Check repeatability
         if (manager.isChallengeComplete(user, challenge.getUniqueId(), world)
-                && (!challenge.isRepeatable() || challenge.getChallengeType().equals(ChallengeType.LEVEL)
+                && (!challenge.isRepeatable() || challenge.getChallengeType().equals(ChallengeType.OTHER)
                         || challenge.getChallengeType().equals(ChallengeType.ISLAND))) {
             user.sendMessage("challenges.not-repeatable");
             return new ChallengeResult();
@@ -226,24 +226,24 @@ public class TryToComplete {
 
         if (vaultHook.isPresent())
         {
-            if (!vaultHook.get().has(this.user, this.challenge.getReqMoney()))
+            if (!vaultHook.get().has(this.user, this.challenge.getRequiredMoney()))
             {
-                this.user.sendMessage("challenges.not-enough-money", "[money]", Integer.toString(this.challenge.getReqMoney()));
+                this.user.sendMessage("challenges.not-enough-money", "[money]", Integer.toString(this.challenge.getRequiredMoney()));
                 return new ChallengeResult();
             }
         }
 
         // Check exp
-        if (this.user.getPlayer().getTotalExperience() < this.challenge.getReqExp())
+        if (this.user.getPlayer().getTotalExperience() < this.challenge.getRequiredExperience())
         {
-            this.user.sendMessage("challenges.not-enough-exp", "[xp]", Integer.toString(this.challenge.getReqExp()));
+            this.user.sendMessage("challenges.not-enough-exp", "[xp]", Integer.toString(this.challenge.getRequiredExperience()));
             return new ChallengeResult();
         }
 
         switch (challenge.getChallengeType()) {
         case INVENTORY:
             return checkInventory();
-        case LEVEL:
+        case OTHER:
             return checkLevel();
         case ISLAND:
             return checkSurrounding();
@@ -303,9 +303,9 @@ public class TryToComplete {
 
         if (vaultHook.isPresent() &&
             this.challenge.isTakeMoney() &&
-            this.challenge.getReqMoney() > 0)
+            this.challenge.getRequiredMoney() > 0)
         {
-            vaultHook.get().withdraw(this.user, this.challenge.getReqMoney());
+            vaultHook.get().withdraw(this.user, this.challenge.getRequiredMoney());
         }
     }
 
@@ -346,12 +346,12 @@ public class TryToComplete {
         // Check if the level addon is installed or not
         long level = addon.getAddonByName("Level")
                 .map(l -> ((Level)l).getIslandLevel(world, user.getUniqueId())).orElse(0L);
-        if (level >= challenge.getReqIslandlevel()) {
+        if (level >= challenge.getRequiredIslandLevel()) {
             // process money removal
             this.removeMoney();
             return new ChallengeResult().setMeetsRequirements();
         } else {
-            user.sendMessage("challenges.error.island-level", TextVariables.NUMBER, String.valueOf(challenge.getReqIslandlevel()));
+            user.sendMessage("challenges.error.island-level", TextVariables.NUMBER, String.valueOf(challenge.getRequiredIslandLevel()));
             return new ChallengeResult();
         }
     }
@@ -428,7 +428,6 @@ public class TryToComplete {
         private boolean meetsRequirements;
         private boolean repeat;
         /**
-         * @param meetsRequirements the meetsRequirements to set
          */
         public ChallengeResult setMeetsRequirements() {
             this.meetsRequirements = true;

--- a/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
@@ -329,8 +329,7 @@ public class TryToComplete
             result = EMPTY_RESULT;
         }
         // Check repeatability
-        else if (this.manager.isChallengeComplete(this.user, this.challenge)
-            && (!this.challenge.isRepeatable() || type.equals(ChallengeType.ISLAND)))
+        else if (!this.challenge.isRepeatable() && this.manager.isChallengeComplete(this.user, this.challenge))
         {
             this.user.sendMessage("challenges.not-repeatable");
             result = EMPTY_RESULT;

--- a/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
@@ -69,6 +69,10 @@ public class TryToComplete
      */
     private Challenge challenge;
 
+    /**
+     * Variable that will be used to avoid multiple empty object generation.
+     */
+    private final ChallengeResult EMPTY_RESULT = new ChallengeResult();
 
 // ---------------------------------------------------------------------
 // Section: Builder
@@ -249,57 +253,69 @@ public class TryToComplete
      */
     private ChallengeResult checkIfCanCompleteChallenge()
     {
+        ChallengeResult result;
+
         ChallengeType type = this.challenge.getChallengeType();
 
         // Check the world
         if (!this.challenge.getUniqueId().startsWith(Util.getWorld(this.world).getName()))
         {
             this.user.sendMessage("general.errors.wrong-world");
+            result = EMPTY_RESULT;
         }
         // Check if user has unlocked challenges level.
         else if (!this.challenge.getLevel().equals(ChallengesManager.FREE) &&
             !this.manager.isLevelUnlocked(this.user, this.world, this.manager.getLevel(this.challenge.getLevel())))
         {
             this.user.sendMessage("challenges.errors.challenge-level-not-available");
+            result = EMPTY_RESULT;
         }
         // Check max times
         else if (this.challenge.isRepeatable() && this.challenge.getMaxTimes() > 0 &&
             this.manager.getChallengeTimes(this.user, this.challenge) >= this.challenge.getMaxTimes())
         {
             this.user.sendMessage("challenges.not-repeatable");
+            result = EMPTY_RESULT;
         }
         // Check repeatability
         else if (this.manager.isChallengeComplete(this.user, this.challenge)
             && (!this.challenge.isRepeatable() || type.equals(ChallengeType.ISLAND)))
         {
             this.user.sendMessage("challenges.not-repeatable");
+            result = EMPTY_RESULT;
         }
         // Check environment
         else if (!this.challenge.getEnvironment().isEmpty() &&
             !this.challenge.getEnvironment().contains(this.user.getWorld().getEnvironment()))
         {
             this.user.sendMessage("challenges.errors.wrong-environment");
+            result = EMPTY_RESULT;
         }
         // Check permission
         else if (!this.checkPermissions())
         {
             this.user.sendMessage("general.errors.no-permission");
+            result = EMPTY_RESULT;
         }
         else if (type.equals(ChallengeType.INVENTORY))
         {
-            return this.checkInventory();
+            result = this.checkInventory();
         }
         else if (type.equals(ChallengeType.ISLAND))
         {
-            return this.checkSurrounding();
+            result = this.checkSurrounding();
         }
         else if (type.equals(ChallengeType.OTHER))
         {
-            return this.checkOthers();
+            result = this.checkOthers();
+        }
+        else
+        {
+            result = EMPTY_RESULT;
         }
 
         // Everything fails till this point.
-        return new ChallengeResult();
+        return result;
     }
 
 
@@ -407,7 +423,7 @@ public class TryToComplete
                         this.user.sendMessage("challenges.error.not-enough-items",
                             "[items]",
                             Util.prettifyText(req.getType().toString()));
-                        return new ChallengeResult();
+                        return EMPTY_RESULT;
                     }
                     break;
                 default:
@@ -417,7 +433,7 @@ public class TryToComplete
                         this.user.sendMessage("challenges.error.not-enough-items",
                             "[items]",
                             Util.prettifyText(req.getType().toString()));
-                        return new ChallengeResult();
+                        return EMPTY_RESULT;
                     }
             }
         }
@@ -500,7 +516,7 @@ public class TryToComplete
         {
             // Player is not on island
             this.user.sendMessage("challenges.error.not-on-island");
-            result = new ChallengeResult();
+            result = EMPTY_RESULT;
         }
         else
         {
@@ -569,7 +585,7 @@ public class TryToComplete
             "[amount]", String.valueOf(v),
             "[item]", Util.prettifyText(k.toString())));
 
-        return new ChallengeResult();
+        return EMPTY_RESULT;
     }
 
 
@@ -598,7 +614,7 @@ public class TryToComplete
             "[amount]", String.valueOf(amount),
             "[item]", Util.prettifyText(reqEnt.toString())));
 
-        return new ChallengeResult();
+        return EMPTY_RESULT;
     }
 
 
@@ -703,7 +719,7 @@ public class TryToComplete
             return new ChallengeResult().setMeetsRequirements();
         }
 
-        return new ChallengeResult();
+        return EMPTY_RESULT;
     }
 
 

--- a/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
@@ -23,8 +23,8 @@ import org.bukkit.util.Vector;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.ChallengesManager;
 import world.bentobox.challenges.commands.ChallengesCommand;
-import world.bentobox.challenges.database.object.Challenges;
-import world.bentobox.challenges.database.object.Challenges.ChallengeType;
+import world.bentobox.challenges.database.object.Challenge;
+import world.bentobox.challenges.database.object.Challenge.ChallengeType;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.hooks.VaultHook;
@@ -43,7 +43,7 @@ public class TryToComplete {
     private String permPrefix;
     private User user;
     private ChallengesManager manager;
-    private Challenges challenge;
+    private Challenge challenge;
     private String label;
 
     public TryToComplete label(String label) {
@@ -61,7 +61,7 @@ public class TryToComplete {
         return this;
     }
 
-    public TryToComplete challenge(Challenges challenge) {
+    public TryToComplete challenge(Challenge challenge) {
         this.challenge = challenge;
         return this;
     }
@@ -138,7 +138,7 @@ public class TryToComplete {
      * @param world
      * @param permPrefix
      */
-    public TryToComplete(ChallengesAddon addon, User user, ChallengesManager manager, Challenges challenge, World world, String permPrefix, String label) {
+    public TryToComplete(ChallengesAddon addon, User user, ChallengesManager manager, Challenge challenge, World world, String permPrefix, String label) {
         this.addon = addon;
         this.world = world;
         this.permPrefix = permPrefix;

--- a/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/panel/TryToComplete.java
@@ -278,7 +278,12 @@ public class TryToComplete
         else if (!this.challenge.getEnvironment().isEmpty() &&
             !this.challenge.getEnvironment().contains(this.user.getWorld().getEnvironment()))
         {
-            this.user.sendMessage("general.errors.wrong-environment");
+            this.user.sendMessage("challenges.errors.wrong-environment");
+        }
+        // Check permission
+        else if (!this.checkPermissions())
+        {
+            this.user.sendMessage("general.errors.no-permission");
         }
         else if (type.equals(ChallengeType.INVENTORY))
         {
@@ -297,6 +302,16 @@ public class TryToComplete
         return new ChallengeResult();
     }
 
+
+    /**
+     * This method checks if user has all required permissions.
+     * @return true if user has all required permissions, otherwise false.
+     */
+    private boolean checkPermissions()
+    {
+        return this.challenge.getRequiredPermissions().isEmpty() ||
+            this.challenge.getRequiredPermissions().stream().allMatch(s -> this.user.hasPermission(s));
+    }
 
     /**
      * This method runs all commands from command list.

--- a/src/main/java/world/bentobox/challenges/panel/admin/AdminGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/AdminGUI.java
@@ -206,7 +206,7 @@ public class AdminGUI extends CommonGUI
 								new EditChallengeGUI(this.addon,
 									this.world,
 									this.user,
-									this.addon.getChallengesManager().createChallenge(reply),
+									this.addon.getChallengesManager().createChallenge(newName),
 									this.topLabel,
 									this.permissionPrefix,
 									this).build();
@@ -242,7 +242,7 @@ public class AdminGUI extends CommonGUI
 								new EditLevelGUI(this.addon,
 									this.world,
 									this.user,
-									this.addon.getChallengesManager().createLevel(reply),
+									this.addon.getChallengesManager().createLevel(newName),
 									this.topLabel,
 									this.permissionPrefix,
 									this).build();

--- a/src/main/java/world/bentobox/challenges/panel/admin/AdminGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/AdminGUI.java
@@ -13,6 +13,7 @@ import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.panel.CommonGUI;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -89,28 +90,31 @@ public class AdminGUI extends CommonGUI
 		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(
 			this.user.getTranslation("challenges.admin.gui-title"));
 
+		GuiUtils.fillBorder(panelBuilder);
 
-		panelBuilder.item(1, this.createButton(Button.COMPLETE_USER_CHALLENGES));
-		panelBuilder.item(10, this.createButton(Button.RESET_USER_CHALLENGES));
+		panelBuilder.item(10, this.createButton(Button.COMPLETE_USER_CHALLENGES));
+		panelBuilder.item(19, this.createButton(Button.RESET_USER_CHALLENGES));
 
 		// Add Challenges
-		panelBuilder.item(3, this.createButton(Button.ADD_CHALLENGE));
-		panelBuilder.item(12, this.createButton(Button.ADD_LEVEL));
+		panelBuilder.item(12, this.createButton(Button.ADD_CHALLENGE));
+		panelBuilder.item(13, this.createButton(Button.ADD_LEVEL));
 
 		// Edit Challenges
-		panelBuilder.item(4, this.createButton(Button.EDIT_CHALLENGE));
-		panelBuilder.item(13, this.createButton(Button.EDIT_LEVEL));
+		panelBuilder.item(21, this.createButton(Button.EDIT_CHALLENGE));
+		panelBuilder.item(22, this.createButton(Button.EDIT_LEVEL));
 
 		// Remove Challenges
-		panelBuilder.item(5, this.createButton(Button.DELETE_CHALLENGE));
-		panelBuilder.item(14, this.createButton(Button.DELETE_LEVEL));
+		panelBuilder.item(30, this.createButton(Button.DELETE_CHALLENGE));
+		panelBuilder.item(31, this.createButton(Button.DELETE_LEVEL));
 
 
 		// Import Challenges
-		panelBuilder.item(7, this.createButton(Button.IMPORT_CHALLENGES));
+		panelBuilder.item(15, this.createButton(Button.IMPORT_CHALLENGES));
 
 		// Edit Addon Settings
-		panelBuilder.item(8, this.createButton(Button.EDIT_SETTINGS));
+		panelBuilder.item(16, this.createButton(Button.EDIT_SETTINGS));
+
+		panelBuilder.item(44, this.returnButton);
 
 		panelBuilder.build();
 	}

--- a/src/main/java/world/bentobox/challenges/panel/admin/AdminGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/AdminGUI.java
@@ -11,6 +11,7 @@ import net.wesjd.anvilgui.AnvilGUI;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.Util;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.utils.GuiUtils;
@@ -198,25 +199,25 @@ public class AdminGUI extends CommonGUI
 						this.user.getPlayer(),
 						"unique_id",
 						(player, reply) -> {
+							String newName = Util.getWorld(this.world).getName() + "_" + reply;
 
-						if (this.addon.getChallengesManager().validateChallengeUniqueID(this.world, reply))
-						{
-							new EditChallengeGUI(this.addon,
-								this.world,
-								this.user,
-								this.addon.getChallengesManager().createChallenge(reply),
-								this.topLabel,
-								this.permissionPrefix,
-								this).build();
-						}
-						else
-						{
-							this.user.sendMessage("challenges.errors.unique-id", "[id]", reply);
-							this.build();
-						}
+							if (this.addon.getChallengesManager().containsChallenge(newName))
+							{
+								new EditChallengeGUI(this.addon,
+									this.world,
+									this.user,
+									this.addon.getChallengesManager().createChallenge(reply),
+									this.topLabel,
+									this.permissionPrefix,
+									this).build();
+							}
+							else
+							{
+								this.user.sendMessage("challenges.errors.unique-id", "[id]", reply);
+							}
 
-						return reply;
-					});
+							return reply;
+						});
 
 					return true;
 				};
@@ -234,8 +235,9 @@ public class AdminGUI extends CommonGUI
 						this.user.getPlayer(),
 						"unique_id",
 						(player, reply) -> {
+							String newName = Util.getWorld(this.world).getName() + "_" + reply;
 
-							if (this.addon.getChallengesManager().validateLevelUniqueID(this.world, reply))
+							if (this.addon.getChallengesManager().containsLevel(newName))
 							{
 								new EditLevelGUI(this.addon,
 									this.world,
@@ -248,7 +250,6 @@ public class AdminGUI extends CommonGUI
 							else
 							{
 								this.user.sendMessage("challenges.errors.unique-id", "[id]", reply);
-								this.build();
 							}
 
 							return reply;

--- a/src/main/java/world/bentobox/challenges/panel/admin/AdminGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/AdminGUI.java
@@ -201,7 +201,7 @@ public class AdminGUI extends CommonGUI
 						(player, reply) -> {
 							String newName = Util.getWorld(this.world).getName() + "_" + reply;
 
-							if (this.addon.getChallengesManager().containsChallenge(newName))
+							if (!this.addon.getChallengesManager().containsChallenge(newName))
 							{
 								new EditChallengeGUI(this.addon,
 									this.world,
@@ -237,7 +237,7 @@ public class AdminGUI extends CommonGUI
 						(player, reply) -> {
 							String newName = Util.getWorld(this.world).getName() + "_" + reply;
 
-							if (this.addon.getChallengesManager().containsLevel(newName))
+							if (!this.addon.getChallengesManager().containsLevel(newName))
 							{
 								new EditLevelGUI(this.addon,
 									this.world,

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
@@ -525,8 +525,13 @@ public class EditChallengeGUI extends CommonGUI
 				description = values;
 				icon = new ItemStack(Material.CREEPER_HEAD);
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: Entities GUI
-					this.build();
+					new ManageEntitiesGUI(this.addon,
+						this.world,
+						this.user,
+						this.challenge.getRequiredEntities(),
+						this.topLabel,
+						this.permissionPrefix,
+						this).build();
 
 					return true;
 				};
@@ -569,8 +574,13 @@ public class EditChallengeGUI extends CommonGUI
 				description = values;
 				icon = new ItemStack(Material.STONE);
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: Block GUI
-					this.build();
+					new ManageBlocksGUI(this.addon,
+						this.world,
+						this.user,
+						this.challenge.getRequiredBlocks(),
+						this.topLabel,
+						this.permissionPrefix,
+						this).build();
 
 					return true;
 				};

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
@@ -280,7 +280,7 @@ public class EditChallengeGUI extends CommonGUI
 				return null;
 		}
 
-		return new PanelItem(icon, name, description, glow, clickHandler, false);
+		return new PanelItem(icon, name, GuiUtils.stringSplit(description), glow, clickHandler, false);
 	}
 
 
@@ -305,11 +305,12 @@ public class EditChallengeGUI extends CommonGUI
 
 				for (Challenge.ChallengeType type : Challenge.ChallengeType.values())
 				{
-					values.add((this.challenge.getChallengeType().equals(type) ? "§2" : "§c") +
+					values.add((this.challenge.getChallengeType().equals(type) ? "&2" : "&c") +
 						this.user.getTranslation("challenges.gui.admin.descriptions." + type.name().toLowerCase()));
 				}
 
-				name = this.user.getTranslation("challenges.gui.admin.buttons.type");
+				name = this.user.getTranslation("challenges.gui.admin.buttons.type",
+					"[value]", this.challenge.getChallengeType().name());
 				description = values;
 
 				if (this.challenge.getChallengeType().equals(Challenge.ChallengeType.ISLAND))
@@ -450,7 +451,7 @@ public class EditChallengeGUI extends CommonGUI
 
 				for (World.Environment environment : World.Environment.values())
 				{
-					values.add((this.challenge.getEnvironment().contains(environment.name()) ? "§2" : "§c") +
+					values.add((this.challenge.getEnvironment().contains(environment.name()) ? "&2" : "&c") +
 						this.user.getTranslation("challenges.gui.admin.descriptions." + environment.name().toLowerCase()));
 				}
 
@@ -1153,7 +1154,7 @@ public class EditChallengeGUI extends CommonGUI
 				return null;
 		}
 
-		return new PanelItem(icon, name, description, glow, clickHandler, false);
+		return new PanelItem(icon, name, GuiUtils.stringSplit(description), glow, clickHandler, false);
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
@@ -102,7 +102,7 @@ public class EditChallengeGUI extends CommonGUI
 				case ISLAND:
 					this.buildIslandRequirementsPanel(panelBuilder);
 					break;
-				case LEVEL:
+				case OTHER:
 					this.buildOtherRequirementsPanel(panelBuilder);
 					break;
 			}
@@ -320,7 +320,7 @@ public class EditChallengeGUI extends CommonGUI
 				{
 					icon = new ItemStack(Material.CHEST);
 				}
-				else if (this.challenge.getChallengeType().equals(Challenge.ChallengeType.LEVEL))
+				else if (this.challenge.getChallengeType().equals(Challenge.ChallengeType.OTHER))
 				{
 					icon = new ItemStack(Material.EXPERIENCE_BOTTLE);
 				}
@@ -427,13 +427,13 @@ public class EditChallengeGUI extends CommonGUI
 				description = Collections.singletonList(
 					this.user.getTranslation("challenges.gui.admin.descriptions.order",
 						"[value]",
-						Integer.toString(this.challenge.getSlot())));
+						Integer.toString(this.challenge.getOrder())));
 				icon = new ItemStack(Material.DROPPER);
 				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, this.challenge.getSlot(), -1, 54, (status, value) -> {
+					new NumberGUI(this.user, this.challenge.getOrder(), -1, 54, (status, value) -> {
 						if (status)
 						{
-							this.challenge.setSlot(value);
+							this.challenge.setOrder(value);
 						}
 
 						this.build();
@@ -640,13 +640,13 @@ public class EditChallengeGUI extends CommonGUI
 			case REQUIRED_PERMISSIONS:
 			{
 				name = this.user.getTranslation("challenges.gui.admin.buttons.permissions");
-				description = new ArrayList<>(this.challenge.getReqPerms());
+				description = new ArrayList<>(this.challenge.getRequiredPermissions());
 				icon = new ItemStack(Material.REDSTONE_LAMP);
 				clickHandler = (panel, user, clickType, slot) -> {
-					new StringListGUI(this.user, this.challenge.getReqPerms(), (status, value) -> {
+					new StringListGUI(this.user, this.challenge.getRequiredPermissions(), (status, value) -> {
 						if (status)
 						{
-							this.challenge.setReqPerms(new HashSet<>(value));
+							this.challenge.setRequiredPermissions(new HashSet<>(value));
 						}
 
 						this.build();
@@ -713,13 +713,13 @@ public class EditChallengeGUI extends CommonGUI
 				description = Collections.singletonList(
 					this.user.getTranslation("challenges.gui.admin.descriptions.required-exp",
 						"[value]",
-						Integer.toString(this.challenge.getMaxTimes())));
+						Integer.toString(this.challenge.getRequiredExperience())));
 				icon = new ItemStack(Material.EXPERIENCE_BOTTLE);
 				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, this.challenge.getReqExp(), 0, (status, value) -> {
+					new NumberGUI(this.user, this.challenge.getRequiredExperience(), 0, (status, value) -> {
 						if (status)
 						{
-							this.challenge.setReqExp(value);
+							this.challenge.setRequiredExperience(value);
 						}
 
 						this.build();
@@ -758,13 +758,13 @@ public class EditChallengeGUI extends CommonGUI
 				description = Collections.singletonList(
 					this.user.getTranslation("challenges.gui.admin.descriptions.required-level",
 						"[value]",
-						Long.toString(this.challenge.getReqIslandlevel())));
+						Long.toString(this.challenge.getRequiredIslandLevel())));
 				icon = new ItemStack(Material.BEACON);
 				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, (int) this.challenge.getReqIslandlevel(), (status, value) -> {
+					new NumberGUI(this.user, (int) this.challenge.getRequiredIslandLevel(), (status, value) -> {
 						if (status)
 						{
-							this.challenge.setReqIslandlevel(value);
+							this.challenge.setRequiredIslandLevel(value);
 						}
 
 						this.build();
@@ -781,13 +781,13 @@ public class EditChallengeGUI extends CommonGUI
 				description = Collections.singletonList(
 					this.user.getTranslation("challenges.gui.admin.descriptions.required-money",
 						"[value]",
-						Integer.toString(this.challenge.getReqMoney())));
+						Integer.toString(this.challenge.getRequiredMoney())));
 				icon = new ItemStack(Material.GOLD_INGOT);
 				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, this.challenge.getReqMoney(), 0, (status, value) -> {
+					new NumberGUI(this.user, this.challenge.getRequiredMoney(), 0, (status, value) -> {
 						if (status)
 						{
-							this.challenge.setReqMoney(value);
+							this.challenge.setRequiredMoney(value);
 						}
 
 						this.build();
@@ -874,13 +874,13 @@ public class EditChallengeGUI extends CommonGUI
 				description = Collections.singletonList(
 					this.user.getTranslation("challenges.gui.admin.descriptions.reward-exp",
 						"[value]",
-						Integer.toString(this.challenge.getRewardExp())));
+						Integer.toString(this.challenge.getRewardExperience())));
 				icon = new ItemStack(Material.EXPERIENCE_BOTTLE);
 				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, this.challenge.getReqExp(), 0, (status, value) -> {
+					new NumberGUI(this.user, this.challenge.getRewardExperience(), 0, (status, value) -> {
 						if (status)
 						{
-							this.challenge.setRewardExp(value);
+							this.challenge.setRewardExperience(value);
 						}
 
 						this.build();
@@ -1035,13 +1035,13 @@ public class EditChallengeGUI extends CommonGUI
 				description = Collections.singletonList(
 					this.user.getTranslation("challenges.gui.admin.descriptions.repeat-reward-exp",
 						"[value]",
-						Integer.toString(this.challenge.getRepeatExpReward())));
+						Integer.toString(this.challenge.getRepeatExperienceReward())));
 				icon = new ItemStack(Material.GLASS_BOTTLE);
 				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, this.challenge.getRepeatExpReward(), 0, (status, value) -> {
+					new NumberGUI(this.user, this.challenge.getRepeatExperienceReward(), 0, (status, value) -> {
 						if (status)
 						{
-							this.challenge.setRepeatExpReward(value);
+							this.challenge.setRepeatExperienceReward(value);
 						}
 
 						this.build();

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
@@ -451,7 +451,7 @@ public class EditChallengeGUI extends CommonGUI
 				for (World.Environment environment : World.Environment.values())
 				{
 					values.add((this.challenge.getEnvironment().contains(environment.name()) ? "§2" : "§c") +
-						this.user.getTranslation("challenges.gui.admin.descriptions." + environment.name()));
+						this.user.getTranslation("challenges.gui.admin.descriptions." + environment.name().toLowerCase()));
 				}
 
 				name = this.user.getTranslation("challenges.gui.admin.buttons.environment");

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
@@ -25,6 +25,9 @@ import world.bentobox.challenges.utils.GuiUtils;
 /**
  * This class contains all necessary methods that creates GUI and allow to edit challenges
  * properties.
+ *
+ * TODO: In current class set that MONEY are availabe only if ECONOMY exist.
+ * TODO: In current class set that ISLAND LEVEL are availabe only if LEVEL ADDON exist.
  */
 public class EditChallengeGUI extends CommonGUI
 {

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
@@ -11,7 +11,6 @@ import net.wesjd.anvilgui.AnvilGUI;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.user.User;
-import world.bentobox.bentobox.util.ItemParser;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.challenges.panel.CommonGUI;
@@ -25,9 +24,6 @@ import world.bentobox.challenges.utils.GuiUtils;
 /**
  * This class contains all necessary methods that creates GUI and allow to edit challenges
  * properties.
- *
- * TODO: In current class set that MONEY are availabe only if ECONOMY exist.
- * TODO: In current class set that ISLAND LEVEL are availabe only if LEVEL ADDON exist.
  */
 public class EditChallengeGUI extends CommonGUI
 {
@@ -762,19 +758,29 @@ public class EditChallengeGUI extends CommonGUI
 					this.user.getTranslation("challenges.gui.admin.descriptions.required-level",
 						"[value]",
 						Long.toString(this.challenge.getRequiredIslandLevel())));
-				icon = new ItemStack(Material.BEACON);
-				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, (int) this.challenge.getRequiredIslandLevel(), (status, value) -> {
-						if (status)
-						{
-							this.challenge.setRequiredIslandLevel(value);
-						}
 
-						this.build();
-					});
+				if (this.addon.isLevelProvided())
+				{
+					icon = new ItemStack(Material.BEACON);
+					clickHandler = (panel, user, clickType, slot) -> {
+						new NumberGUI(this.user, (int) this.challenge.getRequiredIslandLevel(), (status, value) -> {
+							if (status)
+							{
+								this.challenge.setRequiredIslandLevel(value);
+							}
 
-					return true;
-				};
+							this.build();
+						});
+
+						return true;
+					};
+				}
+				else
+				{
+					icon = new ItemStack(Material.BARRIER);
+					clickHandler = null;
+				}
+
 				glow = false;
 				break;
 			}
@@ -785,18 +791,28 @@ public class EditChallengeGUI extends CommonGUI
 					this.user.getTranslation("challenges.gui.admin.descriptions.required-money",
 						"[value]",
 						Integer.toString(this.challenge.getRequiredMoney())));
-				icon = new ItemStack(Material.GOLD_INGOT);
-				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, this.challenge.getRequiredMoney(), 0, (status, value) -> {
-						if (status)
-						{
-							this.challenge.setRequiredMoney(value);
-						}
 
-						this.build();
-					});
-					return true;
-				};
+				if (this.addon.isEconomyProvided())
+				{
+					icon = new ItemStack(Material.GOLD_INGOT);
+					clickHandler = (panel, user, clickType, slot) -> {
+						new NumberGUI(this.user, this.challenge.getRequiredMoney(), 0, (status, value) -> {
+							if (status)
+							{
+								this.challenge.setRequiredMoney(value);
+							}
+
+							this.build();
+						});
+						return true;
+					};
+				}
+				else
+				{
+					icon = new ItemStack(Material.BARRIER);
+					clickHandler = null;
+				}
+
 				glow = false;
 				break;
 			}
@@ -806,20 +822,31 @@ public class EditChallengeGUI extends CommonGUI
 
 				if (this.challenge.isTakeMoney())
 				{
-					description = Collections.singletonList(this.user.getTranslation("challenges.gui.admin.descriptions.enabled"));
+					description = Collections.singletonList(this.user
+						.getTranslation("challenges.gui.admin.descriptions.enabled"));
 				}
 				else
 				{
-					description = Collections.singletonList(this.user.getTranslation("challenges.gui.admin.descriptions.disabled"));
+					description = Collections.singletonList(this.user
+						.getTranslation("challenges.gui.admin.descriptions.disabled"));
 				}
 
-				icon = new ItemStack(Material.LEVER);
-				clickHandler = (panel, user, clickType, slot) -> {
-					this.challenge.setTakeMoney(!this.challenge.isTakeMoney());
+				if (this.addon.isEconomyProvided())
+				{
+					icon = new ItemStack(Material.LEVER);
+					clickHandler = (panel, user, clickType, slot) -> {
+						this.challenge.setTakeMoney(!this.challenge.isTakeMoney());
 
-					this.build();
-					return true;
-				};
+						this.build();
+						return true;
+					};
+				}
+				else
+				{
+					icon = new ItemStack(Material.BARRIER);
+					clickHandler = null;
+				}
+
 				glow = this.challenge.isTakeMoney();
 				break;
 			}
@@ -901,19 +928,29 @@ public class EditChallengeGUI extends CommonGUI
 					this.user.getTranslation("challenges.gui.admin.descriptions.reward-money",
 						"[value]",
 						Integer.toString(this.challenge.getRewardMoney())));
-				icon = new ItemStack(Material.GOLD_INGOT);
-				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, this.challenge.getRewardMoney(), 0, (status, value) -> {
-						if (status)
-						{
-							this.challenge.setRewardMoney(value);
-						}
 
-						this.build();
-					});
+				if (this.addon.isEconomyProvided())
+				{
+					icon = new ItemStack(Material.GOLD_INGOT);
+					clickHandler = (panel, user, clickType, slot) -> {
+						new NumberGUI(this.user, this.challenge.getRewardMoney(), 0, (status, value) -> {
+							if (status)
+							{
+								this.challenge.setRewardMoney(value);
+							}
 
-					return true;
-				};
+							this.build();
+						});
+
+						return true;
+					};
+				}
+				else
+				{
+					icon = new ItemStack(Material.BARRIER);
+					clickHandler = null;
+				}
+
 				glow = false;
 				break;
 			}
@@ -1062,19 +1099,32 @@ public class EditChallengeGUI extends CommonGUI
 					this.user.getTranslation("challenges.gui.admin.descriptions.repeat-reward-money",
 						"[value]",
 						Integer.toString(this.challenge.getRepeatMoneyReward())));
-				icon = new ItemStack(Material.GOLD_NUGGET);
-				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, this.challenge.getRepeatMoneyReward(), 0, (status, value) -> {
-						if (status)
-						{
-							this.challenge.setRepeatMoneyReward(value);
-						}
 
-						this.build();
-					});
+				if (this.addon.isEconomyProvided())
+				{
+					icon = new ItemStack(Material.GOLD_NUGGET);
+					clickHandler = (panel, user, clickType, slot) -> {
+						new NumberGUI(this.user,
+							this.challenge.getRepeatMoneyReward(),
+							0,
+							(status, value) -> {
+								if (status)
+								{
+									this.challenge.setRepeatMoneyReward(value);
+								}
 
-					return true;
-				};
+								this.build();
+							});
+
+						return true;
+					};
+				}
+				else
+				{
+					icon = new ItemStack(Material.BARRIER);
+					clickHandler = null;
+				}
+
 				glow = false;
 				break;
 			}

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
@@ -5,17 +5,19 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
-
 import java.util.*;
 
+import net.wesjd.anvilgui.AnvilGUI;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.ItemParser;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.database.object.Challenges;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.util.ItemSwitchGUI;
 import world.bentobox.challenges.panel.util.NumberGUI;
+import world.bentobox.challenges.panel.util.SelectEnvironmentGUI;
 import world.bentobox.challenges.panel.util.StringListGUI;
 
 
@@ -371,8 +373,24 @@ public class EditChallengeGUI extends CommonGUI
 				description = Collections.emptyList();
 				icon = this.challenge.getIcon();
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: how to change icon.
-					this.build();
+					new AnvilGUI(this.addon.getPlugin(),
+						this.user.getPlayer(),
+						this.challenge.getIcon().getType().name(),
+						(player, reply) -> {
+							ItemStack newIcon = ItemParser.parse(reply);
+
+							if (newIcon != null)
+							{
+								this.challenge.setIcon(newIcon);
+							}
+							else
+							{
+								this.user.sendMessage("challenges.errors.wrong-icon", "[value]", reply);
+							}
+
+							this.build();
+							return reply;
+						});
 
 					return true;
 				};
@@ -436,8 +454,15 @@ public class EditChallengeGUI extends CommonGUI
 				description = values;
 				icon = new ItemStack(Material.DROPPER);
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: Create Enviroment Change GUI
-					this.build();
+					new SelectEnvironmentGUI(this.user, this.challenge.getEnvironment(), (status, value) -> {
+						if (status)
+						{
+							this.challenge.setEnvironment(value);
+						}
+
+						this.build();
+					});
+
 					return true;
 				};
 				glow = false;
@@ -472,8 +497,14 @@ public class EditChallengeGUI extends CommonGUI
 				description = Collections.emptyList();
 				icon = new ItemStack(Material.DROPPER);
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: Implement AnvilGUI.
-					this.build();
+					new AnvilGUI(this.addon.getPlugin(),
+						this.user.getPlayer(),
+						this.challenge.getFriendlyName(),
+						(player, reply) -> {
+							this.challenge.setFriendlyName(reply);
+							this.build();
+							return reply;
+						});
 
 					return true;
 				};
@@ -782,7 +813,14 @@ public class EditChallengeGUI extends CommonGUI
 				description = Collections.singletonList(this.challenge.getRewardText());
 				icon = new ItemStack(Material.WRITTEN_BOOK);
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: Implement AnvilGUI
+					new AnvilGUI(this.addon.getPlugin(),
+						this.user.getPlayer(),
+						this.challenge.getRewardText(),
+						(player, reply) -> {
+							this.challenge.setRewardText(reply);
+							this.build();
+							return reply;
+						});
 
 					return true;
 				};
@@ -936,8 +974,14 @@ public class EditChallengeGUI extends CommonGUI
 				description = Collections.singletonList(this.challenge.getRepeatRewardText());
 				icon = new ItemStack(Material.WRITTEN_BOOK);
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: Implement AnvilGUI
-
+					new AnvilGUI(this.addon.getPlugin(),
+						this.user.getPlayer(),
+						this.challenge.getRepeatRewardText(),
+						(player, reply) -> {
+							this.challenge.setRepeatRewardText(reply);
+							this.build();
+							return reply;
+						});
 
 					return true;
 				};

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
@@ -13,7 +13,7 @@ import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.util.ItemParser;
 import world.bentobox.challenges.ChallengesAddon;
-import world.bentobox.challenges.database.object.Challenges;
+import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.util.ItemSwitchGUI;
 import world.bentobox.challenges.panel.util.NumberGUI;
@@ -40,7 +40,7 @@ public class EditChallengeGUI extends CommonGUI
 	public EditChallengeGUI(ChallengesAddon addon,
 		World world,
 		User user,
-		Challenges challenge,
+		Challenge challenge,
 		String topLabel,
 		String permissionPrefix)
 	{
@@ -55,7 +55,7 @@ public class EditChallengeGUI extends CommonGUI
 	public EditChallengeGUI(ChallengesAddon addon,
 		World world,
 		User user,
-		Challenges challenge,
+		Challenge challenge,
 		String topLabel,
 		String permissionPrefix,
 		CommonGUI parentGUI)
@@ -301,9 +301,9 @@ public class EditChallengeGUI extends CommonGUI
 		{
 			case TYPE:
 			{
-				List<String> values = new ArrayList<>(Challenges.ChallengeType.values().length);
+				List<String> values = new ArrayList<>(Challenge.ChallengeType.values().length);
 
-				for (Challenges.ChallengeType type : Challenges.ChallengeType.values())
+				for (Challenge.ChallengeType type : Challenge.ChallengeType.values())
 				{
 					values.add((this.challenge.getChallengeType().equals(type) ? "§2" : "§c") +
 						this.user.getTranslation("challenges.gui.admin.descriptions." + type.name().toLowerCase()));
@@ -312,15 +312,15 @@ public class EditChallengeGUI extends CommonGUI
 				name = this.user.getTranslation("challenges.gui.admin.buttons.type");
 				description = values;
 
-				if (this.challenge.getChallengeType().equals(Challenges.ChallengeType.ISLAND))
+				if (this.challenge.getChallengeType().equals(Challenge.ChallengeType.ISLAND))
 				{
 					icon = new ItemStack(Material.GRASS_BLOCK);
 				}
-				else if (this.challenge.getChallengeType().equals(Challenges.ChallengeType.INVENTORY))
+				else if (this.challenge.getChallengeType().equals(Challenge.ChallengeType.INVENTORY))
 				{
 					icon = new ItemStack(Material.CHEST);
 				}
-				else if (this.challenge.getChallengeType().equals(Challenges.ChallengeType.LEVEL))
+				else if (this.challenge.getChallengeType().equals(Challenge.ChallengeType.LEVEL))
 				{
 					icon = new ItemStack(Material.EXPERIENCE_BOTTLE);
 				}
@@ -1108,9 +1108,9 @@ public class EditChallengeGUI extends CommonGUI
 	 * @param type Given challenge type.
 	 * @return Next Challenge Type.
 	 */
-	private Challenges.ChallengeType getNextType(Challenges.ChallengeType type)
+	private Challenge.ChallengeType getNextType(Challenge.ChallengeType type)
 	{
-		Challenges.ChallengeType[] values = Challenges.ChallengeType.values();
+		Challenge.ChallengeType[] values = Challenge.ChallengeType.values();
 
 		for (int i = 0; i < values.length; i++)
 		{
@@ -1136,9 +1136,9 @@ public class EditChallengeGUI extends CommonGUI
 	 * @param type Given challenge type.
 	 * @return Previous Challenge Type.
 	 */
-	private Challenges.ChallengeType getPreviousType(Challenges.ChallengeType type)
+	private Challenge.ChallengeType getPreviousType(Challenge.ChallengeType type)
 	{
-		Challenges.ChallengeType[] values = Challenges.ChallengeType.values();
+		Challenge.ChallengeType[] values = Challenge.ChallengeType.values();
 
 		for (int i = 0; i < values.length; i++)
 		{
@@ -1228,7 +1228,7 @@ public class EditChallengeGUI extends CommonGUI
 	/**
 	 * Variable holds challenge thats needs editing.
 	 */
-	private Challenges challenge;
+	private Challenge challenge;
 
 	/**
 	 * Variable holds current active menu.

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
@@ -19,6 +19,7 @@ import world.bentobox.challenges.panel.util.ItemSwitchGUI;
 import world.bentobox.challenges.panel.util.NumberGUI;
 import world.bentobox.challenges.panel.util.SelectEnvironmentGUI;
 import world.bentobox.challenges.panel.util.StringListGUI;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -81,6 +82,8 @@ public class EditChallengeGUI extends CommonGUI
 		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(
 			this.user.getTranslation("challenges.gui.admin.edit-challenge-title"));
 
+		GuiUtils.fillBorder(panelBuilder);
+
 		panelBuilder.item(2, this.createMenuButton(MenuType.PROPERTIES));
 		panelBuilder.item(4, this.createMenuButton(MenuType.REQUIREMENTS));
 		panelBuilder.item(6, this.createMenuButton(MenuType.REWARDS));
@@ -109,7 +112,7 @@ public class EditChallengeGUI extends CommonGUI
 			this.buildRewardsPanel(panelBuilder);
 		}
 
-		panelBuilder.item(53, this.returnButton);
+		panelBuilder.item(44, this.returnButton);
 
 		panelBuilder.build();
 	}
@@ -140,14 +143,14 @@ public class EditChallengeGUI extends CommonGUI
 	 */
 	private void buildIslandRequirementsPanel(PanelBuilder panelBuilder)
 	{
-		panelBuilder.item(10, this.createButton(Button.REQUIRED_ENTITIES));
-		panelBuilder.item(11, this.createButton(Button.REMOVE_ENTITIES));
+		panelBuilder.item(19, this.createButton(Button.REQUIRED_ENTITIES));
+		panelBuilder.item(28, this.createButton(Button.REMOVE_ENTITIES));
 
-		panelBuilder.item(15, this.createButton(Button.REQUIRED_BLOCKS));
-		panelBuilder.item(16, this.createButton(Button.REMOVE_BLOCKS));
+		panelBuilder.item(21, this.createButton(Button.REQUIRED_BLOCKS));
+		panelBuilder.item(29, this.createButton(Button.REMOVE_BLOCKS));
 
-		panelBuilder.item(19, this.createButton(Button.SEARCH_RADIUS));
-		panelBuilder.item(28, this.createButton(Button.REQUIRED_PERMISSIONS));
+		panelBuilder.item(23, this.createButton(Button.SEARCH_RADIUS));
+		panelBuilder.item(25, this.createButton(Button.REQUIRED_PERMISSIONS));
 	}
 
 
@@ -158,9 +161,9 @@ public class EditChallengeGUI extends CommonGUI
 	private void buildInventoryRequirementsPanel(PanelBuilder panelBuilder)
 	{
 		panelBuilder.item(10, this.createButton(Button.REQUIRED_ITEMS));
-		panelBuilder.item(11, this.createButton(Button.REMOVE_ITEMS));
+		panelBuilder.item(19, this.createButton(Button.REMOVE_ITEMS));
 
-		panelBuilder.item(28, this.createButton(Button.REQUIRED_PERMISSIONS));
+		panelBuilder.item(25, this.createButton(Button.REQUIRED_PERMISSIONS));
 	}
 
 
@@ -171,14 +174,14 @@ public class EditChallengeGUI extends CommonGUI
 	private void buildOtherRequirementsPanel(PanelBuilder panelBuilder)
 	{
 		panelBuilder.item(10, this.createButton(Button.REQUIRED_EXPERIENCE));
-		panelBuilder.item(11, this.createButton(Button.REMOVE_EXPERIENCE));
+		panelBuilder.item(19, this.createButton(Button.REMOVE_EXPERIENCE));
 
-		panelBuilder.item(13, this.createButton(Button.REQUIRED_LEVEL));
+		panelBuilder.item(12, this.createButton(Button.REQUIRED_MONEY));
+		panelBuilder.item(21, this.createButton(Button.REMOVE_MONEY));
 
-		panelBuilder.item(15, this.createButton(Button.REQUIRED_MONEY));
-		panelBuilder.item(16, this.createButton(Button.REMOVE_MONEY));
+		panelBuilder.item(23, this.createButton(Button.REQUIRED_LEVEL));
 
-		panelBuilder.item(28, this.createButton(Button.REQUIRED_PERMISSIONS));
+		panelBuilder.item(25, this.createButton(Button.REQUIRED_PERMISSIONS));
 	}
 
 
@@ -188,12 +191,12 @@ public class EditChallengeGUI extends CommonGUI
 	 */
 	private void buildRewardsPanel(PanelBuilder panelBuilder)
 	{
-		panelBuilder.item(11, this.createButton(Button.REWARD_TEXT));
-		panelBuilder.item(20, this.createButton(Button.REWARD_ITEM));
-		panelBuilder.item(29, this.createButton(Button.REWARD_EXPERIENCE));
-		panelBuilder.item(38, this.createButton(Button.REWARD_MONEY));
-		panelBuilder.item(47, this.createButton(Button.REWARD_COMMANDS));
+		panelBuilder.item(10, this.createButton(Button.REWARD_TEXT));
+		panelBuilder.item(19, this.createButton(Button.REWARD_COMMANDS));
 
+		panelBuilder.item(11, this.createButton(Button.REWARD_ITEM));
+		panelBuilder.item(20, this.createButton(Button.REWARD_EXPERIENCE));
+		panelBuilder.item(29, this.createButton(Button.REWARD_MONEY));
 
 		panelBuilder.item(22, this.createButton(Button.REPEATABLE));
 
@@ -202,10 +205,11 @@ public class EditChallengeGUI extends CommonGUI
 			panelBuilder.item(31, this.createButton(Button.REPEAT_COUNT));
 
 			panelBuilder.item(15, this.createButton(Button.REPEAT_REWARD_TEXT));
-			panelBuilder.item(24, this.createButton(Button.REPEAT_REWARD_ITEM));
-			panelBuilder.item(33, this.createButton(Button.REPEAT_REWARD_EXPERIENCE));
-			panelBuilder.item(42, this.createButton(Button.REPEAT_REWARD_MONEY));
-			panelBuilder.item(51, this.createButton(Button.REPEAT_REWARD_COMMANDS));
+			panelBuilder.item(24, this.createButton(Button.REPEAT_REWARD_COMMANDS));
+
+			panelBuilder.item(16, this.createButton(Button.REPEAT_REWARD_ITEM));
+			panelBuilder.item(25, this.createButton(Button.REPEAT_REWARD_EXPERIENCE));
+			panelBuilder.item(34, this.createButton(Button.REPEAT_REWARD_MONEY));
 		}
 	}
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
@@ -24,6 +24,7 @@ import world.bentobox.challenges.utils.GuiUtils;
 /**
  * This class contains all necessary methods that creates GUI and allow to edit challenges
  * properties.
+ * TODO: ISLAND is not repeatable.
  */
 public class EditChallengeGUI extends CommonGUI
 {

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
@@ -147,7 +147,7 @@ public class EditChallengeGUI extends CommonGUI
 		panelBuilder.item(28, this.createButton(Button.REMOVE_ENTITIES));
 
 		panelBuilder.item(21, this.createButton(Button.REQUIRED_BLOCKS));
-		panelBuilder.item(29, this.createButton(Button.REMOVE_BLOCKS));
+		panelBuilder.item(30, this.createButton(Button.REMOVE_BLOCKS));
 
 		panelBuilder.item(23, this.createButton(Button.SEARCH_RADIUS));
 		panelBuilder.item(25, this.createButton(Button.REQUIRED_PERMISSIONS));

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengeGUI.java
@@ -384,18 +384,18 @@ public class EditChallengeGUI extends CommonGUI
 						this.user.getPlayer(),
 						this.challenge.getIcon().getType().name(),
 						(player, reply) -> {
-							ItemStack newIcon = ItemParser.parse(reply);
+							Material material = Material.getMaterial(reply);
 
-							if (newIcon != null)
+							if (material != null)
 							{
-								this.challenge.setIcon(newIcon);
+								this.challenge.setIcon(new ItemStack(material));
+								this.build();
 							}
 							else
 							{
 								this.user.sendMessage("challenges.errors.wrong-icon", "[value]", reply);
 							}
 
-							this.build();
 							return reply;
 						});
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
@@ -23,6 +23,7 @@ import world.bentobox.challenges.panel.util.ItemSwitchGUI;
 import world.bentobox.challenges.panel.util.NumberGUI;
 import world.bentobox.challenges.panel.util.SelectChallengeGUI;
 import world.bentobox.challenges.panel.util.StringListGUI;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -82,6 +83,8 @@ public class EditLevelGUI extends CommonGUI
 		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(
 			this.user.getTranslation("challenges.gui.admin.edit-level-title"));
 
+		GuiUtils.fillBorder(panelBuilder);
+
 		panelBuilder.item(2, this.createMenuButton(MenuType.PROPERTIES));
 		panelBuilder.item(4, this.createMenuButton(MenuType.REWARDS));
 		panelBuilder.item(6, this.createMenuButton(MenuType.CHALLENGES));
@@ -99,7 +102,7 @@ public class EditLevelGUI extends CommonGUI
 			this.buildRewardsPanel(panelBuilder);
 		}
 
-		panelBuilder.item(53, this.returnButton);
+		panelBuilder.item(44, this.returnButton);
 
 		panelBuilder.build();
 	}
@@ -127,11 +130,12 @@ public class EditLevelGUI extends CommonGUI
 	 */
 	private void buildRewardsPanel(PanelBuilder panelBuilder)
 	{
-		panelBuilder.item(11, this.createButton(Button.REWARD_DESCRIPTION));
-		panelBuilder.item(20, this.createButton(Button.REWARD_ITEM));
-		panelBuilder.item(29, this.createButton(Button.REWARD_EXPERIENCE));
-		panelBuilder.item(38, this.createButton(Button.REWARD_MONEY));
-		panelBuilder.item(47, this.createButton(Button.REWARD_COMMANDS));
+		panelBuilder.item(12, this.createButton(Button.REWARD_DESCRIPTION));
+		panelBuilder.item(21, this.createButton(Button.REWARD_COMMANDS));
+
+		panelBuilder.item(13, this.createButton(Button.REWARD_ITEM));
+		panelBuilder.item(22, this.createButton(Button.REWARD_EXPERIENCE));
+		panelBuilder.item(31, this.createButton(Button.REWARD_MONEY));
 	}
 
 
@@ -141,39 +145,45 @@ public class EditLevelGUI extends CommonGUI
 	 */
 	private void buildChallengesPanel(PanelBuilder panelBuilder)
 	{
-		List<Challenges> challenges = this.addon.getChallengesManager().getChallenges(this.challengeLevel);
+		List<Challenges> challengeList = this.addon.getChallengesManager().getChallenges(this.challengeLevel);
+
+		final int MAX_ELEMENTS = 21;
 
 		if (this.pageIndex < 0)
 		{
+			this.pageIndex = challengeList.size() / MAX_ELEMENTS;
+		}
+		else if (this.pageIndex > (challengeList.size() / MAX_ELEMENTS))
+		{
 			this.pageIndex = 0;
 		}
-		else if (this.pageIndex > (challenges.size() / 18))
+
+		int challengeIndex = MAX_ELEMENTS * this.pageIndex;
+
+		// I want first row to be only for navigation and return button.
+		int index = 10;
+
+		while (challengeIndex < ((this.pageIndex + 1) * MAX_ELEMENTS) &&
+			challengeIndex < challengeList.size() &&
+			index < 36)
 		{
-			this.pageIndex = challenges.size() / 18;
+			if (!panelBuilder.slotOccupied(index))
+			{
+				panelBuilder.item(index, this.createChallengeIcon(challengeList.get(challengeIndex++)));
+			}
+
+			index++;
 		}
 
-		int challengeIndex = 18 * this.pageIndex;
-		int elementIndex = 9;
-
-		while (challengeIndex < ((this.pageIndex + 1) * 18) &&
-			challengeIndex < challenges.size())
+		// Navigation buttons only if necessary
+		if (challengeList.size() > MAX_ELEMENTS)
 		{
-			panelBuilder.item(elementIndex++, this.createChallengeIcon(challenges.get(challengeIndex)));
-			challengeIndex++;
+			panelBuilder.item(18, this.getButton(CommonButtons.PREVIOUS));
+			panelBuilder.item(26, this.getButton(CommonButtons.NEXT));
 		}
 
-		if (this.pageIndex > 0)
-		{
-			panelBuilder.item(29, this.getButton(CommonButtons.PREVIOUS));
-		}
-
-		if (challengeIndex < challenges.size())
-		{
-			panelBuilder.item(33, this.getButton(CommonButtons.NEXT));
-		}
-
-		panelBuilder.item(30, this.createButton(Button.ADD_CHALLENGE));
-		panelBuilder.item(32, this.createButton(Button.REMOVE_CHALLENGE));
+		panelBuilder.item(39, this.createButton(Button.ADD_CHALLENGE));
+		panelBuilder.item(41, this.createButton(Button.REMOVE_CHALLENGE));
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
@@ -16,8 +16,8 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.util.ItemParser;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.ChallengesManager;
-import world.bentobox.challenges.database.object.ChallengeLevels;
-import world.bentobox.challenges.database.object.Challenges;
+import world.bentobox.challenges.database.object.ChallengeLevel;
+import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.util.ItemSwitchGUI;
 import world.bentobox.challenges.panel.util.NumberGUI;
@@ -43,7 +43,7 @@ public class EditLevelGUI extends CommonGUI
 	public EditLevelGUI(ChallengesAddon addon,
 		World world,
 		User user,
-		ChallengeLevels challengeLevel,
+		ChallengeLevel challengeLevel,
 		String topLabel,
 		String permissionPrefix)
 	{
@@ -58,7 +58,7 @@ public class EditLevelGUI extends CommonGUI
 	public EditLevelGUI(ChallengesAddon addon,
 		World world,
 		User user,
-		ChallengeLevels challengeLevel,
+		ChallengeLevel challengeLevel,
 		String topLabel,
 		String permissionPrefix,
 		CommonGUI parentGUI)
@@ -145,7 +145,7 @@ public class EditLevelGUI extends CommonGUI
 	 */
 	private void buildChallengesPanel(PanelBuilder panelBuilder)
 	{
-		List<Challenges> challengeList = this.addon.getChallengesManager().getChallenges(this.challengeLevel);
+		List<Challenge> challengeList = this.addon.getChallengesManager().getChallenges(this.challengeLevel);
 
 		final int MAX_ELEMENTS = 21;
 
@@ -262,7 +262,7 @@ public class EditLevelGUI extends CommonGUI
 	 * @param challenge Challenge which icon must be created.
 	 * @return PanelItem that represents given challenge.
 	 */
-	private PanelItem createChallengeIcon(Challenges challenge)
+	private PanelItem createChallengeIcon(Challenge challenge)
 	{
 		return new PanelItemBuilder().
 			name(challenge.getFriendlyName()).
@@ -538,7 +538,7 @@ public class EditLevelGUI extends CommonGUI
 					ChallengesManager manager = this.addon.getChallengesManager();
 
 					// Get all challenge that is not in current challenge.
-					List<Challenges> challengeList = manager.getChallengesList();
+					List<Challenge> challengeList = manager.getChallengesList();
 					challengeList.removeAll(manager.getChallenges(this.challengeLevel));
 
 					new SelectChallengeGUI(this.user, challengeList, (status, value) -> {
@@ -630,7 +630,7 @@ public class EditLevelGUI extends CommonGUI
 	/**
 	 * This variable holds current challenge level that is in editing GUI.
 	 */
-	private ChallengeLevels challengeLevel;
+	private ChallengeLevel challengeLevel;
 
 	/**
 	 * Variable holds current active menu.

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
@@ -15,11 +15,13 @@ import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.util.ItemParser;
 import world.bentobox.challenges.ChallengesAddon;
+import world.bentobox.challenges.ChallengesManager;
 import world.bentobox.challenges.database.object.ChallengeLevels;
 import world.bentobox.challenges.database.object.Challenges;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.util.ItemSwitchGUI;
 import world.bentobox.challenges.panel.util.NumberGUI;
+import world.bentobox.challenges.panel.util.SelectChallengeGUI;
 import world.bentobox.challenges.panel.util.StringListGUI;
 
 
@@ -523,8 +525,20 @@ public class EditLevelGUI extends CommonGUI
 				description = Collections.emptyList();
 				icon = new ItemStack(Material.WATER_BUCKET);
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: Create Challenge List GUI
-					this.build();
+					ChallengesManager manager = this.addon.getChallengesManager();
+
+					// Get all challenge that is not in current challenge.
+					List<Challenges> challengeList = manager.getChallengesList();
+					challengeList.removeAll(manager.getChallenges(this.challengeLevel));
+
+					new SelectChallengeGUI(this.user, challengeList, (status, value) -> {
+						if (status)
+						{
+							manager.linkChallenge(this.challengeLevel, value);
+						}
+
+						this.build();
+					});
 
 					return true;
 				};
@@ -537,8 +551,16 @@ public class EditLevelGUI extends CommonGUI
 				description = Collections.emptyList();
 				icon = new ItemStack(Material.LAVA_BUCKET);
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: Create Levels List GUI
-					this.build();
+					ChallengesManager manager = this.addon.getChallengesManager();
+
+					new SelectChallengeGUI(this.user, manager.getChallenges(this.challengeLevel), (status, value) -> {
+						if (status)
+						{
+							manager.unlinkChallenge(this.challengeLevel, value);
+						}
+
+						this.build();
+					});
 
 					return true;
 				};

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
@@ -28,7 +28,8 @@ import world.bentobox.challenges.utils.GuiUtils;
 
 /**
  * This class contains all necessary elements to create Levels Edit GUI.
- */
+ * TODO: In current class set that MONEY are availabe only if ECONOMY exist.
+*/
 public class EditLevelGUI extends CommonGUI
 {
 // ---------------------------------------------------------------------

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
@@ -398,13 +398,13 @@ public class EditLevelGUI extends CommonGUI
 				description = Collections.singletonList(
 					this.user.getTranslation("challenges.gui.admin.descriptions.waiver-amount",
 						"[value]",
-						Integer.toString(this.challengeLevel.getWaiveramount())));
+						Integer.toString(this.challengeLevel.getWaiverAmount())));
 				icon = new ItemStack(Material.REDSTONE_TORCH);
 				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, this.challengeLevel.getWaiveramount(), 0, (status, value) -> {
+					new NumberGUI(this.user, this.challengeLevel.getWaiverAmount(), 0, (status, value) -> {
 						if (status)
 						{
-							this.challengeLevel.setWaiveramount(value);
+							this.challengeLevel.setWaiverAmount(value);
 						}
 
 						this.build();
@@ -419,14 +419,14 @@ public class EditLevelGUI extends CommonGUI
 			case REWARD_DESCRIPTION:
 			{
 				name = this.user.getTranslation("challenges.gui.admin.buttons.reward-text");
-				description = Collections.singletonList(this.challengeLevel.getRewardDescription());
+				description = Collections.singletonList(this.challengeLevel.getRewardText());
 				icon = new ItemStack(Material.WRITTEN_BOOK);
 				clickHandler = (panel, user, clickType, slot) -> {
 					new AnvilGUI(this.addon.getPlugin(),
 						this.user.getPlayer(),
-						this.challengeLevel.getRewardDescription(),
+						this.challengeLevel.getRewardText(),
 						(player, reply) -> {
-							this.challengeLevel.setRewardDescription(reply);
+							this.challengeLevel.setRewardText(reply);
 							this.build();
 							return reply;
 						});
@@ -468,13 +468,13 @@ public class EditLevelGUI extends CommonGUI
 				description = Collections.singletonList(
 					this.user.getTranslation("challenges.gui.admin.descriptions.reward-exp",
 						"[value]",
-						Integer.toString(this.challengeLevel.getExpReward())));
+						Integer.toString(this.challengeLevel.getRewardExperience())));
 				icon = new ItemStack(Material.EXPERIENCE_BOTTLE);
 				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, this.challengeLevel.getExpReward(), 0, (status, value) -> {
+					new NumberGUI(this.user, this.challengeLevel.getRewardExperience(), 0, (status, value) -> {
 						if (status)
 						{
-							this.challengeLevel.setExpReward(value);
+							this.challengeLevel.setRewardExperience(value);
 						}
 
 						this.build();
@@ -491,13 +491,13 @@ public class EditLevelGUI extends CommonGUI
 				description = Collections.singletonList(
 					this.user.getTranslation("challenges.gui.admin.descriptions.reward-money",
 						"[value]",
-						Integer.toString(this.challengeLevel.getMoneyReward())));
+						Integer.toString(this.challengeLevel.getRewardMoney())));
 				icon = new ItemStack(Material.GOLD_INGOT);
 				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, this.challengeLevel.getMoneyReward(), 0, (status, value) -> {
+					new NumberGUI(this.user, this.challengeLevel.getRewardMoney(), 0, (status, value) -> {
 						if (status)
 						{
-							this.challengeLevel.setMoneyReward(value);
+							this.challengeLevel.setRewardMoney(value);
 						}
 
 						this.build();
@@ -544,7 +544,7 @@ public class EditLevelGUI extends CommonGUI
 					new SelectChallengeGUI(this.user, challengeList, (status, value) -> {
 						if (status)
 						{
-							manager.linkChallenge(this.challengeLevel, value);
+							manager.addChallengeToLevel(value, this.challengeLevel);
 						}
 
 						this.build();

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
@@ -8,10 +8,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import net.wesjd.anvilgui.AnvilGUI;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.ItemParser;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.database.object.ChallengeLevels;
 import world.bentobox.challenges.database.object.Challenges;
@@ -274,7 +276,7 @@ public class EditLevelGUI extends CommonGUI
 	/**
 	 * This method creates buttons for default main menu.
 	 * @param button Button which panel item must be created.
-	 * @return PanelItem that represetns given button.
+	 * @return PanelItem that represents given button.
 	 */
 	private PanelItem createButton(Button button)
 	{
@@ -292,8 +294,14 @@ public class EditLevelGUI extends CommonGUI
 				description = Collections.singletonList(this.challengeLevel.getFriendlyName());
 				icon = new ItemStack(Material.DROPPER);
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: Implement AnvilGui.
-					this.build();
+					new AnvilGUI(this.addon.getPlugin(),
+						this.user.getPlayer(),
+						this.challengeLevel.getFriendlyName(),
+						(player, reply) -> {
+							this.challengeLevel.setFriendlyName(reply);
+							this.build();
+							return reply;
+						});
 
 					return true;
 				};
@@ -306,8 +314,24 @@ public class EditLevelGUI extends CommonGUI
 				description = Collections.emptyList();
 				icon = this.challengeLevel.getIcon();
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: how to change icon.
-					this.build();
+					new AnvilGUI(this.addon.getPlugin(),
+						this.user.getPlayer(),
+						this.challengeLevel.getIcon().getType().name(),
+						(player, reply) -> {
+							ItemStack newIcon = ItemParser.parse(reply);
+
+							if (newIcon != null)
+							{
+								this.challengeLevel.setIcon(newIcon);
+							}
+							else
+							{
+								this.user.sendMessage("challenges.errors.wrong-icon", "[value]", reply);
+							}
+
+							this.build();
+							return reply;
+						});
 
 					return true;
 				};
@@ -320,8 +344,14 @@ public class EditLevelGUI extends CommonGUI
 				description = Collections.singletonList(this.challengeLevel.getUnlockMessage());
 				icon = new ItemStack(Material.WRITABLE_BOOK);
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: Implement AnvilGUI
-					this.build();
+					new AnvilGUI(this.addon.getPlugin(),
+						this.user.getPlayer(),
+						this.challengeLevel.getUnlockMessage(),
+						(player, reply) -> {
+							this.challengeLevel.setUnlockMessage(reply);
+							this.build();
+							return reply;
+						});
 					return true;
 				};
 				glow = false;
@@ -380,8 +410,14 @@ public class EditLevelGUI extends CommonGUI
 				description = Collections.singletonList(this.challengeLevel.getRewardDescription());
 				icon = new ItemStack(Material.WRITTEN_BOOK);
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: Implement AnvilGui
-
+					new AnvilGUI(this.addon.getPlugin(),
+						this.user.getPlayer(),
+						this.challengeLevel.getRewardDescription(),
+						(player, reply) -> {
+							this.challengeLevel.setRewardDescription(reply);
+							this.build();
+							return reply;
+						});
 					return true;
 				};
 				glow = false;

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
@@ -145,7 +145,7 @@ public class EditLevelGUI extends CommonGUI
 	 */
 	private void buildChallengesPanel(PanelBuilder panelBuilder)
 	{
-		List<Challenge> challengeList = this.addon.getChallengesManager().getChallenges(this.challengeLevel);
+		List<Challenge> challengeList = this.addon.getChallengesManager().getLevelChallenges(this.challengeLevel);
 
 		final int MAX_ELEMENTS = 21;
 
@@ -538,8 +538,8 @@ public class EditLevelGUI extends CommonGUI
 					ChallengesManager manager = this.addon.getChallengesManager();
 
 					// Get all challenge that is not in current challenge.
-					List<Challenge> challengeList = manager.getChallengesList();
-					challengeList.removeAll(manager.getChallenges(this.challengeLevel));
+					List<Challenge> challengeList = manager.getAllChallenges(this.world);
+					challengeList.removeAll(manager.getLevelChallenges(this.challengeLevel));
 
 					new SelectChallengeGUI(this.user, challengeList, (status, value) -> {
 						if (status)
@@ -563,10 +563,10 @@ public class EditLevelGUI extends CommonGUI
 				clickHandler = (panel, user, clickType, slot) -> {
 					ChallengesManager manager = this.addon.getChallengesManager();
 
-					new SelectChallengeGUI(this.user, manager.getChallenges(this.challengeLevel), (status, value) -> {
+					new SelectChallengeGUI(this.user, manager.getLevelChallenges(this.challengeLevel), (status, value) -> {
 						if (status)
 						{
-							manager.unlinkChallenge(this.challengeLevel, value);
+							manager.removeChallengeFromLevel(value, this.challengeLevel);
 						}
 
 						this.build();

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
@@ -13,11 +13,10 @@ import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
-import world.bentobox.bentobox.util.ItemParser;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.ChallengesManager;
-import world.bentobox.challenges.database.object.ChallengeLevel;
 import world.bentobox.challenges.database.object.Challenge;
+import world.bentobox.challenges.database.object.ChallengeLevel;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.util.ItemSwitchGUI;
 import world.bentobox.challenges.panel.util.NumberGUI;
@@ -253,7 +252,7 @@ public class EditLevelGUI extends CommonGUI
 				return null;
 		}
 
-		return new PanelItem(icon, name, description, glow, clickHandler, false);
+		return new PanelItem(icon, name, GuiUtils.stringSplit(description), glow, clickHandler, false);
 	}
 
 
@@ -266,7 +265,7 @@ public class EditLevelGUI extends CommonGUI
 	{
 		return new PanelItemBuilder().
 			name(challenge.getFriendlyName()).
-			description(challenge.getDescription()).
+			description(GuiUtils.stringSplit(challenge.getDescription())).
 			icon(challenge.getIcon()).
 			clickHandler((panel, user1, clickType, slot) -> {
 				// Open challenges edit screen.
@@ -591,7 +590,7 @@ public class EditLevelGUI extends CommonGUI
 				return null;
 		}
 
-		return new PanelItem(icon, name, description, glow, clickHandler, false);
+		return new PanelItem(icon, name, GuiUtils.stringSplit(description), glow, clickHandler, false);
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
@@ -28,7 +28,6 @@ import world.bentobox.challenges.utils.GuiUtils;
 
 /**
  * This class contains all necessary elements to create Levels Edit GUI.
- * TODO: In current class set that MONEY are availabe only if ECONOMY exist.
 */
 public class EditLevelGUI extends CommonGUI
 {
@@ -493,19 +492,29 @@ public class EditLevelGUI extends CommonGUI
 					this.user.getTranslation("challenges.gui.admin.descriptions.reward-money",
 						"[value]",
 						Integer.toString(this.challengeLevel.getRewardMoney())));
-				icon = new ItemStack(Material.GOLD_INGOT);
-				clickHandler = (panel, user, clickType, slot) -> {
-					new NumberGUI(this.user, this.challengeLevel.getRewardMoney(), 0, (status, value) -> {
-						if (status)
-						{
-							this.challengeLevel.setRewardMoney(value);
-						}
 
-						this.build();
-					});
+				if (this.addon.isEconomyProvided())
+				{
+					icon = new ItemStack(Material.GOLD_INGOT);
+					clickHandler = (panel, user, clickType, slot) -> {
+						new NumberGUI(this.user, this.challengeLevel.getRewardMoney(), 0, (status, value) -> {
+							if (status)
+							{
+								this.challengeLevel.setRewardMoney(value);
+							}
 
-					return true;
-				};
+							this.build();
+						});
+
+						return true;
+					};
+				}
+				else
+				{
+					icon = new ItemStack(Material.BARRIER);
+					clickHandler = null;
+				}
+
 				glow = false;
 				break;
 			}

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditLevelGUI.java
@@ -331,18 +331,18 @@ public class EditLevelGUI extends CommonGUI
 						this.user.getPlayer(),
 						this.challengeLevel.getIcon().getType().name(),
 						(player, reply) -> {
-							ItemStack newIcon = ItemParser.parse(reply);
+							Material material = Material.getMaterial(reply);
 
-							if (newIcon != null)
+							if (material != null)
 							{
-								this.challengeLevel.setIcon(newIcon);
+								this.challengeLevel.setIcon(new ItemStack(material));
+								this.build();
 							}
 							else
 							{
 								this.user.sendMessage("challenges.errors.wrong-icon", "[value]", reply);
 							}
 
-							this.build();
 							return reply;
 						});
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditSettingsGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditSettingsGUI.java
@@ -71,6 +71,7 @@ public class EditSettingsGUI extends CommonGUI
 			clickHandler((panel, user1, clickType, i) -> {
 				this.addon.getChallengesSettings().setResetChallenges(
 					!this.addon.getChallengesSettings().isResetChallenges());
+				this.build();
 				return true;
 			}).
 			glow(this.addon.getChallengesSettings().isResetChallenges()).
@@ -84,6 +85,7 @@ public class EditSettingsGUI extends CommonGUI
 			clickHandler((panel, user1, clickType, i) -> {
 				this.addon.getChallengesSettings().setBroadcastMessages(
 					!this.addon.getChallengesSettings().isBroadcastMessages());
+				this.build();
 				return true;
 			}).
 			glow(this.addon.getChallengesSettings().isBroadcastMessages()).
@@ -97,6 +99,7 @@ public class EditSettingsGUI extends CommonGUI
 			clickHandler((panel, user1, clickType, i) -> {
 				this.addon.getChallengesSettings().setRemoveCompleteOneTimeChallenges(
 					!this.addon.getChallengesSettings().isRemoveCompleteOneTimeChallenges());
+				this.build();
 				return true;
 			}).
 			glow(this.addon.getChallengesSettings().isRemoveCompleteOneTimeChallenges()).
@@ -110,6 +113,7 @@ public class EditSettingsGUI extends CommonGUI
 			clickHandler((panel, user1, clickType, i) -> {
 				this.addon.getChallengesSettings().setAddCompletedGlow(
 					!this.addon.getChallengesSettings().isAddCompletedGlow());
+				this.build();
 				return true;
 			}).
 			glow(this.addon.getChallengesSettings().isAddCompletedGlow()).
@@ -123,6 +127,7 @@ public class EditSettingsGUI extends CommonGUI
 			clickHandler((panel, user1, clickType, i) -> {
 				this.addon.getChallengesSettings().setFreeChallengesFirst(
 					!this.addon.getChallengesSettings().isFreeChallengesFirst());
+				this.build();
 				return true;
 			}).
 			glow(this.addon.getChallengesSettings().isFreeChallengesFirst()).

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditSettingsGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditSettingsGUI.java
@@ -66,7 +66,7 @@ public class EditSettingsGUI extends CommonGUI
 		// resetChallenges
 		panelBuilder.item(19, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.reset")).
-			description(this.user.getTranslation("challenges.gui.admin.descriptions.reset")).
+			description(GuiUtils.stringSplit(this.user.getTranslation("challenges.gui.admin.descriptions.reset"))).
 			icon(Material.LAVA_BUCKET).
 			clickHandler((panel, user1, clickType, i) -> {
 				this.addon.getChallengesSettings().setResetChallenges(
@@ -79,7 +79,7 @@ public class EditSettingsGUI extends CommonGUI
 		// broadcastMessages
 		panelBuilder.item(20, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.broadcast")).
-			description(this.user.getTranslation("challenges.gui.admin.descriptions.broadcast")).
+			description(GuiUtils.stringSplit(this.user.getTranslation("challenges.gui.admin.descriptions.broadcast"))).
 			icon(Material.JUKEBOX).
 			clickHandler((panel, user1, clickType, i) -> {
 				this.addon.getChallengesSettings().setBroadcastMessages(
@@ -92,7 +92,7 @@ public class EditSettingsGUI extends CommonGUI
 		// removeCompleteOneTimeChallenges
 		panelBuilder.item(21, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.remove-on-complete")).
-			description(this.user.getTranslation("challenges.gui.admin.descriptions.remove-on-complete")).
+			description(GuiUtils.stringSplit(this.user.getTranslation("challenges.gui.admin.descriptions.remove-on-complete"))).
 			icon(Material.MAGMA_BLOCK).
 			clickHandler((panel, user1, clickType, i) -> {
 				this.addon.getChallengesSettings().setRemoveCompleteOneTimeChallenges(
@@ -105,7 +105,7 @@ public class EditSettingsGUI extends CommonGUI
 		// addCompletedGlow
 		panelBuilder.item(22, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.glow")).
-			description(this.user.getTranslation("challenges.gui.admin.descriptions.glow")).
+			description(GuiUtils.stringSplit(this.user.getTranslation("challenges.gui.admin.descriptions.glow"))).
 			icon(Material.GLOWSTONE).
 			clickHandler((panel, user1, clickType, i) -> {
 				this.addon.getChallengesSettings().setAddCompletedGlow(
@@ -118,7 +118,7 @@ public class EditSettingsGUI extends CommonGUI
 		// freeChallengesAtTheTop
 		panelBuilder.item(23, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.free-challenges")).
-			description(this.user.getTranslation("challenges.gui.admin.descriptions.free-challenges")).
+			description(GuiUtils.stringSplit(this.user.getTranslation("challenges.gui.admin.descriptions.free-challenges"))).
 			icon(Material.FILLED_MAP).
 			clickHandler((panel, user1, clickType, i) -> {
 				this.addon.getChallengesSettings().setFreeChallengesFirst(

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditSettingsGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditSettingsGUI.java
@@ -9,6 +9,7 @@ import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.panel.CommonGUI;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -60,8 +61,10 @@ public class EditSettingsGUI extends CommonGUI
 		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(
 			this.user.getTranslation("challenges.gui.admin.settings-title"));
 
+		GuiUtils.fillBorder(panelBuilder);
+
 		// resetChallenges
-		panelBuilder.item(0, new PanelItemBuilder().
+		panelBuilder.item(19, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.reset")).
 			description(this.user.getTranslation("challenges.gui.admin.descriptions.reset")).
 			icon(Material.LAVA_BUCKET).
@@ -74,7 +77,7 @@ public class EditSettingsGUI extends CommonGUI
 			build());
 
 		// broadcastMessages
-		panelBuilder.item(1, new PanelItemBuilder().
+		panelBuilder.item(20, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.broadcast")).
 			description(this.user.getTranslation("challenges.gui.admin.descriptions.broadcast")).
 			icon(Material.JUKEBOX).
@@ -87,7 +90,7 @@ public class EditSettingsGUI extends CommonGUI
 			build());
 
 		// removeCompleteOneTimeChallenges
-		panelBuilder.item(2, new PanelItemBuilder().
+		panelBuilder.item(21, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.remove-on-complete")).
 			description(this.user.getTranslation("challenges.gui.admin.descriptions.remove-on-complete")).
 			icon(Material.MAGMA_BLOCK).
@@ -100,7 +103,7 @@ public class EditSettingsGUI extends CommonGUI
 			build());
 
 		// addCompletedGlow
-		panelBuilder.item(3, new PanelItemBuilder().
+		panelBuilder.item(22, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.glow")).
 			description(this.user.getTranslation("challenges.gui.admin.descriptions.glow")).
 			icon(Material.GLOWSTONE).
@@ -112,8 +115,21 @@ public class EditSettingsGUI extends CommonGUI
 			glow(this.addon.getChallengesSettings().isAddCompletedGlow()).
 			build());
 
+		// freeChallengesAtTheTop
+		panelBuilder.item(23, new PanelItemBuilder().
+			name(this.user.getTranslation("challenges.gui.admin.buttons.free-challenges")).
+			description(this.user.getTranslation("challenges.gui.admin.descriptions.free-challenges")).
+			icon(Material.FILLED_MAP).
+			clickHandler((panel, user1, clickType, i) -> {
+				this.addon.getChallengesSettings().setFreeChallengesFirst(
+					!this.addon.getChallengesSettings().isFreeChallengesFirst());
+				return true;
+			}).
+			glow(this.addon.getChallengesSettings().isFreeChallengesFirst()).
+			build());
+
 		// Return Button
-		panelBuilder.item(8, this.returnButton);
+		panelBuilder.item(44, this.returnButton);
 
 		panelBuilder.build();
 	}

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListChallengesGUI.java
@@ -134,7 +134,7 @@ public class ListChallengesGUI extends CommonGUI
 	{
 		PanelItemBuilder itemBuilder = new PanelItemBuilder().
 			name(challenge.getFriendlyName()).
-			description(challenge.getDescription()).
+			description(GuiUtils.stringSplit(challenge.getDescription())).
 			icon(challenge.getIcon()).
 			glow(challenge.isDeployed());
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListChallengesGUI.java
@@ -82,7 +82,7 @@ public class ListChallengesGUI extends CommonGUI
 			GuiUtils.fillBorder(panelBuilder);
 		}
 
-		List<Challenge> challengeList = this.addon.getChallengesManager().getChallengesList();
+		List<Challenge> challengeList = this.addon.getChallengesManager().getAllChallenges(this.world);
 
 		final int MAX_ELEMENTS = 21;
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListChallengesGUI.java
@@ -10,7 +10,7 @@ import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.challenges.ChallengesAddon;
-import world.bentobox.challenges.database.object.Challenges;
+import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.util.ConfirmationGUI;
 import world.bentobox.challenges.utils.GuiUtils;
@@ -82,7 +82,7 @@ public class ListChallengesGUI extends CommonGUI
 			GuiUtils.fillBorder(panelBuilder);
 		}
 
-		List<Challenges> challengeList = this.addon.getChallengesManager().getChallengesList();
+		List<Challenge> challengeList = this.addon.getChallengesManager().getChallengesList();
 
 		final int MAX_ELEMENTS = 21;
 
@@ -130,7 +130,7 @@ public class ListChallengesGUI extends CommonGUI
 	 * @param challenge Challenge which button must be created.
 	 * @return Challenge button.
 	 */
-	private PanelItem createChallengeIcon(Challenges challenge)
+	private PanelItem createChallengeIcon(Challenge challenge)
 	{
 		PanelItemBuilder itemBuilder = new PanelItemBuilder().
 			name(challenge.getFriendlyName()).

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListChallengesGUI.java
@@ -1,6 +1,7 @@
 package world.bentobox.challenges.panel.admin;
 
 
+import org.bukkit.Material;
 import org.bukkit.World;
 import java.util.List;
 
@@ -12,6 +13,7 @@ import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.database.object.Challenges;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.util.ConfirmationGUI;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -71,42 +73,53 @@ public class ListChallengesGUI extends CommonGUI
 		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(
 			this.user.getTranslation("challenges.gui.admin.choose-challenge-title"));
 
+		if (this.currentMode.equals(Mode.DELETE))
+		{
+			GuiUtils.fillBorder(panelBuilder, Material.RED_STAINED_GLASS_PANE);
+		}
+		else
+		{
+			GuiUtils.fillBorder(panelBuilder);
+		}
+
 		List<Challenges> challengeList = this.addon.getChallengesManager().getChallengesList();
 
-		int MAX_ELEMENTS = 45;
+		final int MAX_ELEMENTS = 21;
+
 		if (this.pageIndex < 0)
 		{
-			this.pageIndex = 0;
+			this.pageIndex = challengeList.size() / MAX_ELEMENTS;
 		}
 		else if (this.pageIndex > (challengeList.size() / MAX_ELEMENTS))
 		{
-			this.pageIndex = challengeList.size() / MAX_ELEMENTS;
+			this.pageIndex = 0;
 		}
 
 		int challengeIndex = MAX_ELEMENTS * this.pageIndex;
 
+		// I want first row to be only for navigation and return button.
+		int index = 10;
+
 		while (challengeIndex < ((this.pageIndex + 1) * MAX_ELEMENTS) &&
-			challengeIndex < challengeList.size())
+			challengeIndex < challengeList.size() &&
+			index < 36)
 		{
-			panelBuilder.item(this.createChallengeIcon(challengeList.get(challengeIndex)));
-			challengeIndex++;
+			if (!panelBuilder.slotOccupied(index))
+			{
+				panelBuilder.item(index, this.createChallengeIcon(challengeList.get(challengeIndex++)));
+			}
+
+			index++;
 		}
 
-		int nextIndex = challengeIndex % MAX_ELEMENTS == 0 ?
-			MAX_ELEMENTS :
-			(((challengeIndex % MAX_ELEMENTS) - 1) / 9 + 1) * 9;
-
-		if (challengeIndex > MAX_ELEMENTS)
+		// Navigation buttons only if necessary
+		if (challengeList.size() > MAX_ELEMENTS)
 		{
-			panelBuilder.item(nextIndex + 2, this.getButton(CommonButtons.PREVIOUS));
+			panelBuilder.item(18, this.getButton(CommonButtons.PREVIOUS));
+			panelBuilder.item(26, this.getButton(CommonButtons.NEXT));
 		}
 
-		if (challengeIndex < challengeList.size())
-		{
-			panelBuilder.item(nextIndex + 6, this.getButton(CommonButtons.NEXT));
-		}
-
-		panelBuilder.item(nextIndex + 8, this.returnButton);
+		panelBuilder.item(44, this.returnButton);
 
 		panelBuilder.build();
 	}

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListLevelsGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListLevelsGUI.java
@@ -1,6 +1,7 @@
 package world.bentobox.challenges.panel.admin;
 
 
+import org.bukkit.Material;
 import org.bukkit.World;
 import java.util.List;
 
@@ -12,6 +13,7 @@ import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.database.object.ChallengeLevels;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.util.ConfirmationGUI;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -71,42 +73,53 @@ public class ListLevelsGUI extends CommonGUI
 		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(
 			this.user.getTranslation("challenges.gui.admin.choose-level-title"));
 
+		if (this.currentMode.equals(Mode.DELETE))
+		{
+			GuiUtils.fillBorder(panelBuilder, Material.RED_STAINED_GLASS_PANE);
+		}
+		else
+		{
+			GuiUtils.fillBorder(panelBuilder);
+		}
+
 		List<ChallengeLevels> levelList = this.addon.getChallengesManager().getChallengeLevelList();
 
-		int MAX_ELEMENTS = 45;
+		final int MAX_ELEMENTS = 21;
+
 		if (this.pageIndex < 0)
 		{
-			this.pageIndex = 0;
+			this.pageIndex = levelList.size() / MAX_ELEMENTS;
 		}
 		else if (this.pageIndex > (levelList.size() / MAX_ELEMENTS))
 		{
-			this.pageIndex = levelList.size() / MAX_ELEMENTS;
+			this.pageIndex = 0;
 		}
 
 		int levelIndex = MAX_ELEMENTS * this.pageIndex;
 
+		// I want first row to be only for navigation and return button.
+		int index = 10;
+
 		while (levelIndex < ((this.pageIndex + 1) * MAX_ELEMENTS) &&
-			levelIndex < levelList.size())
+			levelIndex < levelList.size() &&
+			index < 36)
 		{
-			panelBuilder.item(this.createLevelIcon(levelList.get(levelIndex)));
-			levelIndex++;
+			if (!panelBuilder.slotOccupied(index))
+			{
+				panelBuilder.item(index, this.createLevelIcon(levelList.get(levelIndex++)));
+			}
+
+			index++;
 		}
 
-		int nextIndex = levelIndex % MAX_ELEMENTS == 0 ?
-			MAX_ELEMENTS :
-			(((levelIndex % MAX_ELEMENTS) - 1) / 9 + 1) * 9;
-
-		if (levelIndex > MAX_ELEMENTS)
+		// Navigation buttons only if necessary
+		if (levelList.size() > MAX_ELEMENTS)
 		{
-			panelBuilder.item(nextIndex + 2, this.getButton(CommonButtons.PREVIOUS));
+			panelBuilder.item(18, this.getButton(CommonButtons.PREVIOUS));
+			panelBuilder.item(26, this.getButton(CommonButtons.NEXT));
 		}
 
-		if (levelIndex < levelList.size())
-		{
-			panelBuilder.item(nextIndex + 6, this.getButton(CommonButtons.NEXT));
-		}
-
-		panelBuilder.item(nextIndex + 8, this.returnButton);
+		panelBuilder.item(44, this.returnButton);
 
 		panelBuilder.build();
 	}

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListLevelsGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListLevelsGUI.java
@@ -82,7 +82,7 @@ public class ListLevelsGUI extends CommonGUI
 			GuiUtils.fillBorder(panelBuilder);
 		}
 
-		List<ChallengeLevel> levelList = this.addon.getChallengesManager().getChallengeLevelList();
+		List<ChallengeLevel> levelList = this.addon.getChallengesManager().getLevels(this.world);
 
 		final int MAX_ELEMENTS = 21;
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListLevelsGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListLevelsGUI.java
@@ -10,7 +10,7 @@ import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.challenges.ChallengesAddon;
-import world.bentobox.challenges.database.object.ChallengeLevels;
+import world.bentobox.challenges.database.object.ChallengeLevel;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.util.ConfirmationGUI;
 import world.bentobox.challenges.utils.GuiUtils;
@@ -82,7 +82,7 @@ public class ListLevelsGUI extends CommonGUI
 			GuiUtils.fillBorder(panelBuilder);
 		}
 
-		List<ChallengeLevels> levelList = this.addon.getChallengesManager().getChallengeLevelList();
+		List<ChallengeLevel> levelList = this.addon.getChallengesManager().getChallengeLevelList();
 
 		final int MAX_ELEMENTS = 21;
 
@@ -130,7 +130,7 @@ public class ListLevelsGUI extends CommonGUI
 	 * @param challengeLevel Level which button must be created.
 	 * @return Level button.
 	 */
-	private PanelItem createLevelIcon(ChallengeLevels challengeLevel)
+	private PanelItem createLevelIcon(ChallengeLevel challengeLevel)
 	{
 		PanelItemBuilder itemBuilder = new PanelItemBuilder().
 			name(challengeLevel.getFriendlyName()).

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListLevelsGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListLevelsGUI.java
@@ -134,7 +134,7 @@ public class ListLevelsGUI extends CommonGUI
 	{
 		PanelItemBuilder itemBuilder = new PanelItemBuilder().
 			name(challengeLevel.getFriendlyName()).
-			description(challengeLevel.getUnlockMessage()).
+			description(GuiUtils.stringSplit(challengeLevel.getUnlockMessage())).
 			icon(challengeLevel.getIcon()).
 			glow(false);
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListUsersGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListUsersGUI.java
@@ -216,7 +216,7 @@ public class ListUsersGUI extends CommonGUI
 			return new PanelItemBuilder().
 				name(player.getName()).
 				icon(Material.BARRIER).
-				description(this.user.getTranslation("general.errors.player-has-no-island")).
+				description(GuiUtils.stringSplit(this.user.getTranslation("general.errors.player-has-no-island"))).
 				clickHandler((panel, user1, clickType, slot) -> false).
 				build();
 		}
@@ -258,7 +258,7 @@ public class ListUsersGUI extends CommonGUI
 
 		for (int i = 0; i < ViewMode.values().length; i++)
 		{
-			values.add((this.modeIndex == i ? "§2" : "§c") +
+			values.add((this.modeIndex == i ? "&2" : "&c") +
 				this.user.getTranslation("challenges.gui.admin.descriptions." +
 					ViewMode.values()[i].name().toLowerCase()));
 		}
@@ -267,7 +267,7 @@ public class ListUsersGUI extends CommonGUI
 			name(this.user.getTranslation("challenges.gui.admin.buttons.toggle-users",
 				"[value]",
 				this.user.getTranslation("challenges.gui.admin.descriptions." + ViewMode.values()[this.modeIndex].name().toLowerCase()))).
-			description(values).
+			description(GuiUtils.stringSplit(values)).
 			icon(Material.STONE_BUTTON).
 			clickHandler(
 				(panel, user1, clickType, slot) -> {

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListUsersGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListUsersGUI.java
@@ -178,20 +178,20 @@ public class ListUsersGUI extends CommonGUI
 					switch (this.operationMode)
 					{
 						case COMPLETE:
-							new SelectChallengeGUI(this.user, manager.getChallengesList(), (status, value) -> {
+							new SelectChallengeGUI(this.user, manager.getAllChallenges(this.world), (status, value) -> {
 								if (status)
 								{
-									manager.completeChallenge(player.getUniqueId(), value);
+									manager.setChallengeComplete(User.getInstance(player), value);
 								}
 
 								this.build();
 							});
 							break;
 						case RESET:
-							new SelectChallengeGUI(this.user, manager.getChallengesList(), (status, value) -> {
+							new SelectChallengeGUI(this.user, manager.getAllChallenges(this.world), (status, value) -> {
 								if (status)
 								{
-									manager.resetChallenge(player.getUniqueId(), value);
+									manager.resetChallenge(User.getInstance(player), value);
 								}
 
 								this.build();

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListUsersGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListUsersGUI.java
@@ -3,16 +3,17 @@ package world.bentobox.challenges.panel.admin;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Players;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.ChallengesManager;
 import world.bentobox.challenges.panel.CommonGUI;
@@ -235,7 +236,10 @@ public class ListUsersGUI extends CommonGUI
 		}
 		else if (mode.equals(ViewMode.WITH_ISLAND))
 		{
-			return this.addon.getChallengesManager().getPlayers(this.world);
+			return this.addon.getPlayers().getPlayers().stream().
+				filter(player -> this.addon.getIslands().getIsland(this.world, player.getPlayerUUID()) != null).
+				map(Players::getPlayer).
+				collect(Collectors.toList());
 		}
 		else
 		{

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListUsersGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListUsersGUI.java
@@ -14,8 +14,10 @@ import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.challenges.ChallengesAddon;
+import world.bentobox.challenges.ChallengesManager;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.util.ConfirmationGUI;
+import world.bentobox.challenges.panel.util.SelectChallengeGUI;
 
 
 /**
@@ -167,19 +169,35 @@ public class ListUsersGUI extends CommonGUI
 		{
 			return new PanelItemBuilder().name(player.getName()).icon(player.getName()).clickHandler(
 				(panel, user1, clickType, slot) -> {
+					ChallengesManager manager = this.addon.getChallengesManager();
+
 					switch (this.operationMode)
 					{
 						case COMPLETE:
-							// TODO: Open Complete Challenge GUI.
+							new SelectChallengeGUI(this.user, manager.getChallengesList(), (status, value) -> {
+								if (status)
+								{
+									manager.completeChallenge(player.getUniqueId(), value);
+								}
+
+								this.build();
+							});
 							break;
 						case RESET:
-							// TODO: Open Reset Challenge GUI.
+							new SelectChallengeGUI(this.user, manager.getChallengesList(), (status, value) -> {
+								if (status)
+								{
+									manager.resetChallenge(player.getUniqueId(), value);
+								}
+
+								this.build();
+							});
 							break;
 						case RESET_ALL:
 							new ConfirmationGUI(this.user, status -> {
 								if (status)
 								{
-									this.addon.getChallengesManager().resetAllChallenges(this.user, this.world);
+									manager.resetAllChallenges(this.user, this.world);
 								}
 							});
 							break;

--- a/src/main/java/world/bentobox/challenges/panel/admin/ManageBlocksGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ManageBlocksGUI.java
@@ -79,7 +79,8 @@ public class ManageBlocksGUI extends CommonGUI
 		int index = 10;
 
 		while (entitiesIndex < ((this.pageIndex + 1) * MAX_ELEMENTS) &&
-			entitiesIndex < this.materialList.size())
+			entitiesIndex < this.materialList.size() &&
+			index < 36)
 		{
 			if (!panelBuilder.slotOccupied(index))
 			{

--- a/src/main/java/world/bentobox/challenges/panel/admin/ManageBlocksGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ManageBlocksGUI.java
@@ -1,0 +1,224 @@
+package world.bentobox.challenges.panel.admin;
+
+
+import org.apache.commons.lang.WordUtils;
+import org.bukkit.Material;
+import org.bukkit.World;
+import java.util.*;
+
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.ChallengesAddon;
+import world.bentobox.challenges.panel.CommonGUI;
+import world.bentobox.challenges.panel.util.NumberGUI;
+import world.bentobox.challenges.panel.util.SelectBlocksGUI;
+import world.bentobox.challenges.utils.GuiUtils;
+
+
+/**
+ * This class allows to edit material that are in required material map.
+ */
+public class ManageBlocksGUI extends CommonGUI
+{
+	public ManageBlocksGUI(ChallengesAddon addon,
+		World world,
+		User user,
+		Map<Material, Integer> materialMap,
+		String topLabel,
+		String permissionPrefix,
+		CommonGUI parentGUI)
+	{
+		super(addon, world, user, topLabel, permissionPrefix, parentGUI);
+		this.materialMap = materialMap;
+
+		this.materialList = new ArrayList<>(this.materialMap.keySet());
+
+		// Sort materials by their ordinal value.
+		this.materialList.sort(Comparator.comparing(Enum::ordinal));
+
+		this.selectedMaterials = new HashSet<>();
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Methods
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * This method builds all necessary elements in GUI panel.
+	 */
+	@Override
+	public void build()
+	{
+		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).
+			name(this.user.getTranslation("challenges.gui.admin.manage-blocks"));
+
+		// Create nice border.
+		GuiUtils.fillBorder(panelBuilder);
+
+		panelBuilder.item(3, this.createButton(Button.ADD));
+		panelBuilder.item(5, this.createButton(Button.REMOVE));
+
+		final int MAX_ELEMENTS = 21;
+
+		if (this.pageIndex < 0)
+		{
+			this.pageIndex = this.materialList.size() / MAX_ELEMENTS;
+		}
+		else if (this.pageIndex > (this.materialList.size() / MAX_ELEMENTS))
+		{
+			this.pageIndex = 0;
+		}
+
+		int entitiesIndex = MAX_ELEMENTS * this.pageIndex;
+
+		// I want first row to be only for navigation and return button.
+		int index = 10;
+
+		while (entitiesIndex < ((this.pageIndex + 1) * MAX_ELEMENTS) &&
+			entitiesIndex < this.materialList.size())
+		{
+			if (!panelBuilder.slotOccupied(index))
+			{
+				panelBuilder.item(index, this.createElementButton(this.materialList.get(entitiesIndex++)));
+			}
+
+			index++;
+		}
+
+		// Navigation buttons only if necessary
+		if (this.materialList.size() > MAX_ELEMENTS)
+		{
+			panelBuilder.item(18, this.getButton(CommonButtons.PREVIOUS));
+			panelBuilder.item(26, this.getButton(CommonButtons.NEXT));
+		}
+
+		// Add return button.
+		panelBuilder.item(44, this.returnButton);
+
+		panelBuilder.build();
+	}
+
+
+	/**
+	 * This method creates PanelItem button of requested type.
+	 * @param button Button which must be created.
+	 * @return new PanelItem with requested functionality.
+	 */
+	private PanelItem createButton(Button button)
+	{
+		PanelItemBuilder builder = new PanelItemBuilder();
+
+		switch (button)
+		{
+			case ADD:
+				builder.name(this.user.getTranslation("challenges.gui.button.add"));
+				builder.icon(Material.BUCKET);
+				builder.clickHandler((panel, user1, clickType, slot) -> {
+
+					new SelectBlocksGUI(this.user, new HashSet<>(this.materialList), (status, material) -> {
+						if (status)
+						{
+							this.materialMap.put(material, 1);
+							this.materialList.add(material);
+						}
+
+						this.build();
+					});
+					return true;
+				});
+				break;
+			case REMOVE:
+				builder.name(this.user.getTranslation("challenges.gui.button.remove-selected"));
+				builder.icon(Material.LAVA_BUCKET);
+				builder.clickHandler((panel, user1, clickType, slot) -> {
+					this.materialMap.keySet().removeAll(this.selectedMaterials);
+					this.materialList.removeAll(this.selectedMaterials);
+					this.build();
+					return true;
+				});
+				break;
+		}
+
+		return builder.build();
+	}
+
+
+	/**
+	 * This method creates button for given material.
+	 * @param material material which button must be created.
+	 * @return new Button for material.
+	 */
+	private PanelItem createElementButton(Material material)
+	{
+		return new PanelItemBuilder().
+			name(WordUtils.capitalize(material.name().toLowerCase().replace("_", " "))).
+			icon(GuiUtils.getMaterialItem(material, this.materialMap.get(material))).
+			clickHandler((panel, user1, clickType, slot) -> {
+				// On right click change which entities are selected for deletion.
+				if (clickType.isRightClick())
+				{
+					if (!this.selectedMaterials.add(material))
+					{
+						// Remove material if it is already selected
+						this.selectedMaterials.remove(material);
+					}
+
+					this.build();
+				}
+				else
+				{
+					new NumberGUI(this.user, this.materialMap.get(material), 1, (status, value) -> {
+						if (status)
+						{
+							// Update value only when something changes.
+							this.materialMap.put(material, value);
+						}
+
+						this.build();
+					});
+				}
+				return true;
+			}).
+			glow(this.selectedMaterials.contains(material)).
+			build();
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Enums
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * Functional buttons in current GUI.
+	 */
+	private enum Button
+	{
+		ADD,
+		REMOVE
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
+
+	/**
+	 * Contains selected materials.
+	 */
+	private Set<Material> selectedMaterials;
+
+	/**
+	 * List of materials to avoid order issues.
+	 */
+	private List<Material> materialList;
+
+	/**
+	 * List of required materials.
+	 */
+	private Map<Material, Integer> materialMap;
+}

--- a/src/main/java/world/bentobox/challenges/panel/admin/ManageEntitiesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ManageEntitiesGUI.java
@@ -1,0 +1,339 @@
+package world.bentobox.challenges.panel.admin;
+
+
+import org.apache.commons.lang.WordUtils;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
+import java.util.*;
+
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.ChallengesAddon;
+import world.bentobox.challenges.panel.CommonGUI;
+import world.bentobox.challenges.panel.util.NumberGUI;
+import world.bentobox.challenges.panel.util.SelectEntityGUI;
+import world.bentobox.challenges.utils.HeadLib;
+
+
+/**
+ * This class allows to edit entities that are in required entities map.
+ */
+public class ManageEntitiesGUI extends CommonGUI
+{
+	public ManageEntitiesGUI(ChallengesAddon addon,
+		World world,
+		User user,
+		Map<EntityType, Integer> requiredEntities,
+		String topLabel,
+		String permissionPrefix,
+		CommonGUI parentGUI)
+	{
+		super(addon, world, user, topLabel, permissionPrefix, parentGUI);
+		this.requiredEntities = requiredEntities;
+
+		this.entityList = new ArrayList<>(this.requiredEntities.keySet());
+		this.entityList.sort(Comparator.comparing(Enum::name));
+
+		this.selectedEntities = new HashSet<>(EntityType.values().length);
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Methods
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * This method builds all necessary elements in GUI panel.
+	 */
+	@Override
+	public void build()
+	{
+		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).
+			name(this.user.getTranslation("challenges.gui.admin.edit-entities"));
+
+		// create border
+		this.fillBorder(panelBuilder);
+
+		panelBuilder.item(3, this.createButton(Button.ADD));
+		panelBuilder.item(5, this.createButton(Button.REMOVE));
+
+		final int MAX_ELEMENTS = 21;
+
+		if (this.pageIndex < 0)
+		{
+			this.pageIndex = this.entityList.size() / MAX_ELEMENTS;
+		}
+		else if (this.pageIndex > (this.entityList.size() / MAX_ELEMENTS))
+		{
+			this.pageIndex = 0;
+		}
+
+		int entitiesIndex = MAX_ELEMENTS * this.pageIndex;
+
+		// I want first row to be only for navigation and return button.
+		int index = 10;
+
+		while (entitiesIndex < ((this.pageIndex + 1) * MAX_ELEMENTS) &&
+			entitiesIndex < this.entityList.size())
+		{
+			if (!panelBuilder.slotOccupied(index))
+			{
+				panelBuilder.item(index, this.createEntityButton(this.entityList.get(entitiesIndex++)));
+			}
+
+			index++;
+		}
+
+		// Navigation buttons only if necessary
+		if (this.entityList.size() > MAX_ELEMENTS)
+		{
+			panelBuilder.item(18, this.getButton(CommonButtons.PREVIOUS));
+			panelBuilder.item(26, this.getButton(CommonButtons.NEXT));
+		}
+
+		// Add return button.
+		panelBuilder.item(44, this.returnButton);
+
+		panelBuilder.build();
+	}
+
+
+	/**
+	 * This method creates PanelItem button of requested type.
+	 * @param button Button which must be created.
+	 * @return new PanelItem with requested functionality.
+	 */
+	private PanelItem createButton(Button button)
+	{
+		PanelItemBuilder builder = new PanelItemBuilder();
+
+		switch (button)
+		{
+			case ADD:
+				builder.name(this.user.getTranslation("challenges.gui.button.add"));
+				builder.icon(Material.BUCKET);
+				builder.clickHandler((panel, user1, clickType, slot) -> {
+					new SelectEntityGUI(this.user, (status, entity) -> {
+						if (status)
+						{
+							if (!this.requiredEntities.containsKey(entity))
+							{
+								this.requiredEntities.put(entity, 1);
+								this.entityList.add(entity);
+							}
+						}
+
+						this.build();
+					});
+					return true;
+				});
+				break;
+			case REMOVE:
+				builder.name(this.user.getTranslation("challenges.gui.button.remove-selected"));
+				builder.icon(Material.LAVA_BUCKET);
+				builder.clickHandler((panel, user1, clickType, slot) -> {
+					this.requiredEntities.keySet().removeAll(this.selectedEntities);
+					this.entityList.removeAll(this.selectedEntities);
+					return true;
+				});
+				break;
+		}
+
+		return builder.build();
+	}
+
+
+	/**
+	 * This method creates button for given entity.
+	 * @param entity Entity which button must be created.
+	 * @return new Button for entity.
+	 */
+	private PanelItem createEntityButton(EntityType entity)
+	{
+		return new PanelItemBuilder().
+			name(WordUtils.capitalize(entity.name().toLowerCase().replace("_", " "))).
+			icon(this.asEggs ? this.getEntityEgg(entity) : this.getEntityHead(entity)).
+			clickHandler((panel, user1, clickType, slot) -> {
+				// On right click change which entities are selected for deletion.
+				if (clickType.isRightClick())
+				{
+					if (!this.selectedEntities.add(entity))
+					{
+						// Remove entity if it is already selected
+						this.selectedEntities.remove(entity);
+					}
+
+					this.build();
+				}
+				else
+				{
+					new NumberGUI(this.user, this.requiredEntities.get(entity), 1, (status, value) -> {
+						if (status)
+						{
+							// Update value only when something changes.
+							this.requiredEntities.put(entity, value);
+						}
+
+						this.build();
+					});
+				}
+				return true;
+			}).
+			glow(this.selectedEntities.contains(entity)).
+			build();
+	}
+
+
+	/**
+	 * This method transforms entity into egg or block that corresponds given entity. If entity egg is not
+	 * found, then it is replaced by block that represents entity or barrier block.
+	 * @param entity Entity which egg must be returned.
+	 * @return ItemStack that may be egg for given entity.
+	 */
+	private ItemStack getEntityEgg(EntityType entity)
+	{
+		ItemStack itemStack;
+
+		switch (entity)
+		{
+			case PIG_ZOMBIE:
+				itemStack = new ItemStack(Material.ZOMBIE_PIGMAN_SPAWN_EGG);
+				break;
+			case ENDER_DRAGON:
+				itemStack = new ItemStack(Material.DRAGON_EGG);
+				break;
+			case WITHER:
+				itemStack = new ItemStack(Material.SOUL_SAND);
+				break;
+			case PLAYER:
+				itemStack = new ItemStack(Material.PLAYER_HEAD);
+				break;
+			case MUSHROOM_COW:
+				itemStack = new ItemStack(Material.MOOSHROOM_SPAWN_EGG);
+				break;
+			case SNOWMAN:
+				itemStack = new ItemStack(Material.CARVED_PUMPKIN);
+				break;
+			case IRON_GOLEM:
+				itemStack = new ItemStack(Material.IRON_BLOCK);
+				break;
+			case ARMOR_STAND:
+				itemStack = new ItemStack(Material.ARMOR_STAND);
+				break;
+			default:
+				Material material = Material.getMaterial(entity.name() + "_SPAWN_EGG");
+
+				if (material == null)
+				{
+					itemStack = new ItemStack(Material.BARRIER);
+				}
+				else
+				{
+					itemStack = new ItemStack(material);
+				}
+
+				break;
+		}
+
+		itemStack.setAmount(this.requiredEntities.get(entity));
+
+		return itemStack;
+	}
+
+
+	/**
+	 * This method transforms entity into player head with skin that corresponds given entity. If entity head
+	 * is not found, then it is replaced by barrier block.
+	 * @param entity Entity which head must be returned.
+	 * @return ItemStack that may be head for given entity.
+	 */
+	private ItemStack getEntityHead(EntityType entity)
+	{
+		ItemStack itemStack;
+
+		switch (entity)
+		{
+			case PLAYER:
+				itemStack = new ItemStack(Material.PLAYER_HEAD);
+				break;
+			case WITHER_SKELETON:
+				itemStack = new ItemStack(Material.WITHER_SKELETON_SKULL);
+				break;
+			case ARMOR_STAND:
+				itemStack = new ItemStack(Material.ARMOR_STAND);
+				break;
+			case SKELETON:
+				itemStack = new ItemStack(Material.SKELETON_SKULL);
+				break;
+			case GIANT:
+			case ZOMBIE:
+				itemStack = new ItemStack(Material.ZOMBIE_HEAD);
+				break;
+			case CREEPER:
+				itemStack = new ItemStack(Material.CREEPER_HEAD);
+				break;
+			case ENDER_DRAGON:
+				itemStack = new ItemStack(Material.DRAGON_HEAD);
+				break;
+			default:
+				HeadLib head = HeadLib.getHead(entity.name());
+
+				if (head == null)
+				{
+					itemStack = new ItemStack(Material.BARRIER);
+				}
+				else
+				{
+					itemStack = head.toItemStack(this.requiredEntities.get(entity));
+				}
+				break;
+		}
+
+		return itemStack;
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Enums
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * Functional buttons in current GUI.
+	 */
+	private enum Button
+	{
+		ADD,
+		REMOVE
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
+
+	/**
+	 * List with entities to avoid list irregularities.
+	 */
+	private List<EntityType> entityList;
+
+	/**
+	 * Set with entities that are selected.
+	 */
+	private Set<EntityType> selectedEntities;
+
+	/**
+	 * Map that contains all entities and their cound.
+	 */
+	private Map<EntityType, Integer> requiredEntities;
+
+	/**
+	 * Boolean indicate if entities should be displayed as eggs or mob heads.
+	 */
+	private boolean asEggs;
+}

--- a/src/main/java/world/bentobox/challenges/panel/admin/ManageEntitiesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ManageEntitiesGUI.java
@@ -79,7 +79,8 @@ public class ManageEntitiesGUI extends CommonGUI
 		int index = 10;
 
 		while (entitiesIndex < ((this.pageIndex + 1) * MAX_ELEMENTS) &&
-			entitiesIndex < this.entityList.size())
+			entitiesIndex < this.entityList.size() &&
+			index < 26)
 		{
 			if (!panelBuilder.slotOccupied(index))
 			{

--- a/src/main/java/world/bentobox/challenges/panel/admin/ManageEntitiesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ManageEntitiesGUI.java
@@ -16,7 +16,7 @@ import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.util.NumberGUI;
 import world.bentobox.challenges.panel.util.SelectEntityGUI;
-import world.bentobox.challenges.utils.HeadLib;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -57,7 +57,7 @@ public class ManageEntitiesGUI extends CommonGUI
 			name(this.user.getTranslation("challenges.gui.admin.edit-entities"));
 
 		// create border
-		this.fillBorder(panelBuilder);
+		GuiUtils.fillBorder(panelBuilder);
 
 		panelBuilder.item(3, this.createButton(Button.ADD));
 		panelBuilder.item(5, this.createButton(Button.REMOVE));
@@ -158,7 +158,9 @@ public class ManageEntitiesGUI extends CommonGUI
 	{
 		return new PanelItemBuilder().
 			name(WordUtils.capitalize(entity.name().toLowerCase().replace("_", " "))).
-			icon(this.asEggs ? this.getEntityEgg(entity) : this.getEntityHead(entity)).
+			icon(this.asEggs ?
+				GuiUtils.getEntityEgg(entity, this.requiredEntities.get(entity)) :
+				GuiUtils.getEntityHead(entity, this.requiredEntities.get(entity))).
 			clickHandler((panel, user1, clickType, slot) -> {
 				// On right click change which entities are selected for deletion.
 				if (clickType.isRightClick())
@@ -187,115 +189,6 @@ public class ManageEntitiesGUI extends CommonGUI
 			}).
 			glow(this.selectedEntities.contains(entity)).
 			build();
-	}
-
-
-	/**
-	 * This method transforms entity into egg or block that corresponds given entity. If entity egg is not
-	 * found, then it is replaced by block that represents entity or barrier block.
-	 * @param entity Entity which egg must be returned.
-	 * @return ItemStack that may be egg for given entity.
-	 */
-	private ItemStack getEntityEgg(EntityType entity)
-	{
-		ItemStack itemStack;
-
-		switch (entity)
-		{
-			case PIG_ZOMBIE:
-				itemStack = new ItemStack(Material.ZOMBIE_PIGMAN_SPAWN_EGG);
-				break;
-			case ENDER_DRAGON:
-				itemStack = new ItemStack(Material.DRAGON_EGG);
-				break;
-			case WITHER:
-				itemStack = new ItemStack(Material.SOUL_SAND);
-				break;
-			case PLAYER:
-				itemStack = new ItemStack(Material.PLAYER_HEAD);
-				break;
-			case MUSHROOM_COW:
-				itemStack = new ItemStack(Material.MOOSHROOM_SPAWN_EGG);
-				break;
-			case SNOWMAN:
-				itemStack = new ItemStack(Material.CARVED_PUMPKIN);
-				break;
-			case IRON_GOLEM:
-				itemStack = new ItemStack(Material.IRON_BLOCK);
-				break;
-			case ARMOR_STAND:
-				itemStack = new ItemStack(Material.ARMOR_STAND);
-				break;
-			default:
-				Material material = Material.getMaterial(entity.name() + "_SPAWN_EGG");
-
-				if (material == null)
-				{
-					itemStack = new ItemStack(Material.BARRIER);
-				}
-				else
-				{
-					itemStack = new ItemStack(material);
-				}
-
-				break;
-		}
-
-		itemStack.setAmount(this.requiredEntities.get(entity));
-
-		return itemStack;
-	}
-
-
-	/**
-	 * This method transforms entity into player head with skin that corresponds given entity. If entity head
-	 * is not found, then it is replaced by barrier block.
-	 * @param entity Entity which head must be returned.
-	 * @return ItemStack that may be head for given entity.
-	 */
-	private ItemStack getEntityHead(EntityType entity)
-	{
-		ItemStack itemStack;
-
-		switch (entity)
-		{
-			case PLAYER:
-				itemStack = new ItemStack(Material.PLAYER_HEAD);
-				break;
-			case WITHER_SKELETON:
-				itemStack = new ItemStack(Material.WITHER_SKELETON_SKULL);
-				break;
-			case ARMOR_STAND:
-				itemStack = new ItemStack(Material.ARMOR_STAND);
-				break;
-			case SKELETON:
-				itemStack = new ItemStack(Material.SKELETON_SKULL);
-				break;
-			case GIANT:
-			case ZOMBIE:
-				itemStack = new ItemStack(Material.ZOMBIE_HEAD);
-				break;
-			case CREEPER:
-				itemStack = new ItemStack(Material.CREEPER_HEAD);
-				break;
-			case ENDER_DRAGON:
-				itemStack = new ItemStack(Material.DRAGON_HEAD);
-				break;
-			default:
-				HeadLib head = HeadLib.getHead(entity.name());
-
-				if (head == null)
-				{
-					itemStack = new ItemStack(Material.BARRIER);
-				}
-				else
-				{
-					itemStack = head.toItemStack(this.requiredEntities.get(entity));
-				}
-				break;
-		}
-
-		return itemStack;
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/ManageEntitiesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ManageEntitiesGUI.java
@@ -139,6 +139,7 @@ public class ManageEntitiesGUI extends CommonGUI
 				builder.clickHandler((panel, user1, clickType, slot) -> {
 					this.requiredEntities.keySet().removeAll(this.selectedEntities);
 					this.entityList.removeAll(this.selectedEntities);
+					this.build();
 					return true;
 				});
 				break;

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
@@ -48,7 +48,18 @@ public class ChallengesGUI extends CommonGUI
 		this.challengesManager = this.addon.getChallengesManager();
 
 		this.levelStatusList = this.challengesManager.getChallengeLevelStatus(this.user, this.world);
-		this.lastSelectedLevel = this.levelStatusList.get(0);
+
+		for (int i = 0; i < this.levelStatusList.size(); i++)
+		{
+			if (this.levelStatusList.get(i).isUnlocked())
+			{
+				this.lastSelectedLevel = this.levelStatusList.get(i);
+			}
+			else
+			{
+				break;
+			}
+		}
 	}
 
 // ---------------------------------------------------------------------
@@ -172,55 +183,58 @@ public class ChallengesGUI extends CommonGUI
 	 */
 	private void addChallenges(PanelBuilder panelBuilder)
 	{
-		List<Challenges> challenges = this.challengesManager.getChallenges(this.lastSelectedLevel.getLevel());
-		final int challengesCount = challenges.size();
-
-		if (challengesCount > 18)
+		if (this.lastSelectedLevel != null)
 		{
-			int firstIndex = panelBuilder.nextSlot();
+			List<Challenges> challenges = this.challengesManager.getChallenges(this.lastSelectedLevel.getLevel());
+			final int challengesCount = challenges.size();
 
-			if (this.pageIndex > 0)
+			if (challengesCount > 18)
 			{
-				panelBuilder.item(new PanelItemBuilder().
-					icon(Material.SIGN).
-					name("Previous").
-					clickHandler((panel, user1, clickType, slot) -> {
-						this.pageIndex--;
-						this.build();
-						return true;
-					}).build());
-			}
+				int firstIndex = panelBuilder.nextSlot();
 
-			int currentIndex = this.pageIndex;
+				if (this.pageIndex > 0)
+				{
+					panelBuilder.item(new PanelItemBuilder().
+						icon(Material.SIGN).
+						name("Previous").
+						clickHandler((panel, user1, clickType, slot) -> {
+							this.pageIndex--;
+							this.build();
+							return true;
+						}).build());
+				}
 
-			while (panelBuilder.nextSlot() != firstIndex + 18 && currentIndex < challengesCount)
-			{
-				panelBuilder.item(this.getChallengeButton(challenges.get(currentIndex++)));
-			}
+				int currentIndex = this.pageIndex;
 
-			// Check if one challenge is left
-			if (currentIndex + 1 == challengesCount)
-			{
-				panelBuilder.item(this.getChallengeButton(challenges.get(currentIndex)));
+				while (panelBuilder.nextSlot() != firstIndex + 18 && currentIndex < challengesCount)
+				{
+					panelBuilder.item(this.getChallengeButton(challenges.get(currentIndex++)));
+				}
+
+				// Check if one challenge is left
+				if (currentIndex + 1 == challengesCount)
+				{
+					panelBuilder.item(this.getChallengeButton(challenges.get(currentIndex)));
+				}
+				else if (currentIndex < challengesCount)
+				{
+					panelBuilder.item(new PanelItemBuilder().
+						icon(Material.SIGN).
+						name("Next").
+						clickHandler((panel, user1, clickType, slot) -> {
+							this.pageIndex++;
+							this.build();
+							return true;
+						}).build());
+				}
 			}
-			else if (currentIndex < challengesCount)
+			else
 			{
-				panelBuilder.item(new PanelItemBuilder().
-					icon(Material.SIGN).
-					name("Next").
-					clickHandler((panel, user1, clickType, slot) -> {
-						this.pageIndex++;
-						this.build();
-						return true;
-					}).build());
-			}
-		}
-		else
-		{
-			for (Challenges challenge : challenges)
-			{
-				// there are no limitations. Just bunch insert.
-				panelBuilder.item(this.getChallengeButton(challenge));
+				for (Challenges challenge : challenges)
+				{
+					// there are no limitations. Just bunch insert.
+					panelBuilder.item(this.getChallengeButton(challenge));
+				}
 			}
 		}
 	}
@@ -497,13 +511,10 @@ public class ChallengesGUI extends CommonGUI
 		{
 			icon = new ItemStack(Material.BOOK);
 
-			// This should be safe as first level always should be unlocked.
-			LevelStatus previousLevel = this.levelStatusList.get(this.levelStatusList.indexOf(level) - 1);
-
 			description = Collections.singletonList(
 				this.user.getTranslation("challenges.to-complete",
-					"[challengesToDo]", Integer.toString(previousLevel.getNumberOfChallengesStillToDo()),
-					"[thisLevel]", previousLevel.getLevel().getFriendlyName()));
+					"[challengesToDo]", Integer.toString(level.getNumberOfChallengesStillToDo()),
+					"[thisLevel]", level.getPreviousLevel().getFriendlyName()));
 
 			clickHandler = null;
 		}

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
@@ -443,13 +443,13 @@ public class ChallengesGUI extends CommonGUI
 		{
 			rewardText = challenge.getRewardText();
 			rewardMoney = challenge.getRewardMoney();
-			rewardExperience = challenge.getRewardExp();
+			rewardExperience = challenge.getRewardExperience();
 		}
 		else
 		{
 			rewardText = challenge.getRepeatRewardText();
 			rewardMoney = challenge.getRepeatMoneyReward();
-			rewardExperience = challenge.getRepeatExpReward();
+			rewardExperience = challenge.getRepeatExperienceReward();
 		}
 
 		List<String> result = new ArrayList<>();

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
@@ -5,7 +5,6 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.inventory.ItemStack;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import world.bentobox.bentobox.api.panels.PanelItem;
@@ -17,6 +16,7 @@ import world.bentobox.challenges.ChallengesManager;
 import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.TryToComplete;
+import world.bentobox.challenges.utils.GuiUtils;
 import world.bentobox.challenges.utils.LevelStatus;
 
 
@@ -320,7 +320,7 @@ public class ChallengesGUI extends CommonGUI
 		return new PanelItemBuilder().
 			icon(challenge.getIcon()).
 			name(challenge.getFriendlyName().isEmpty() ? challenge.getUniqueId() : challenge.getFriendlyName()).
-			description(this.createChallengeDescription(challenge)).
+			description(GuiUtils.stringSplit(this.createChallengeDescription(challenge))).
 			clickHandler((panel, user1, clickType, slot) -> {
 				new TryToComplete(this.addon,
 					this.user,
@@ -496,8 +496,7 @@ public class ChallengesGUI extends CommonGUI
 		if (level.isUnlocked())
 		{
 			icon = level.getLevel().getIcon();
-			description = Collections.singletonList(
-				this.user.getTranslation("challenges.navigation", "[level]", name));
+			description = GuiUtils.stringSplit(this.user.getTranslation("challenges.navigation", "[level]", name));
 			clickHandler = (panel, user1, clickType, slot) -> {
 				this.lastSelectedLevel = level;
 
@@ -514,7 +513,7 @@ public class ChallengesGUI extends CommonGUI
 		{
 			icon = new ItemStack(Material.BOOK);
 
-			description = Collections.singletonList(
+			description = GuiUtils.stringSplit(
 				this.user.getTranslation("challenges.to-complete",
 					"[challengesToDo]", Integer.toString(level.getNumberOfChallengesStillToDo()),
 					"[thisLevel]", level.getPreviousLevel().getFriendlyName()));

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
@@ -123,7 +123,7 @@ public class ChallengesGUI extends CommonGUI
 	 */
 	private void addFreeChallenges(PanelBuilder panelBuilder)
 	{
-		List<Challenge> freeChallenges = this.challengesManager.getFreeChallenges(this.user, this.world);
+		List<Challenge> freeChallenges = this.challengesManager.getFreeChallenges(this.world);
 		final int freeChallengesCount = freeChallenges.size();
 
 		if (freeChallengesCount > 18)
@@ -185,7 +185,7 @@ public class ChallengesGUI extends CommonGUI
 	{
 		if (this.lastSelectedLevel != null)
 		{
-			List<Challenge> challenges = this.challengesManager.getChallenges(this.lastSelectedLevel.getLevel());
+			List<Challenge> challenges = this.challengesManager.getLevelChallenges(this.lastSelectedLevel.getLevel());
 			final int challengesCount = challenges.size();
 
 			if (challengesCount > 18)
@@ -346,7 +346,7 @@ public class ChallengesGUI extends CommonGUI
 		List<String> result = new ArrayList<>();
 
 		result.add(this.user.getTranslation("challenges.level",
-			"[level]", this.challengesManager.getChallengesLevel(challenge)));
+			"[level]", this.challengesManager.getLevel(challenge).getFriendlyName()));
 
 		boolean completed = this.challengesManager.isChallengeComplete(this.user, challenge);
 
@@ -358,7 +358,7 @@ public class ChallengesGUI extends CommonGUI
 		if (challenge.isRepeatable())
 		{
 			int maxTimes = challenge.getMaxTimes();
-			long doneTimes = this.challengesManager.checkChallengeTimes(this.user, challenge);
+			long doneTimes = this.challengesManager.getChallengeTimes(this.user, challenge);
 
 			if (maxTimes > 0)
 			{

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
@@ -49,11 +49,11 @@ public class ChallengesGUI extends CommonGUI
 
 		this.levelStatusList = this.challengesManager.getChallengeLevelStatus(this.user, this.world);
 
-		for (int i = 0; i < this.levelStatusList.size(); i++)
+		for (LevelStatus levelStatus : this.levelStatusList)
 		{
-			if (this.levelStatusList.get(i).isUnlocked())
+			if (levelStatus.isUnlocked())
 			{
-				this.lastSelectedLevel = this.levelStatusList.get(i);
+				this.lastSelectedLevel = levelStatus;
 			}
 			else
 			{
@@ -491,6 +491,7 @@ public class ChallengesGUI extends CommonGUI
 		ItemStack icon;
 		List<String> description;
 		PanelItem.ClickHandler clickHandler;
+		boolean glow;
 
 		if (level.isUnlocked())
 		{
@@ -507,6 +508,7 @@ public class ChallengesGUI extends CommonGUI
 				this.build();
 				return true;
 			};
+			glow = this.challengesManager.isLevelCompleted(this.user, level.getLevel());
 		}
 		else
 		{
@@ -518,9 +520,10 @@ public class ChallengesGUI extends CommonGUI
 					"[thisLevel]", level.getPreviousLevel().getFriendlyName()));
 
 			clickHandler = null;
+			glow = false;
 		}
 
-		return new PanelItem(icon, name, description, false, clickHandler, false);
+		return new PanelItem(icon, name, description, glow, clickHandler, false);
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
@@ -15,7 +15,7 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.ChallengesManager;
 import world.bentobox.challenges.LevelStatus;
-import world.bentobox.challenges.database.object.Challenges;
+import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.TryToComplete;
 
@@ -123,7 +123,7 @@ public class ChallengesGUI extends CommonGUI
 	 */
 	private void addFreeChallenges(PanelBuilder panelBuilder)
 	{
-		List<Challenges> freeChallenges = this.challengesManager.getFreeChallenges(this.user, this.world);
+		List<Challenge> freeChallenges = this.challengesManager.getFreeChallenges(this.user, this.world);
 		final int freeChallengesCount = freeChallenges.size();
 
 		if (freeChallengesCount > 18)
@@ -168,7 +168,7 @@ public class ChallengesGUI extends CommonGUI
 		}
 		else
 		{
-			for (Challenges challenge : freeChallenges)
+			for (Challenge challenge : freeChallenges)
 			{
 				// there are no limitations. Just bunch insert.
 				panelBuilder.item(this.getChallengeButton(challenge));
@@ -185,7 +185,7 @@ public class ChallengesGUI extends CommonGUI
 	{
 		if (this.lastSelectedLevel != null)
 		{
-			List<Challenges> challenges = this.challengesManager.getChallenges(this.lastSelectedLevel.getLevel());
+			List<Challenge> challenges = this.challengesManager.getChallenges(this.lastSelectedLevel.getLevel());
 			final int challengesCount = challenges.size();
 
 			if (challengesCount > 18)
@@ -230,7 +230,7 @@ public class ChallengesGUI extends CommonGUI
 			}
 			else
 			{
-				for (Challenges challenge : challenges)
+				for (Challenge challenge : challenges)
 				{
 					// there are no limitations. Just bunch insert.
 					panelBuilder.item(this.getChallengeButton(challenge));
@@ -315,7 +315,7 @@ public class ChallengesGUI extends CommonGUI
 	 * @param challenge which icon must be constructed.
 	 * @return PanelItem icon for challenge.
 	 */
-	private PanelItem getChallengeButton(Challenges challenge)
+	private PanelItem getChallengeButton(Challenge challenge)
 	{
 		return new PanelItemBuilder().
 			icon(challenge.getIcon()).
@@ -341,7 +341,7 @@ public class ChallengesGUI extends CommonGUI
 	 * @param challenge Which information must be retrieved.
 	 * @return List with strings that contains information about given challenge.
 	 */
-	private List<String> createChallengeDescription(Challenges challenge)
+	private List<String> createChallengeDescription(Challenge challenge)
 	{
 		List<String> result = new ArrayList<>();
 
@@ -392,14 +392,14 @@ public class ChallengesGUI extends CommonGUI
 		{
 			result.addAll(challenge.getDescription());
 
-			if (challenge.getChallengeType().equals(Challenges.ChallengeType.INVENTORY))
+			if (challenge.getChallengeType().equals(Challenge.ChallengeType.INVENTORY))
 			{
 				if (challenge.isTakeItems())
 				{
 					result.add(this.user.getTranslation("challenges.item-take-warning"));
 				}
 			}
-			else if (challenge.getChallengeType().equals(Challenges.ChallengeType.ISLAND))
+			else if (challenge.getChallengeType().equals(Challenge.ChallengeType.ISLAND))
 			{
 				result.add(this.user.getTranslation("challenges.items-closeby"));
 
@@ -433,7 +433,7 @@ public class ChallengesGUI extends CommonGUI
 	 * @param challenge which reward message must be created.
 	 * @return list of strings that contains rewards message.
 	 */
-	private List<String> challengeRewards(Challenges challenge)
+	private List<String> challengeRewards(Challenge challenge)
 	{
 		String rewardText;
 		double rewardMoney;

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
@@ -1,0 +1,543 @@
+package world.bentobox.challenges.panel.user;
+
+
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.inventory.ItemStack;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.ChallengesAddon;
+import world.bentobox.challenges.ChallengesManager;
+import world.bentobox.challenges.LevelStatus;
+import world.bentobox.challenges.database.object.Challenges;
+import world.bentobox.challenges.panel.CommonGUI;
+import world.bentobox.challenges.panel.TryToComplete;
+
+
+/**
+ * This is UserGUI class. It contains everything necessary for user to use it.
+ */
+public class ChallengesGUI extends CommonGUI
+{
+// ---------------------------------------------------------------------
+// Section: Constructors
+// ---------------------------------------------------------------------
+
+	/**
+	 * Default constructor that inits panels with minimal requirements, without parent panel.
+	 *
+	 * @param addon Addon where panel operates.
+	 * @param world World from which panel was created.
+	 * @param user User who created panel.
+	 * @param topLabel Command top label which creates panel (f.e. island or ai)
+	 * @param permissionPrefix Command permission prefix (f.e. bskyblock.)
+	 */
+	public ChallengesGUI(ChallengesAddon addon,
+		World world,
+		User user,
+		String topLabel,
+		String permissionPrefix)
+	{
+		super(addon, world, user, topLabel, permissionPrefix);
+		this.challengesManager = this.addon.getChallengesManager();
+
+		this.levelStatusList = this.challengesManager.getChallengeLevelStatus(this.user, this.world);
+		this.lastSelectedLevel = this.levelStatusList.get(0);
+	}
+
+// ---------------------------------------------------------------------
+// Section: Methods
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * This method builds all necessary elements in GUI panel.
+	 */
+	@Override
+	public void build()
+	{
+		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).
+			name(this.user.getTranslation("challenges.gui.title"));
+
+		// TODO: get last completed level.
+
+		if (this.addon.getChallengesSettings().isFreeChallengesFirst())
+		{
+			this.addFreeChallenges(panelBuilder);
+
+			// Start new row for challenges.
+			while (panelBuilder.nextSlot() % 9 != 0)
+			{
+				panelBuilder.item(
+					new PanelItemBuilder().icon(Material.LIGHT_GRAY_STAINED_GLASS_PANE).name(" ").build());
+			}
+		}
+
+		this.addChallenges(panelBuilder);
+
+		// Start new row for levels.
+		while (panelBuilder.nextSlot() % 9 != 0)
+		{
+			panelBuilder.item(
+				new PanelItemBuilder().icon(Material.LIGHT_GRAY_STAINED_GLASS_PANE).name(" ").build());
+		}
+
+		this.addChallengeLevels(panelBuilder);
+
+		if (!this.addon.getChallengesSettings().isFreeChallengesFirst())
+		{
+			// Start new row for free challenges.
+			while (panelBuilder.nextSlot() % 9 != 0)
+			{
+				panelBuilder.item(
+					new PanelItemBuilder().icon(Material.LIGHT_GRAY_STAINED_GLASS_PANE).name(" ").build());
+			}
+
+			this.addFreeChallenges(panelBuilder);
+		}
+
+		panelBuilder.build();
+	}
+
+
+	/**
+	 * This method adds free challenges to panelBuilder.
+	 * @param panelBuilder where free challenges must be added.
+	 */
+	private void addFreeChallenges(PanelBuilder panelBuilder)
+	{
+		List<Challenges> freeChallenges = this.challengesManager.getFreeChallenges(this.user, this.world);
+		final int freeChallengesCount = freeChallenges.size();
+
+		if (freeChallengesCount > 18)
+		{
+			int firstIndex = panelBuilder.nextSlot();
+
+			if (this.freeChallengeIndex > 0)
+			{
+				panelBuilder.item(new PanelItemBuilder().
+					icon(Material.SIGN).
+					name("Previous").
+					clickHandler((panel, user1, clickType, slot) -> {
+						this.freeChallengeIndex--;
+						this.build();
+						return true;
+					}).build());
+			}
+
+			int currentIndex = this.freeChallengeIndex;
+
+			while (panelBuilder.nextSlot() != firstIndex + 18 && currentIndex < freeChallengesCount)
+			{
+				panelBuilder.item(this.getChallengeButton(freeChallenges.get(currentIndex++)));
+			}
+
+			// Check if one challenge is left
+			if (currentIndex + 1 == freeChallengesCount)
+			{
+				panelBuilder.item(this.getChallengeButton(freeChallenges.get(currentIndex)));
+			}
+			else if (currentIndex < freeChallengesCount)
+			{
+				panelBuilder.item(new PanelItemBuilder().
+					icon(Material.SIGN).
+					name("Next").
+					clickHandler((panel, user1, clickType, slot) -> {
+						this.freeChallengeIndex++;
+						this.build();
+						return true;
+					}).build());
+			}
+		}
+		else
+		{
+			for (Challenges challenge : freeChallenges)
+			{
+				// there are no limitations. Just bunch insert.
+				panelBuilder.item(this.getChallengeButton(challenge));
+			}
+		}
+	}
+
+
+	/**
+	 * This method adds last selected level challenges to panelBuilder.
+	 * @param panelBuilder where last selected level challenges must be added.
+	 */
+	private void addChallenges(PanelBuilder panelBuilder)
+	{
+		List<Challenges> challenges = this.challengesManager.getChallenges(this.lastSelectedLevel.getLevel());
+		final int challengesCount = challenges.size();
+
+		if (challengesCount > 18)
+		{
+			int firstIndex = panelBuilder.nextSlot();
+
+			if (this.pageIndex > 0)
+			{
+				panelBuilder.item(new PanelItemBuilder().
+					icon(Material.SIGN).
+					name("Previous").
+					clickHandler((panel, user1, clickType, slot) -> {
+						this.pageIndex--;
+						this.build();
+						return true;
+					}).build());
+			}
+
+			int currentIndex = this.pageIndex;
+
+			while (panelBuilder.nextSlot() != firstIndex + 18 && currentIndex < challengesCount)
+			{
+				panelBuilder.item(this.getChallengeButton(challenges.get(currentIndex++)));
+			}
+
+			// Check if one challenge is left
+			if (currentIndex + 1 == challengesCount)
+			{
+				panelBuilder.item(this.getChallengeButton(challenges.get(currentIndex)));
+			}
+			else if (currentIndex < challengesCount)
+			{
+				panelBuilder.item(new PanelItemBuilder().
+					icon(Material.SIGN).
+					name("Next").
+					clickHandler((panel, user1, clickType, slot) -> {
+						this.pageIndex++;
+						this.build();
+						return true;
+					}).build());
+			}
+		}
+		else
+		{
+			for (Challenges challenge : challenges)
+			{
+				// there are no limitations. Just bunch insert.
+				panelBuilder.item(this.getChallengeButton(challenge));
+			}
+		}
+	}
+
+
+	/**
+	 * This method adds challenge levels to panelBuilder.
+	 * @param panelBuilder where challenge levels must be added.
+	 */
+	private void addChallengeLevels(PanelBuilder panelBuilder)
+	{
+		// Clone to avoid creating new level on each build.
+		List<LevelStatus> leftLevels = new ArrayList<>(this.levelStatusList);
+		leftLevels.remove(this.lastSelectedLevel);
+
+		// TODO: Focusing on middle should be awsome.
+
+		final int levelCounts = leftLevels.size();
+
+		if (levelCounts > 9)
+		{
+			int firstIndex = panelBuilder.nextSlot();
+
+			if (this.levelIndex > 0)
+			{
+				panelBuilder.item(new PanelItemBuilder().
+					icon(Material.SIGN).
+					name("Previous").
+					clickHandler((panel, user1, clickType, slot) -> {
+						this.levelIndex--;
+						this.build();
+						return true;
+					}).build());
+			}
+
+			int currentIndex = this.levelIndex;
+
+			while (panelBuilder.nextSlot() != firstIndex + 9 && currentIndex < levelCounts)
+			{
+				panelBuilder.item(this.getLevelButton(leftLevels.get(currentIndex++)));
+			}
+
+			// Check if one challenge is left
+			if (currentIndex + 1 == levelCounts)
+			{
+				panelBuilder.item(this.getLevelButton(leftLevels.get(currentIndex)));
+			}
+			else if (currentIndex < levelCounts)
+			{
+				panelBuilder.item(new PanelItemBuilder().
+					icon(Material.SIGN).
+					name("Next").
+					clickHandler((panel, user1, clickType, slot) -> {
+						this.levelIndex++;
+						this.build();
+						return true;
+					}).build());
+			}
+		}
+		else
+		{
+			for (LevelStatus level : leftLevels)
+			{
+				// there are no limitations. Just bunch insert.
+				panelBuilder.item(this.getLevelButton(level));
+			}
+		}
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Icon building
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * This method creates given challenges icon that on press tries to complete it.
+	 * @param challenge which icon must be constructed.
+	 * @return PanelItem icon for challenge.
+	 */
+	private PanelItem getChallengeButton(Challenges challenge)
+	{
+		return new PanelItemBuilder().
+			icon(challenge.getIcon()).
+			name(challenge.getFriendlyName().isEmpty() ? challenge.getUniqueId() : challenge.getFriendlyName()).
+			description(this.createChallengeDescription(challenge)).
+			clickHandler((panel, user1, clickType, slot) -> {
+				new TryToComplete(this.addon,
+					this.user,
+					this.challengesManager,
+					challenge,
+					this.world,
+					this.permissionPrefix,
+					this.topLabel);
+				return true;
+			}).
+			glow(this.challengesManager.isChallengeComplete(this.user, challenge)).
+			build();
+	}
+
+
+	/**
+	 * This method creates challenges description by adding all information that is necessary for this challenge.
+	 * @param challenge Which information must be retrieved.
+	 * @return List with strings that contains information about given challenge.
+	 */
+	private List<String> createChallengeDescription(Challenges challenge)
+	{
+		List<String> result = new ArrayList<>();
+
+		result.add(this.user.getTranslation("challenges.level",
+			"[level]", this.challengesManager.getChallengesLevel(challenge)));
+
+		boolean completed = this.challengesManager.isChallengeComplete(this.user, challenge);
+
+		if (completed)
+		{
+			result.add(this.user.getTranslation("challenges.complete"));
+		}
+
+		if (challenge.isRepeatable())
+		{
+			int maxTimes = challenge.getMaxTimes();
+			long doneTimes = this.challengesManager.checkChallengeTimes(this.user, challenge);
+
+			if (maxTimes > 0)
+			{
+				if (doneTimes < maxTimes)
+				{
+					result.add(this.user.getTranslation("challenges.completed-times",
+						"[donetimes]", String.valueOf(doneTimes),
+						"[maxtimes]", String.valueOf(maxTimes)));
+
+					// Change value to false, as max count not reached.
+					completed = false;
+				}
+				else
+				{
+					result.add(this.user.getTranslation("challenges.maxed-reached",
+						"[donetimes]", String.valueOf(doneTimes),
+						"[maxtimes]", String.valueOf(maxTimes)));
+				}
+			}
+			else
+			{
+				result.add(this.user.getTranslation("challenges.completed-times",
+					"[donetimes]", String.valueOf(doneTimes)));
+
+				// Change value to false, as max count not reached.
+				completed = false;
+			}
+		}
+
+		if (!completed)
+		{
+			result.addAll(challenge.getDescription());
+
+			if (challenge.getChallengeType().equals(Challenges.ChallengeType.INVENTORY))
+			{
+				if (challenge.isTakeItems())
+				{
+					result.add(this.user.getTranslation("challenges.item-take-warning"));
+				}
+			}
+			else if (challenge.getChallengeType().equals(Challenges.ChallengeType.ISLAND))
+			{
+				result.add(this.user.getTranslation("challenges.items-closeby"));
+
+				if (challenge.isRemoveEntities() && !challenge.getRequiredEntities().isEmpty())
+				{
+					result.add(this.user.getTranslation("challenges.entities-kill-warning"));
+				}
+
+				if (challenge.isRemoveBlocks() && !challenge.getRequiredBlocks().isEmpty())
+				{
+					result.add(this.user.getTranslation("challenges.blocks-take-warning"));
+				}
+			}
+		}
+
+		if (completed)
+		{
+			result.add(this.user.getTranslation("challenges.not-repeatable"));
+		}
+		else
+		{
+			result.addAll(this.challengeRewards(challenge));
+		}
+
+		return result;
+	}
+
+
+	/**
+	 * This method returns list of strings that contains basic information about challenge rewards.
+	 * @param challenge which reward message must be created.
+	 * @return list of strings that contains rewards message.
+	 */
+	private List<String> challengeRewards(Challenges challenge)
+	{
+		String rewardText;
+		double rewardMoney;
+		int rewardExperience;
+
+		if (!this.challengesManager.isChallengeComplete(this.user, challenge))
+		{
+			rewardText = challenge.getRewardText();
+			rewardMoney = challenge.getRewardMoney();
+			rewardExperience = challenge.getRewardExp();
+		}
+		else
+		{
+			rewardText = challenge.getRepeatRewardText();
+			rewardMoney = challenge.getRepeatMoneyReward();
+			rewardExperience = challenge.getRepeatExpReward();
+		}
+
+		List<String> result = new ArrayList<>();
+
+		// Add reward text
+		result.add(rewardText);
+
+		// Add message about reward XP
+		if (rewardExperience > 0)
+		{
+			result.add(this.user.getTranslation("challenges.exp-reward",
+				"[reward]", Integer.toString(rewardExperience)));
+		}
+
+		// Add message about reward money
+		if (this.addon.getPlugin().getSettings().isUseEconomy() && rewardMoney > 0)
+		{
+			result.add(this.user.getTranslation("challenges.money-reward",
+				"[reward]", Double.toString(rewardMoney)));
+		}
+
+		return result;
+	}
+
+
+	/**
+	 * This method creates button for given level.
+	 * @param level which button must be created.
+	 * @return Button for given level.
+	 */
+	private PanelItem getLevelButton(LevelStatus level)
+	{
+		// Create a nice name for the level
+		String name = level.getLevel().getFriendlyName().isEmpty() ?
+			level.getLevel().getUniqueId() :
+			level.getLevel().getFriendlyName();
+
+		ItemStack icon;
+		List<String> description;
+		PanelItem.ClickHandler clickHandler;
+
+		if (level.isUnlocked())
+		{
+			icon = level.getLevel().getIcon();
+			description = Collections.singletonList(
+				this.user.getTranslation("challenges.navigation", "[level]", name));
+			clickHandler = (panel, user1, clickType, slot) -> {
+				this.lastSelectedLevel = level;
+
+				// Reset level and page index.
+				this.levelIndex = 0;
+				this.pageIndex = 0;
+
+				this.build();
+				return true;
+			};
+		}
+		else
+		{
+			icon = new ItemStack(Material.BOOK);
+
+			// This should be safe as first level always should be unlocked.
+			LevelStatus previousLevel = this.levelStatusList.get(this.levelStatusList.indexOf(level) - 1);
+
+			description = Collections.singletonList(
+				this.user.getTranslation("challenges.to-complete",
+					"[challengesToDo]", Integer.toString(previousLevel.getNumberOfChallengesStillToDo()),
+					"[thisLevel]", previousLevel.getLevel().getFriendlyName()));
+
+			clickHandler = null;
+		}
+
+		return new PanelItem(icon, name, description, false, clickHandler, false);
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
+
+	/**
+	 * This will be used if free challenges are more then 18.
+	 */
+	private int freeChallengeIndex = 0;
+
+	/**
+	 * This will be used if levels are more then 9.
+	 */
+	private int levelIndex;
+
+	/**
+	 * This list contains all information about level completion in current world.
+	 */
+	private List<LevelStatus> levelStatusList;
+
+	/**
+	 * This indicate last selected level.
+	 */
+	private LevelStatus lastSelectedLevel;
+
+	/**
+	 * Challenge Manager object.
+	 */
+	private ChallengesManager challengesManager;
+}

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
@@ -134,7 +134,7 @@ public class ChallengesGUI extends CommonGUI
 			{
 				panelBuilder.item(new PanelItemBuilder().
 					icon(Material.SIGN).
-					name("Previous").
+					name(this.user.getTranslation("challenges.gui.buttons.previous")).
 					clickHandler((panel, user1, clickType, slot) -> {
 						this.freeChallengeIndex--;
 						this.build();
@@ -158,7 +158,7 @@ public class ChallengesGUI extends CommonGUI
 			{
 				panelBuilder.item(new PanelItemBuilder().
 					icon(Material.SIGN).
-					name("Next").
+					name(this.user.getTranslation("challenges.gui.buttons.next")).
 					clickHandler((panel, user1, clickType, slot) -> {
 						this.freeChallengeIndex++;
 						this.build();
@@ -196,7 +196,7 @@ public class ChallengesGUI extends CommonGUI
 				{
 					panelBuilder.item(new PanelItemBuilder().
 						icon(Material.SIGN).
-						name("Previous").
+						name(this.user.getTranslation("challenges.gui.buttons.previous")).
 						clickHandler((panel, user1, clickType, slot) -> {
 							this.pageIndex--;
 							this.build();
@@ -220,7 +220,7 @@ public class ChallengesGUI extends CommonGUI
 				{
 					panelBuilder.item(new PanelItemBuilder().
 						icon(Material.SIGN).
-						name("Next").
+						name(this.user.getTranslation("challenges.gui.buttons.next")).
 						clickHandler((panel, user1, clickType, slot) -> {
 							this.pageIndex++;
 							this.build();
@@ -262,7 +262,7 @@ public class ChallengesGUI extends CommonGUI
 			{
 				panelBuilder.item(new PanelItemBuilder().
 					icon(Material.SIGN).
-					name("Previous").
+					name(this.user.getTranslation("challenges.gui.buttons.previous")).
 					clickHandler((panel, user1, clickType, slot) -> {
 						this.levelIndex--;
 						this.build();
@@ -286,7 +286,7 @@ public class ChallengesGUI extends CommonGUI
 			{
 				panelBuilder.item(new PanelItemBuilder().
 					icon(Material.SIGN).
-					name("Next").
+					name(this.user.getTranslation("challenges.gui.buttons.next")).
 					clickHandler((panel, user1, clickType, slot) -> {
 						this.levelIndex++;
 						this.build();

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
@@ -14,7 +14,7 @@ import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.ChallengesManager;
-import world.bentobox.challenges.LevelStatus;
+import world.bentobox.challenges.utils.LevelStatus;
 import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.TryToComplete;

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
@@ -424,6 +424,8 @@ public class ChallengesGUI extends CommonGUI
 			result.addAll(this.challengeRewards(challenge));
 		}
 
+		result.replaceAll(x -> x.replace("[label]", this.topLabel));
+
 		return result;
 	}
 

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesGUI.java
@@ -14,10 +14,10 @@ import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.ChallengesManager;
-import world.bentobox.challenges.utils.LevelStatus;
 import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.challenges.panel.CommonGUI;
 import world.bentobox.challenges.panel.TryToComplete;
+import world.bentobox.challenges.utils.LevelStatus;
 
 
 /**
@@ -324,11 +324,10 @@ public class ChallengesGUI extends CommonGUI
 			clickHandler((panel, user1, clickType, slot) -> {
 				new TryToComplete(this.addon,
 					this.user,
-					this.challengesManager,
 					challenge,
 					this.world,
-					this.permissionPrefix,
-					this.topLabel);
+					this.topLabel,
+					this.permissionPrefix);
 				return true;
 			}).
 			glow(this.challengesManager.isChallengeComplete(this.user, challenge)).

--- a/src/main/java/world/bentobox/challenges/panel/util/ConfirmationGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/ConfirmationGUI.java
@@ -5,9 +5,11 @@ import org.bukkit.Material;
 
 import java.util.function.Consumer;
 
+import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -37,25 +39,62 @@ public class ConfirmationGUI
 	{
 		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(this.user.getTranslation("challenges.gui.admin.confirm-title"));
 
-		panelBuilder.item(3, new PanelItemBuilder().
-			name(this.user.getTranslation("challenges.gui.admin.buttons.proceed")).
-			icon(Material.GREEN_STAINED_GLASS_PANE).
-			clickHandler((panel, user1, clickType, index) -> {
-				this.consumer.accept(true);
-				return true;
-			}).
-			build());
+		GuiUtils.fillBorder(panelBuilder, Material.BLUE_STAINED_GLASS_PANE);
 
-		panelBuilder.item(5, new PanelItemBuilder().
-			name(this.user.getTranslation("challenges.gui.admin.buttons.cancel")).
-			icon(Material.RED_STAINED_GLASS_PANE).
-			clickHandler((panel, user1, clickType, i) -> {
-				this.consumer.accept(false);
-				return true;
-			}).
-			build());
+		// Accept buttons
+		panelBuilder.item(10, this.getButton(true));
+		panelBuilder.item(11, this.getButton(true));
+		panelBuilder.item(12, this.getButton(true));
+
+		panelBuilder.item(19, this.getButton(true));
+		panelBuilder.item(20, this.getButton(true));
+		panelBuilder.item(21, this.getButton(true));
+
+		panelBuilder.item(28, this.getButton(true));
+		panelBuilder.item(29, this.getButton(true));
+		panelBuilder.item(30, this.getButton(true));
+
+		// Cancel Buttons
+		panelBuilder.item(14, this.getButton(false));
+		panelBuilder.item(15, this.getButton(false));
+		panelBuilder.item(16, this.getButton(false));
+
+		panelBuilder.item(23, this.getButton(false));
+		panelBuilder.item(24, this.getButton(false));
+		panelBuilder.item(25, this.getButton(false));
+
+		panelBuilder.item(32, this.getButton(false));
+		panelBuilder.item(33, this.getButton(false));
+		panelBuilder.item(34, this.getButton(false));
+
+		panelBuilder.item(44,
+			new PanelItemBuilder().
+				icon(Material.OAK_DOOR).
+				name(this.user.getTranslation("challenges.gui.buttons.return")).
+				clickHandler( (panel, user1, clickType, slot) -> {
+					this.consumer.accept(false);
+					return true;
+				}).build());
 
 		panelBuilder.build();
+	}
+
+
+	/**
+	 * This method creates button with requested value.
+	 * @param returnValue requested value
+	 * @return PanelItem button.
+	 */
+	private PanelItem getButton(boolean returnValue)
+	{
+		return new PanelItemBuilder().
+			name(this.user.getTranslation("challenges.gui.admin.buttons." + (returnValue ? "accept" : "cancel"))).
+			icon(returnValue ? Material.GRAY_STAINED_GLASS_PANE : Material.RED_STAINED_GLASS_PANE).
+			clickHandler((panel, user1, clickType, i) -> {
+				this.consumer.accept(returnValue);
+				return true;
+			}).
+			build();
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/panel/util/ItemSwitchGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/ItemSwitchGUI.java
@@ -14,6 +14,7 @@ import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.PanelListener;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -123,7 +124,7 @@ public class ItemSwitchGUI
 				return null;
 		}
 
-		return new PanelItem(icon, name, description, false, clickHandler, false);
+		return new PanelItem(icon, name, GuiUtils.stringSplit(description), false, clickHandler, false);
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/panel/util/NumberGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/NumberGUI.java
@@ -13,6 +13,7 @@ import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -54,11 +55,15 @@ public class NumberGUI
 	{
 		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(this.user.getTranslation("challenges.gui.edit-number-title"));
 
+		GuiUtils.fillBorder(panelBuilder);
+
 		// Others
-		panelBuilder.item(0, this.getButton(Button.SAVE));
-		panelBuilder.item(1, this.getButton(Button.VALUE));
-		panelBuilder.item(8, this.getButton(Button.CANCEL));
-		panelBuilder.item(10, this.getButton(Button.INPUT));
+		panelBuilder.item(1, this.getButton(Button.SAVE));
+
+		panelBuilder.item(19, this.getButton(Button.VALUE));
+		panelBuilder.item(44, this.getButton(Button.CANCEL));
+
+		panelBuilder.item(2, this.getButton(Button.INPUT));
 
 		// operations
 		panelBuilder.item(3, this.getButton(Button.SET));
@@ -67,23 +72,23 @@ public class NumberGUI
 		panelBuilder.item(6, this.getButton(Button.MULTIPLY));
 
 		// Numbers
-		panelBuilder.item(20, this.createNumberButton(1));
-		panelBuilder.item(21, this.createNumberButton(10));
-		panelBuilder.item(22, this.createNumberButton(100));
-		panelBuilder.item(23, this.createNumberButton(1000));
-		panelBuilder.item(24, this.createNumberButton(10000));
+		panelBuilder.item(11, this.createNumberButton(1));
+		panelBuilder.item(12, this.createNumberButton(10));
+		panelBuilder.item(13, this.createNumberButton(100));
+		panelBuilder.item(14, this.createNumberButton(1000));
+		panelBuilder.item(15, this.createNumberButton(10000));
 
-		panelBuilder.item(29, this.createNumberButton(2));
-		panelBuilder.item(30, this.createNumberButton(20));
-		panelBuilder.item(31, this.createNumberButton(200));
-		panelBuilder.item(32, this.createNumberButton(2000));
-		panelBuilder.item(33, this.createNumberButton(20000));
+		panelBuilder.item(20, this.createNumberButton(2));
+		panelBuilder.item(21, this.createNumberButton(20));
+		panelBuilder.item(22, this.createNumberButton(200));
+		panelBuilder.item(23, this.createNumberButton(2000));
+		panelBuilder.item(24, this.createNumberButton(20000));
 
-		panelBuilder.item(38, this.createNumberButton(5));
-		panelBuilder.item(39, this.createNumberButton(50));
-		panelBuilder.item(40, this.createNumberButton(500));
-		panelBuilder.item(41, this.createNumberButton(5000));
-		panelBuilder.item(42, this.createNumberButton(50000));
+		panelBuilder.item(29, this.createNumberButton(5));
+		panelBuilder.item(30, this.createNumberButton(50));
+		panelBuilder.item(31, this.createNumberButton(500));
+		panelBuilder.item(32, this.createNumberButton(5000));
+		panelBuilder.item(33, this.createNumberButton(50000));
 
 		panelBuilder.build();
 	}
@@ -120,7 +125,7 @@ public class NumberGUI
 			{
 				name = this.user.getTranslation("challenges.gui.buttons.cancel");
 				description = Collections.emptyList();
-				icon = new ItemStack(Material.IRON_DOOR);
+				icon = new ItemStack(Material.OAK_DOOR);
 				clickHandler = (panel, user, clickType, slot) -> {
 					this.consumer.accept(false, this.value);
 					return true;

--- a/src/main/java/world/bentobox/challenges/panel/util/NumberGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/NumberGUI.java
@@ -238,7 +238,7 @@ public class NumberGUI
 				return null;
 		}
 
-		return new PanelItem(icon, name, description, glow, clickHandler, false);
+		return new PanelItem(icon, name, GuiUtils.stringSplit(description), glow, clickHandler, false);
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/panel/util/NumberGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/NumberGUI.java
@@ -7,6 +7,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import net.wesjd.anvilgui.AnvilGUI;
+import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
@@ -132,21 +134,35 @@ public class NumberGUI
 				description = Collections.emptyList();
 				icon = new ItemStack(Material.ANVIL);
 				clickHandler = (panel, user, clickType, slot) -> {
-					// TODO: Build Anvil GUI for editing value.
+					new AnvilGUI(BentoBox.getInstance(),
+						this.user.getPlayer(),
+						Integer.toString(this.value),
+						(player, reply) -> {
+							try
+							{
+								this.value = Integer.parseInt(reply);
 
-					if (this.value > this.maxValue)
-					{
-						// TODO: Throw warning message.
-						this.value = this.maxValue;
-					}
+								if (this.value > this.maxValue || this.value < this.minValue)
+								{
+									this.user.sendMessage("challenges.error.not-valid-integer",
+										"[value]", reply,
+										"[min]", Integer.toString(this.minValue),
+										"[max]", Integer.toString(this.maxValue));
+								}
+								else
+								{
+									this.build();
+								}
+							}
+							catch (Exception e)
+							{
+								reply = Integer.toString(this.value);
+								this.user.sendMessage("challenges.error.not-a-integer", "[value]", reply);
+							}
 
-					if (this.value < this.minValue)
-					{
-						// TODO: Throw warning message.
-						this.value = this.minValue;
-					}
+							return reply;
+						});
 
-					this.build();
 					return true;
 				};
 				glow = false;
@@ -241,13 +257,21 @@ public class NumberGUI
 
 					if (this.value > this.maxValue)
 					{
-						// TODO: Throw warning message.
+						this.user.sendMessage("challenges.error.not-valid-integer",
+							"[value]", Integer.toString(this.value),
+							"[min]", Integer.toString(this.minValue),
+							"[max]", Integer.toString(this.maxValue));
+
 						this.value = this.maxValue;
 					}
 
 					if (this.value < this.minValue)
 					{
-						// TODO: Throw warning message.
+						this.user.sendMessage("challenges.error.not-valid-integer",
+							"[value]", Integer.toString(this.value),
+							"[min]", Integer.toString(this.minValue),
+							"[max]", Integer.toString(this.maxValue));
+
 						this.value = this.minValue;
 					}
 
@@ -266,7 +290,11 @@ public class NumberGUI
 
 					if (this.value > this.maxValue)
 					{
-						// TODO: Throw warning message.
+						this.user.sendMessage("challenges.error.not-valid-integer",
+							"[value]", Integer.toString(this.value),
+							"[min]", Integer.toString(this.minValue),
+							"[max]", Integer.toString(this.maxValue));
+
 						this.value = this.maxValue;
 					}
 
@@ -285,7 +313,11 @@ public class NumberGUI
 
 					if (this.value < this.minValue)
 					{
-						// TODO: Throw warning message.
+						this.user.sendMessage("challenges.error.not-valid-integer",
+							"[value]", Integer.toString(this.value),
+							"[min]", Integer.toString(this.minValue),
+							"[max]", Integer.toString(this.maxValue));
+
 						this.value = this.minValue;
 					}
 
@@ -304,7 +336,11 @@ public class NumberGUI
 
 					if (this.value > this.maxValue)
 					{
-						// TODO: Throw warning message.
+						this.user.sendMessage("challenges.error.not-valid-integer",
+							"[value]", Integer.toString(this.value),
+							"[min]", Integer.toString(this.minValue),
+							"[max]", Integer.toString(this.maxValue));
+
 						this.value = this.maxValue;
 					}
 

--- a/src/main/java/world/bentobox/challenges/panel/util/SelectBlocksGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SelectBlocksGUI.java
@@ -3,6 +3,7 @@ package world.bentobox.challenges.panel.util;
 
 import org.apache.commons.lang.WordUtils;
 import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -13,6 +14,7 @@ import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -144,115 +146,17 @@ public class SelectBlocksGUI
 	 */
 	private PanelItem createMaterialButton(Material material)
 	{
-		PanelItemBuilder builder = new PanelItemBuilder().
-			name(WordUtils.capitalize(material.name().toLowerCase().replace("_", " ")));
+		ItemStack itemStack = GuiUtils.getMaterialItem(material);
 
-		// Process items that cannot be item-stacks.
-		if (material.name().contains("_WALL"))
-		{
-			// Materials that is attached to wall cannot be showed in GUI. But they should be in list.
-			builder.icon(Material.getMaterial(material.name().replace("WALL_", "")));
-			builder.glow(true);
-		}
-		else if (material.name().startsWith("POTTED_"))
-		{
-			// Materials Potted elements cannot be in inventory.
-			builder.icon(Material.getMaterial(material.name().replace("POTTED_", "")));
-			builder.glow(true);
-		}
-		else if (material.name().startsWith("POTTED_"))
-		{
-			// Materials Potted elements cannot be in inventory.
-			builder.icon(Material.getMaterial(material.name().replace("POTTED_", "")));
-			builder.glow(true);
-		}
-		else if (material.equals(Material.MELON_STEM) || material.equals(Material.ATTACHED_MELON_STEM))
-		{
-			builder.icon(Material.MELON_SEEDS);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.PUMPKIN_STEM) || material.equals(Material.ATTACHED_PUMPKIN_STEM))
-		{
-			builder.icon(Material.PUMPKIN_SEEDS);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.TALL_SEAGRASS))
-		{
-			builder.icon(Material.SEAGRASS);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.CARROTS))
-		{
-			builder.icon(Material.CARROT);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.BEETROOTS))
-		{
-			builder.icon(Material.BEETROOT);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.POTATOES))
-		{
-			builder.icon(Material.POTATO);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.COCOA))
-		{
-			builder.icon(Material.COCOA_BEANS);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.KELP_PLANT))
-		{
-			builder.icon(Material.KELP);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.REDSTONE_WIRE))
-		{
-			builder.icon(Material.REDSTONE);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.TRIPWIRE))
-		{
-			builder.icon(Material.STRING);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.FROSTED_ICE))
-		{
-			builder.icon(Material.ICE);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.END_PORTAL) || material.equals(Material.END_GATEWAY) || material.equals(Material.NETHER_PORTAL))
-		{
-			builder.icon(Material.PAPER);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.BUBBLE_COLUMN) || material.equals(Material.WATER))
-		{
-			builder.icon(Material.WATER_BUCKET);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.LAVA))
-		{
-			builder.icon(Material.LAVA_BUCKET);
-			builder.glow(true);
-		}
-		else if (material.equals(Material.FIRE))
-		{
-			builder.icon(Material.FIRE_CHARGE);
-			builder.glow(true);
-		}
-		else
-		{
-			builder.icon(material);
-			builder.glow(false);
-		}
-
-		builder.clickHandler((panel, user1, clickType, slot) -> {
-			this.consumer.accept(true, material);
-			return true;
-		});
-
-		return builder.build();
+		return new PanelItemBuilder().
+			name(WordUtils.capitalize(material.name().toLowerCase().replace("_", " "))).
+			icon(itemStack).
+			clickHandler((panel, user1, clickType, slot) -> {
+				this.consumer.accept(true, material);
+				return true;
+			}).
+			glow(!itemStack.getType().equals(material)).
+			build();
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/panel/util/SelectBlocksGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SelectBlocksGUI.java
@@ -73,6 +73,7 @@ public class SelectBlocksGUI
 		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).
 			name(this.user.getTranslation("challenges.gui.admin.select-block"));
 
+		GuiUtils.fillBorder(panelBuilder, Material.BLUE_STAINED_GLASS_PANE);
 
 		final int MAX_ELEMENTS = 21;
 		final int correctPage;
@@ -93,7 +94,7 @@ public class SelectBlocksGUI
 		int entitiesIndex = MAX_ELEMENTS * correctPage;
 
 		// I want first row to be only for navigation and return button.
-		int index = 9;
+		int index = 10;
 
 		while (entitiesIndex < ((correctPage + 1) * MAX_ELEMENTS) &&
 			entitiesIndex < this.elements.size())
@@ -106,31 +107,44 @@ public class SelectBlocksGUI
 			index++;
 		}
 
-		// Add navigation Buttons
-		panelBuilder.item(3,
-			new PanelItemBuilder().
-				icon(Material.SIGN).
-				name(this.user.getTranslation("challenges.gui.buttons.previous")).
-				clickHandler( (panel, user1, clickType, slot) -> {
-					this.build(correctPage - 1);
-					return true;
-				}).build());
-
 		panelBuilder.item(4,
 			new PanelItemBuilder().
-				icon(Material.OAK_DOOR).
-				name(this.user.getTranslation("challenges.gui.buttons.return")).
+				icon(Material.RED_STAINED_GLASS_PANE).
+				name(this.user.getTranslation("challenges.gui.buttons.cancel")).
 				clickHandler( (panel, user1, clickType, slot) -> {
 					this.consumer.accept(false, null);
 					return true;
 				}).build());
 
-		panelBuilder.item(5,
+		if (this.elements.size() > MAX_ELEMENTS)
+		{
+			// Navigation buttons if necessary
+
+			panelBuilder.item(18,
+				new PanelItemBuilder().
+					icon(Material.SIGN).
+					name(this.user.getTranslation("challenges.gui.buttons.previous")).
+					clickHandler((panel, user1, clickType, slot) -> {
+						this.build(correctPage - 1);
+						return true;
+					}).build());
+
+			panelBuilder.item(26,
+				new PanelItemBuilder().
+					icon(Material.SIGN).
+					name(this.user.getTranslation("challenges.gui.buttons.next")).
+					clickHandler((panel, user1, clickType, slot) -> {
+						this.build(correctPage + 1);
+						return true;
+					}).build());
+		}
+
+		panelBuilder.item(44,
 			new PanelItemBuilder().
-				icon(Material.SIGN).
-				name(this.user.getTranslation("challenges.gui.buttons.next")).
+				icon(Material.OAK_DOOR).
+				name(this.user.getTranslation("challenges.gui.buttons.return")).
 				clickHandler( (panel, user1, clickType, slot) -> {
-					this.build(correctPage + 1);
+					this.consumer.accept(false, null);
 					return true;
 				}).build());
 

--- a/src/main/java/world/bentobox/challenges/panel/util/SelectBlocksGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SelectBlocksGUI.java
@@ -1,0 +1,277 @@
+package world.bentobox.challenges.panel.util;
+
+
+import org.apache.commons.lang.WordUtils;
+import org.bukkit.Material;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+import world.bentobox.bentobox.api.user.User;
+
+
+/**
+ * This class contains all necessary things that allows to select single block from all ingame blocks. Selected
+ * block will be returned via BiConsumer.
+ */
+public class SelectBlocksGUI
+{
+	public SelectBlocksGUI(User user, BiConsumer<Boolean, Material> consumer)
+	{
+		this(user, Collections.emptySet(), consumer);
+	}
+
+
+	public SelectBlocksGUI(User user, Set<Material> excludedMaterial, BiConsumer<Boolean, Material> consumer)
+	{
+		this.consumer = consumer;
+		this.user = user;
+
+		// Current GUI cannot display air blocks. It crashes with null-pointer
+		excludedMaterial.add(Material.AIR);
+		excludedMaterial.add(Material.CAVE_AIR);
+		excludedMaterial.add(Material.VOID_AIR);
+
+		// Piston head and moving piston is not necessary. useless.
+		excludedMaterial.add(Material.PISTON_HEAD);
+		excludedMaterial.add(Material.MOVING_PISTON);
+
+		// Barrier cannot be accessible to user.
+		excludedMaterial.add(Material.BARRIER);
+
+		this.elements = new ArrayList<>();
+
+		for (Material material : Material.values())
+		{
+			if (material.isBlock() && !material.isLegacy() && !excludedMaterial.contains(material))
+			{
+				this.elements.add(material);
+			}
+		}
+
+		this.build(0);
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Methods
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * This method builds all necessary elements in GUI panel.
+	 */
+	public void build(int pageIndex)
+	{
+		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).
+			name(this.user.getTranslation("challenges.gui.admin.select-block"));
+
+
+		final int MAX_ELEMENTS = 21;
+		final int correctPage;
+
+		if (pageIndex < 0)
+		{
+			correctPage = this.elements.size() / MAX_ELEMENTS;
+		}
+		else if (pageIndex > (this.elements.size() / MAX_ELEMENTS))
+		{
+			correctPage = 0;
+		}
+		else
+		{
+			correctPage = pageIndex;
+		}
+
+		int entitiesIndex = MAX_ELEMENTS * correctPage;
+
+		// I want first row to be only for navigation and return button.
+		int index = 9;
+
+		while (entitiesIndex < ((correctPage + 1) * MAX_ELEMENTS) &&
+			entitiesIndex < this.elements.size())
+		{
+			if (!panelBuilder.slotOccupied(index))
+			{
+				panelBuilder.item(index, this.createMaterialButton(this.elements.get(entitiesIndex++)));
+			}
+
+			index++;
+		}
+
+		// Add navigation Buttons
+		panelBuilder.item(3,
+			new PanelItemBuilder().
+				icon(Material.SIGN).
+				name(this.user.getTranslation("challenges.gui.buttons.previous")).
+				clickHandler( (panel, user1, clickType, slot) -> {
+					this.build(correctPage - 1);
+					return true;
+				}).build());
+
+		panelBuilder.item(4,
+			new PanelItemBuilder().
+				icon(Material.OAK_DOOR).
+				name(this.user.getTranslation("challenges.gui.buttons.return")).
+				clickHandler( (panel, user1, clickType, slot) -> {
+					this.consumer.accept(false, null);
+					return true;
+				}).build());
+
+		panelBuilder.item(5,
+			new PanelItemBuilder().
+				icon(Material.SIGN).
+				name(this.user.getTranslation("challenges.gui.buttons.next")).
+				clickHandler( (panel, user1, clickType, slot) -> {
+					this.build(correctPage + 1);
+					return true;
+				}).build());
+
+		panelBuilder.build();
+	}
+
+
+	/**
+	 * This method creates PanelItem that represents given material.
+	 * Some materials is not displayable in Inventory GUI, so they are replaced with "placeholder" items.
+	 * @param material Material which icon must be created.
+	 * @return PanelItem that represents given material.
+	 */
+	private PanelItem createMaterialButton(Material material)
+	{
+		PanelItemBuilder builder = new PanelItemBuilder().
+			name(WordUtils.capitalize(material.name().toLowerCase().replace("_", " ")));
+
+		// Process items that cannot be item-stacks.
+		if (material.name().contains("_WALL"))
+		{
+			// Materials that is attached to wall cannot be showed in GUI. But they should be in list.
+			builder.icon(Material.getMaterial(material.name().replace("WALL_", "")));
+			builder.glow(true);
+		}
+		else if (material.name().startsWith("POTTED_"))
+		{
+			// Materials Potted elements cannot be in inventory.
+			builder.icon(Material.getMaterial(material.name().replace("POTTED_", "")));
+			builder.glow(true);
+		}
+		else if (material.name().startsWith("POTTED_"))
+		{
+			// Materials Potted elements cannot be in inventory.
+			builder.icon(Material.getMaterial(material.name().replace("POTTED_", "")));
+			builder.glow(true);
+		}
+		else if (material.equals(Material.MELON_STEM) || material.equals(Material.ATTACHED_MELON_STEM))
+		{
+			builder.icon(Material.MELON_SEEDS);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.PUMPKIN_STEM) || material.equals(Material.ATTACHED_PUMPKIN_STEM))
+		{
+			builder.icon(Material.PUMPKIN_SEEDS);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.TALL_SEAGRASS))
+		{
+			builder.icon(Material.SEAGRASS);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.CARROTS))
+		{
+			builder.icon(Material.CARROT);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.BEETROOTS))
+		{
+			builder.icon(Material.BEETROOT);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.POTATOES))
+		{
+			builder.icon(Material.POTATO);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.COCOA))
+		{
+			builder.icon(Material.COCOA_BEANS);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.KELP_PLANT))
+		{
+			builder.icon(Material.KELP);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.REDSTONE_WIRE))
+		{
+			builder.icon(Material.REDSTONE);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.TRIPWIRE))
+		{
+			builder.icon(Material.STRING);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.FROSTED_ICE))
+		{
+			builder.icon(Material.ICE);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.END_PORTAL) || material.equals(Material.END_GATEWAY) || material.equals(Material.NETHER_PORTAL))
+		{
+			builder.icon(Material.PAPER);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.BUBBLE_COLUMN) || material.equals(Material.WATER))
+		{
+			builder.icon(Material.WATER_BUCKET);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.LAVA))
+		{
+			builder.icon(Material.LAVA_BUCKET);
+			builder.glow(true);
+		}
+		else if (material.equals(Material.FIRE))
+		{
+			builder.icon(Material.FIRE_CHARGE);
+			builder.glow(true);
+		}
+		else
+		{
+			builder.icon(material);
+			builder.glow(false);
+		}
+
+		builder.clickHandler((panel, user1, clickType, slot) -> {
+			this.consumer.accept(true, material);
+			return true;
+		});
+
+		return builder.build();
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
+
+	/**
+	 * List with elements that will be displayed in current GUI.
+	 */
+	private List<Material> elements;
+
+	/**
+	 * This variable stores consumer.
+	 */
+	private BiConsumer<Boolean, Material> consumer;
+
+	/**
+	 * User who runs GUI.
+	 */
+	private User user;
+}

--- a/src/main/java/world/bentobox/challenges/panel/util/SelectChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SelectChallengeGUI.java
@@ -10,6 +10,7 @@ import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.challenges.database.object.Challenges;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -34,8 +35,10 @@ public class SelectChallengeGUI
 	{
 		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(this.user.getTranslation("challenges.gui.choose-challenge-title"));
 
+		GuiUtils.fillBorder(panelBuilder, Material.BLUE_STAINED_GLASS_PANE);
+
 		// Maximal elements in page.
-		final int MAX_ELEMENTS = 36;
+		final int MAX_ELEMENTS = 21;
 
 		final int correctPage;
 
@@ -52,18 +55,57 @@ public class SelectChallengeGUI
 			correctPage = pageIndex;
 		}
 
-		// Navigation buttons
-
-		panelBuilder.item(3,
+		panelBuilder.item(4,
 			new PanelItemBuilder().
-				icon(Material.SIGN).
-				name(this.user.getTranslation("challenges.gui.buttons.previous")).
+				icon(Material.RED_STAINED_GLASS_PANE).
+				name(this.user.getTranslation("challenges.gui.buttons.return")).
 				clickHandler( (panel, user1, clickType, slot) -> {
-					this.build(correctPage - 1);
+					this.consumer.accept(false, null);
 					return true;
 				}).build());
 
-		panelBuilder.item(4,
+		if (this.challengesList.size() > MAX_ELEMENTS)
+		{
+			// Navigation buttons if necessary
+
+			panelBuilder.item(18,
+				new PanelItemBuilder().
+					icon(Material.SIGN).
+					name(this.user.getTranslation("challenges.gui.buttons.previous")).
+					clickHandler((panel, user1, clickType, slot) -> {
+						this.build(correctPage - 1);
+						return true;
+					}).build());
+
+			panelBuilder.item(26,
+				new PanelItemBuilder().
+					icon(Material.SIGN).
+					name(this.user.getTranslation("challenges.gui.buttons.next")).
+					clickHandler((panel, user1, clickType, slot) -> {
+						this.build(correctPage + 1);
+						return true;
+					}).build());
+		}
+
+		int challengesIndex = MAX_ELEMENTS * correctPage;
+
+		// I want first row to be only for navigation and return button.
+		int index = 10;
+
+		while (challengesIndex < ((correctPage + 1) * MAX_ELEMENTS) &&
+			challengesIndex < this.challengesList.size() &&
+			index < 36)
+		{
+			if (!panelBuilder.slotOccupied(index))
+			{
+				panelBuilder.item(index,
+					this.createChallengeButton(this.challengesList.get(challengesIndex++)));
+			}
+
+			index++;
+		}
+
+		panelBuilder.item(44,
 			new PanelItemBuilder().
 				icon(Material.OAK_DOOR).
 				name(this.user.getTranslation("challenges.gui.buttons.return")).
@@ -71,28 +113,6 @@ public class SelectChallengeGUI
 					this.consumer.accept(false, null);
 					return true;
 				}).build());
-
-		panelBuilder.item(5,
-			new PanelItemBuilder().
-				icon(Material.SIGN).
-				name(this.user.getTranslation("challenges.gui.buttons.next")).
-				clickHandler( (panel, user1, clickType, slot) -> {
-					this.build(correctPage + 1);
-					return true;
-				}).build());
-
-		int challengesIndex = MAX_ELEMENTS * correctPage;
-
-		// I want first row to be only for navigation and return button.
-		int index = 9;
-
-		while (challengesIndex < ((correctPage + 1) * MAX_ELEMENTS) &&
-			challengesIndex < this.challengesList.size())
-		{
-			panelBuilder.item(index++, this.createChallengeButton(this.challengesList.get(challengesIndex++)));
-		}
-
-		panelBuilder.build();
 
 		panelBuilder.build();
 	}

--- a/src/main/java/world/bentobox/challenges/panel/util/SelectChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SelectChallengeGUI.java
@@ -1,0 +1,138 @@
+package world.bentobox.challenges.panel.util;
+
+
+import org.bukkit.Material;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.database.object.Challenges;
+
+
+/**
+ * This class creates new GUI that allows to select single challenge, which is returned via consumer.
+ */
+public class SelectChallengeGUI
+{
+	public SelectChallengeGUI(User user, List<Challenges> challengesList, BiConsumer<Boolean, Challenges> consumer)
+	{
+		this.consumer = consumer;
+		this.user = user;
+		this.challengesList = challengesList;
+
+		this.build(0);
+	}
+
+
+	/**
+	 * This method builds panel that allows to select single challenge from input challenges.
+	 */
+	private void build(int pageIndex)
+	{
+		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(this.user.getTranslation("challenges.gui.choose-challenge-title"));
+
+		// Maximal elements in page.
+		final int MAX_ELEMENTS = 36;
+
+		final int correctPage;
+
+		if (pageIndex < 0)
+		{
+			correctPage = this.challengesList.size() / MAX_ELEMENTS;
+		}
+		else if (pageIndex > (this.challengesList.size() / MAX_ELEMENTS))
+		{
+			correctPage = 0;
+		}
+		else
+		{
+			correctPage = pageIndex;
+		}
+
+		// Navigation buttons
+
+		panelBuilder.item(3,
+			new PanelItemBuilder().
+				icon(Material.SIGN).
+				name(this.user.getTranslation("challenges.gui.buttons.previous")).
+				clickHandler( (panel, user1, clickType, slot) -> {
+					this.build(correctPage - 1);
+					return true;
+				}).build());
+
+		panelBuilder.item(4,
+			new PanelItemBuilder().
+				icon(Material.OAK_DOOR).
+				name(this.user.getTranslation("challenges.gui.buttons.return")).
+				clickHandler( (panel, user1, clickType, slot) -> {
+					this.consumer.accept(false, null);
+					return true;
+				}).build());
+
+		panelBuilder.item(5,
+			new PanelItemBuilder().
+				icon(Material.SIGN).
+				name(this.user.getTranslation("challenges.gui.buttons.next")).
+				clickHandler( (panel, user1, clickType, slot) -> {
+					this.build(correctPage + 1);
+					return true;
+				}).build());
+
+		int challengesIndex = MAX_ELEMENTS * correctPage;
+
+		// I want first row to be only for navigation and return button.
+		int index = 9;
+
+		while (challengesIndex < ((correctPage + 1) * MAX_ELEMENTS) &&
+			challengesIndex < this.challengesList.size())
+		{
+			panelBuilder.item(index++, this.createChallengeButton(this.challengesList.get(challengesIndex++)));
+		}
+
+		panelBuilder.build();
+
+		panelBuilder.build();
+	}
+
+
+	/**
+	 * This method builds PanelItem for given challenge.
+	 * @param challenge Challenge which PanelItem must be created.
+	 * @return new PanelItem for given Challenge.
+	 */
+	private PanelItem createChallengeButton(Challenges challenge)
+	{
+		return new PanelItemBuilder().
+			name(challenge.getFriendlyName()).
+			description(challenge.getDescription()).
+			icon(challenge.getIcon()).
+			clickHandler((panel, user1, clickType, slot) -> {
+				this.consumer.accept(true, challenge);
+				return true;
+			}).build();
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * This variable stores consumer.
+	 */
+	private BiConsumer<Boolean, Challenges> consumer;
+
+	/**
+	 * User who runs GUI.
+	 */
+	private User user;
+
+	/**
+	 * Current value.
+	 */
+	private List<Challenges> challengesList;
+}

--- a/src/main/java/world/bentobox/challenges/panel/util/SelectChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SelectChallengeGUI.java
@@ -9,7 +9,7 @@ import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
-import world.bentobox.challenges.database.object.Challenges;
+import world.bentobox.challenges.database.object.Challenge;
 import world.bentobox.challenges.utils.GuiUtils;
 
 
@@ -18,7 +18,7 @@ import world.bentobox.challenges.utils.GuiUtils;
  */
 public class SelectChallengeGUI
 {
-	public SelectChallengeGUI(User user, List<Challenges> challengesList, BiConsumer<Boolean, Challenges> consumer)
+	public SelectChallengeGUI(User user, List<Challenge> challengesList, BiConsumer<Boolean, Challenge> consumer)
 	{
 		this.consumer = consumer;
 		this.user = user;
@@ -123,7 +123,7 @@ public class SelectChallengeGUI
 	 * @param challenge Challenge which PanelItem must be created.
 	 * @return new PanelItem for given Challenge.
 	 */
-	private PanelItem createChallengeButton(Challenges challenge)
+	private PanelItem createChallengeButton(Challenge challenge)
 	{
 		return new PanelItemBuilder().
 			name(challenge.getFriendlyName()).
@@ -144,7 +144,7 @@ public class SelectChallengeGUI
 	/**
 	 * This variable stores consumer.
 	 */
-	private BiConsumer<Boolean, Challenges> consumer;
+	private BiConsumer<Boolean, Challenge> consumer;
 
 	/**
 	 * User who runs GUI.
@@ -154,5 +154,5 @@ public class SelectChallengeGUI
 	/**
 	 * Current value.
 	 */
-	private List<Challenges> challengesList;
+	private List<Challenge> challengesList;
 }

--- a/src/main/java/world/bentobox/challenges/panel/util/SelectChallengeGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SelectChallengeGUI.java
@@ -127,7 +127,7 @@ public class SelectChallengeGUI
 	{
 		return new PanelItemBuilder().
 			name(challenge.getFriendlyName()).
-			description(challenge.getDescription()).
+			description(GuiUtils.stringSplit(challenge.getDescription())).
 			icon(challenge.getIcon()).
 			clickHandler((panel, user1, clickType, slot) -> {
 				this.consumer.accept(true, challenge);

--- a/src/main/java/world/bentobox/challenges/panel/util/SelectEntityGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SelectEntityGUI.java
@@ -12,7 +12,7 @@ import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
-import world.bentobox.challenges.utils.HeadLib;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -120,8 +120,6 @@ public class SelectEntityGUI
 		}
 
 		panelBuilder.build();
-
-		panelBuilder.build();
 	}
 
 
@@ -132,121 +130,17 @@ public class SelectEntityGUI
 	 */
 	private PanelItem createEntityButton(EntityType entity)
 	{
+		ItemStack itemStack = this.asEggs ? GuiUtils.getEntityEgg(entity) : GuiUtils.getEntityHead(entity);
+
 		return new PanelItemBuilder().
 			name(WordUtils.capitalize(entity.name().toLowerCase().replace("_", " "))).
-			icon(this.asEggs ? this.getEntityEgg(entity) : this.getEntityHead(entity)).
+			icon(itemStack).
 			clickHandler((panel, user1, clickType, slot) -> {
 				this.consumer.accept(true, entity);
 				return true;
 			}).build();
 	}
 
-
-	/**
-	 * This method transforms entity into egg or block that corresponds given entity. If entity egg is not
-	 * found, then it is replaced by block that represents entity or barrier block.
-	 * @param entity Entity which egg must be returned.
-	 * @return ItemStack that may be egg for given entity.
-	 */
-	private ItemStack getEntityEgg(EntityType entity)
-	{
-		ItemStack itemStack;
-
-		switch (entity)
-		{
-			case PIG_ZOMBIE:
-				itemStack = new ItemStack(Material.ZOMBIE_PIGMAN_SPAWN_EGG);
-				break;
-			case ENDER_DRAGON:
-				itemStack = new ItemStack(Material.DRAGON_EGG);
-				break;
-			case WITHER:
-				itemStack = new ItemStack(Material.SOUL_SAND);
-				break;
-			case PLAYER:
-				itemStack = new ItemStack(Material.PLAYER_HEAD);
-				break;
-			case MUSHROOM_COW:
-				itemStack = new ItemStack(Material.MOOSHROOM_SPAWN_EGG);
-				break;
-			case SNOWMAN:
-				itemStack = new ItemStack(Material.CARVED_PUMPKIN);
-				break;
-			case IRON_GOLEM:
-				itemStack = new ItemStack(Material.IRON_BLOCK);
-				break;
-			case ARMOR_STAND:
-				itemStack = new ItemStack(Material.ARMOR_STAND);
-				break;
-			default:
-				Material material = Material.getMaterial(entity.name() + "_SPAWN_EGG");
-
-				if (material == null)
-				{
-					itemStack = new ItemStack(Material.BARRIER);
-				}
-				else
-				{
-					itemStack = new ItemStack(material);
-				}
-
-				break;
-		}
-
-		return itemStack;
-	}
-
-
-	/**
-	 * This method transforms entity into player head with skin that corresponds given entity. If entity head
-	 * is not found, then it is replaced by barrier block.
-	 * @param entity Entity which head must be returned.
-	 * @return ItemStack that may be head for given entity.
-	 */
-	private ItemStack getEntityHead(EntityType entity)
-	{
-		ItemStack itemStack;
-
-		switch (entity)
-		{
-			case PLAYER:
-				itemStack = new ItemStack(Material.PLAYER_HEAD);
-				break;
-			case WITHER_SKELETON:
-				itemStack = new ItemStack(Material.WITHER_SKELETON_SKULL);
-				break;
-			case ARMOR_STAND:
-				itemStack = new ItemStack(Material.ARMOR_STAND);
-				break;
-			case SKELETON:
-				itemStack = new ItemStack(Material.SKELETON_SKULL);
-				break;
-			case GIANT:
-			case ZOMBIE:
-				itemStack = new ItemStack(Material.ZOMBIE_HEAD);
-				break;
-			case CREEPER:
-				itemStack = new ItemStack(Material.CREEPER_HEAD);
-				break;
-			case ENDER_DRAGON:
-				itemStack = new ItemStack(Material.DRAGON_HEAD);
-				break;
-			default:
-				HeadLib head = HeadLib.getHead(entity.name());
-
-				if (head == null)
-				{
-					itemStack = new ItemStack(Material.BARRIER);
-				}
-				else
-				{
-					itemStack = head.toItemStack();
-				}
-				break;
-		}
-
-		return itemStack;
-	}
 
 
 // ---------------------------------------------------------------------

--- a/src/main/java/world/bentobox/challenges/panel/util/SelectEntityGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SelectEntityGUI.java
@@ -61,8 +61,10 @@ public class SelectEntityGUI
 	{
 		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(this.user.getTranslation("challenges.gui.choose-entity-title"));
 
+		GuiUtils.fillBorder(panelBuilder, Material.BLUE_STAINED_GLASS_PANE);
+
 		// Maximal elements in page.
-		final int MAX_ELEMENTS = 36;
+		final int MAX_ELEMENTS = 21;
 
 		final int correctPage;
 
@@ -79,45 +81,64 @@ public class SelectEntityGUI
 			correctPage = pageIndex;
 		}
 
-		// Navigation buttons
-
-		panelBuilder.item(3,
-			new PanelItemBuilder().
-				icon(Material.SIGN).
-				name(this.user.getTranslation("challenges.gui.buttons.previous")).
-				clickHandler( (panel, user1, clickType, slot) -> {
-					this.build(correctPage - 1);
-					return true;
-				}).build());
-
 		panelBuilder.item(4,
 			new PanelItemBuilder().
-				icon(Material.OAK_DOOR).
-				name(this.user.getTranslation("challenges.gui.buttons.return")).
+				icon(Material.RED_STAINED_GLASS_PANE).
+				name(this.user.getTranslation("challenges.gui.buttons.cancel")).
 				clickHandler( (panel, user1, clickType, slot) -> {
 					this.consumer.accept(false, null);
 					return true;
 				}).build());
 
-		panelBuilder.item(5,
-			new PanelItemBuilder().
-				icon(Material.SIGN).
-				name(this.user.getTranslation("challenges.gui.buttons.next")).
-				clickHandler( (panel, user1, clickType, slot) -> {
-					this.build(correctPage + 1);
-					return true;
-				}).build());
+		if (this.entities.size() > MAX_ELEMENTS)
+		{
+			// Navigation buttons if necessary
+
+			panelBuilder.item(18,
+				new PanelItemBuilder().
+					icon(Material.SIGN).
+					name(this.user.getTranslation("challenges.gui.buttons.previous")).
+					clickHandler((panel, user1, clickType, slot) -> {
+						this.build(correctPage - 1);
+						return true;
+					}).build());
+
+			panelBuilder.item(26,
+				new PanelItemBuilder().
+					icon(Material.SIGN).
+					name(this.user.getTranslation("challenges.gui.buttons.next")).
+					clickHandler((panel, user1, clickType, slot) -> {
+						this.build(correctPage + 1);
+						return true;
+					}).build());
+		}
 
 		int entitiesIndex = MAX_ELEMENTS * correctPage;
 
 		// I want first row to be only for navigation and return button.
-		int index = 9;
+		int slot = 10;
 
 		while (entitiesIndex < ((correctPage + 1) * MAX_ELEMENTS) &&
-			entitiesIndex < this.entities.size())
+			entitiesIndex < this.entities.size() &&
+			slot < 36)
 		{
-			panelBuilder.item(index++, this.createEntityButton(this.entities.get(entitiesIndex++)));
+			if (!panelBuilder.slotOccupied(slot))
+			{
+				panelBuilder.item(slot,
+					this.createEntityButton(this.entities.get(entitiesIndex++)));
+			}
+
+			slot++;
 		}
+
+		panelBuilder.item(44,
+			new PanelItemBuilder().
+				icon(Material.OAK_DOOR).
+				name(this.user.getTranslation("challenges.gui.buttons.return")).
+				clickHandler( (panel, user1, clickType, i) -> {
+					this.consumer.accept(false, null);
+					return true;
+				}).build());
 
 		panelBuilder.build();
 	}

--- a/src/main/java/world/bentobox/challenges/panel/util/SelectEnvironmentGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SelectEnvironmentGUI.java
@@ -1,0 +1,134 @@
+package world.bentobox.challenges.panel.util;
+
+
+import org.bukkit.Material;
+import org.bukkit.World;
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+import world.bentobox.bentobox.api.user.User;
+
+
+/**
+ * This class creates panel that allows to select and deselect World Environments. On save it runs
+ * input consumer with true and selected values.
+ */
+public class SelectEnvironmentGUI
+{
+	public SelectEnvironmentGUI(User user, Set<World.Environment> values, BiConsumer<Boolean, Set<World.Environment>> consumer)
+	{
+		this.user = user;
+		this.values = values;
+		this.consumer = consumer;
+
+		this.build();
+	}
+
+
+	/**
+	 * This method builds environment select panel.
+	 */
+	private void build()
+	{
+		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(this.user.getTranslation("challenges.gui.admin.environment-title"));
+
+		panelBuilder.item(3, new PanelItemBuilder().
+			name(this.user.getTranslation("challenges.gui.admin.buttons.save")).
+			icon(Material.GREEN_STAINED_GLASS_PANE).
+			clickHandler((panel, user1, clickType, index) -> {
+				this.consumer.accept(true, this.values);
+				return true;
+			}).
+			build());
+
+		panelBuilder.item(5, new PanelItemBuilder().
+			name(this.user.getTranslation("challenges.gui.admin.buttons.cancel")).
+			icon(Material.RED_STAINED_GLASS_PANE).
+			clickHandler((panel, user1, clickType, i) -> {
+				this.consumer.accept(false, Collections.emptySet());
+				return true;
+			}).
+			build());
+
+		panelBuilder.item(12, new PanelItemBuilder().
+			name(this.user.getTranslation("challenges.gui.admin.buttons.nether")).
+			icon(Material.NETHERRACK).
+			clickHandler((panel, user1, clickType, i) -> {
+				if (this.values.contains(World.Environment.NETHER))
+				{
+					this.values.remove(World.Environment.NETHER);
+				}
+				else
+				{
+					this.values.add(World.Environment.NETHER);
+				}
+
+				this.build();
+				return true;
+			}).
+			glow(this.values.contains(World.Environment.NETHER)).
+			build());
+		panelBuilder.item(13, new PanelItemBuilder().
+			name(this.user.getTranslation("challenges.gui.admin.buttons.normal")).
+			icon(Material.DIRT).
+			clickHandler((panel, user1, clickType, i) -> {
+				if (this.values.contains(World.Environment.NORMAL))
+				{
+					this.values.remove(World.Environment.NORMAL);
+				}
+				else
+				{
+					this.values.add(World.Environment.NORMAL);
+				}
+
+				this.build();
+				return true;
+			}).
+			glow(this.values.contains(World.Environment.NORMAL)).
+			build());
+		panelBuilder.item(14, new PanelItemBuilder().
+			name(this.user.getTranslation("challenges.gui.admin.buttons.end")).
+			icon(Material.END_STONE).
+			clickHandler((panel, user1, clickType, i) -> {
+				if (this.values.contains(World.Environment.THE_END))
+				{
+					this.values.remove(World.Environment.THE_END);
+				}
+				else
+				{
+					this.values.add(World.Environment.THE_END);
+				}
+
+				this.build();
+				return true;
+			}).
+			glow(this.values.contains(World.Environment.THE_END)).
+			build());
+
+		panelBuilder.build();
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
+
+	/**
+	 * User who wants to run command.
+	 */
+	private User user;
+
+	/**
+	 * List with selected environments.
+	 */
+	private Set<World.Environment> values;
+
+	/**
+	 * Stores current Consumer
+	 */
+	private BiConsumer<Boolean, Set<World.Environment>> consumer;
+
+}

--- a/src/main/java/world/bentobox/challenges/panel/util/SelectEnvironmentGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SelectEnvironmentGUI.java
@@ -10,6 +10,7 @@ import java.util.function.BiConsumer;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -35,6 +36,8 @@ public class SelectEnvironmentGUI
 	{
 		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(this.user.getTranslation("challenges.gui.admin.environment-title"));
 
+		GuiUtils.fillBorder(panelBuilder, Material.BLUE_STAINED_GLASS_PANE);
+
 		panelBuilder.item(3, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.save")).
 			icon(Material.GREEN_STAINED_GLASS_PANE).
@@ -53,7 +56,7 @@ public class SelectEnvironmentGUI
 			}).
 			build());
 
-		panelBuilder.item(12, new PanelItemBuilder().
+		panelBuilder.item(20, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.nether")).
 			icon(Material.NETHERRACK).
 			clickHandler((panel, user1, clickType, i) -> {
@@ -71,7 +74,7 @@ public class SelectEnvironmentGUI
 			}).
 			glow(this.values.contains(World.Environment.NETHER)).
 			build());
-		panelBuilder.item(13, new PanelItemBuilder().
+		panelBuilder.item(22, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.normal")).
 			icon(Material.DIRT).
 			clickHandler((panel, user1, clickType, i) -> {
@@ -89,7 +92,7 @@ public class SelectEnvironmentGUI
 			}).
 			glow(this.values.contains(World.Environment.NORMAL)).
 			build());
-		panelBuilder.item(14, new PanelItemBuilder().
+		panelBuilder.item(24, new PanelItemBuilder().
 			name(this.user.getTranslation("challenges.gui.admin.buttons.end")).
 			icon(Material.END_STONE).
 			clickHandler((panel, user1, clickType, i) -> {
@@ -106,6 +109,16 @@ public class SelectEnvironmentGUI
 				return true;
 			}).
 			glow(this.values.contains(World.Environment.THE_END)).
+			build());
+
+
+		panelBuilder.item(44, new PanelItemBuilder().
+			name(this.user.getTranslation("challenges.gui.admin.buttons.return")).
+			icon(Material.OAK_DOOR).
+			clickHandler((panel, user1, clickType, i) -> {
+				this.consumer.accept(false, Collections.emptySet());
+				return true;
+			}).
 			build());
 
 		panelBuilder.build();

--- a/src/main/java/world/bentobox/challenges/panel/util/StringListGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/StringListGUI.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import net.wesjd.anvilgui.AnvilGUI;
+import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
@@ -61,9 +63,9 @@ public class StringListGUI
 
 		panelBuilder.item(8, this.getButton(Button.CANCEL));
 
-		for (String element : this.value)
+		for (int i = 0; i < this.value.size(); i++)
 		{
-			panelBuilder.item(this.createStringElement(element));
+			panelBuilder.item(this.createStringElement(this.value.get(i), i));
 		}
 
 		panelBuilder.build();
@@ -122,10 +124,14 @@ public class StringListGUI
 				description = Collections.emptyList();
 				icon = new ItemStack(Material.WHITE_STAINED_GLASS_PANE);
 				clickHandler = (panel, user, clickType, slot) -> {
-
-					// TODO: Open Anvil GUI.
-
-					this.build();
+					new AnvilGUI(BentoBox.getInstance(),
+						this.user.getPlayer(),
+						" ",
+						(player, reply) -> {
+							this.value.add(reply);
+							this.build();
+							return reply;
+						});
 					return true;
 				};
 				break;
@@ -168,13 +174,20 @@ public class StringListGUI
 	 * @param element Paper Icon name
 	 * @return PanelItem.
 	 */
-	private PanelItem createStringElement(String element)
+	private PanelItem createStringElement(String element, int stringIndex)
 	{
 		return new PanelItemBuilder().
 			name(element).
 			icon(Material.PAPER).
 			clickHandler((panel, user1, clickType, i) -> {
-			// TODO: open anvil gui.
+				new AnvilGUI(BentoBox.getInstance(),
+					this.user.getPlayer(),
+					element,
+					(player, reply) -> {
+						this.value.set(stringIndex, reply);
+						this.build();
+						return reply;
+					});
 			return true;
 		}).build();
 	}

--- a/src/main/java/world/bentobox/challenges/panel/util/StringListGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/StringListGUI.java
@@ -3,7 +3,10 @@ package world.bentobox.challenges.panel.util;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.BiConsumer;
 
 import net.wesjd.anvilgui.AnvilGUI;
@@ -174,7 +177,7 @@ public class StringListGUI
 				return null;
 		}
 
-		return new PanelItem(icon, name, description, false, clickHandler, false);
+		return new PanelItem(icon, name, GuiUtils.stringSplit(description), false, clickHandler, false);
 	}
 
 

--- a/src/main/java/world/bentobox/challenges/panel/util/StringListGUI.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/StringListGUI.java
@@ -3,10 +3,7 @@ package world.bentobox.challenges.panel.util;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.function.BiConsumer;
 
 import net.wesjd.anvilgui.AnvilGUI;
@@ -15,6 +12,7 @@ import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.utils.GuiUtils;
 
 
 /**
@@ -35,7 +33,7 @@ public class StringListGUI
 		this.user = user;
 		this.value = value;
 
-		if (this.value.size() > 18)
+		if (this.value.size() > 21)
 		{
 			// TODO: throw error that so large list cannot be edited.
 			this.consumer.accept(false, this.value);
@@ -52,20 +50,31 @@ public class StringListGUI
 	 */
 	private void build()
 	{
-		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).name(this.user.getTranslation("challenges.gui.text-edit-title"));
+		PanelBuilder panelBuilder = new PanelBuilder().user(this.user).
+			name(this.user.getTranslation("challenges.gui.text-edit-title"));
 
-		panelBuilder.item(0, this.getButton(Button.SAVE));
-		panelBuilder.item(1, this.getButton(Button.VALUE));
+		GuiUtils.fillBorder(panelBuilder, Material.BLACK_STAINED_GLASS_PANE);
 
-		panelBuilder.item(3, this.getButton(Button.ADD));
-		panelBuilder.item(4, this.getButton(Button.REMOVE));
-		panelBuilder.item(4, this.getButton(Button.CLEAR));
+		panelBuilder.item(1, this.getButton(Button.SAVE));
+		panelBuilder.item(2, this.getButton(Button.VALUE));
 
-		panelBuilder.item(8, this.getButton(Button.CANCEL));
+		panelBuilder.item(4, this.getButton(Button.ADD));
+		panelBuilder.item(5, this.getButton(Button.REMOVE));
+		panelBuilder.item(6, this.getButton(Button.CLEAR));
 
-		for (int i = 0; i < this.value.size(); i++)
+		panelBuilder.item(44, this.getButton(Button.CANCEL));
+
+		int slot = 10;
+
+		for (int stringIndex = 0; stringIndex < this.value.size() && slot < 36; stringIndex++)
 		{
-			panelBuilder.item(this.createStringElement(this.value.get(i), i));
+			if (!panelBuilder.slotOccupied(slot))
+			{
+				panelBuilder.item(slot,
+					this.createStringElement(this.value.get(stringIndex), stringIndex));
+			}
+
+			slot++;
 		}
 
 		panelBuilder.build();
@@ -90,7 +99,7 @@ public class StringListGUI
 			{
 				name = this.user.getTranslation("challenges.gui.buttons.save");
 				description = Collections.emptyList();
-				icon = new ItemStack(Material.COMMAND_BLOCK);
+				icon = new ItemStack(Material.GREEN_STAINED_GLASS_PANE);
 				clickHandler = (panel, user, clickType, slot) -> {
 					this.consumer.accept(true, this.value);
 
@@ -102,7 +111,7 @@ public class StringListGUI
 			{
 				name = this.user.getTranslation("challenges.gui.buttons.cancel");
 				description = Collections.emptyList();
-				icon = new ItemStack(Material.IRON_DOOR);
+				icon = new ItemStack(Material.OAK_DOOR);
 				clickHandler = (panel, user, clickType, slot) -> {
 					this.consumer.accept(false, this.value);
 

--- a/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
+++ b/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
@@ -5,8 +5,10 @@ import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Collections;
+
+import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
-import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 
 
 /**
@@ -72,7 +74,7 @@ public class GuiUtils
 
 			if (i < 9 || i > 9 * (rowCount - 1) || i % 9 == 0 || i % 9 == 8)
 			{
-				panelBuilder.item(i, new PanelItemBuilder().name("&2").icon(material).build());
+				panelBuilder.item(i, BorderBlock.getPanelBorder(material));
 			}
 		}
 	}
@@ -331,5 +333,31 @@ public class GuiUtils
 		itemStack.setAmount(amount);
 
 		return itemStack;
+	}
+
+
+	/**
+	 * This BorderBlock is simple PanelItem but without item meta data.
+	 */
+	private static class BorderBlock extends PanelItem
+	{
+		private BorderBlock(ItemStack icon)
+		{
+			super(icon.clone(), " ", Collections.emptyList(), false, null, false);
+		}
+
+
+		/**
+		 * This method retunrs BorderBlock with requested item stack.
+		 * @param material of which broder must be created.
+		 * @return PanelItem that acts like border.
+		 */
+		private static BorderBlock getPanelBorder(Material material)
+		{
+			ItemStack itemStack = new ItemStack(material);
+			itemStack.getItemMeta().setDisplayName(" ");
+
+			return new BorderBlock(itemStack);
+		}
 	}
 }

--- a/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
+++ b/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
@@ -79,7 +79,7 @@ public class GuiUtils
 
 
 // ---------------------------------------------------------------------
-// Section: Entities Visualization Block
+// Section: ItemStack transformations
 // ---------------------------------------------------------------------
 
 	/**
@@ -213,6 +213,124 @@ public class GuiUtils
 					itemStack = head.toItemStack();
 				}
 				break;
+		}
+
+		itemStack.setAmount(amount);
+
+		return itemStack;
+	}
+
+
+	/**
+	 * This method transforms material into item stack that can be displayed in users
+	 * inventory.
+	 * @param material Material which item stack must be returned.
+	 * @return ItemStack that represents given material.
+	 */
+	public static ItemStack getMaterialItem(Material material)
+	{
+		return GuiUtils.getMaterialItem(material, 1);
+	}
+
+
+	/**
+	 * This method transforms material into item stack that can be displayed in users
+	 * inventory.
+	 * @param material Material which item stack must be returned.
+	 * @param amount Amount of ItemStack elements.
+	 * @return ItemStack that represents given material.
+	 */
+	public static ItemStack getMaterialItem(Material material, int amount)
+	{
+		ItemStack itemStack;
+
+		// Process items that cannot be item-stacks.
+		if (material.name().contains("_WALL"))
+		{
+			// Materials that is attached to wall cannot be showed in GUI. But they should be in list.
+			itemStack = new ItemStack(Material.getMaterial(material.name().replace("WALL_", "")));
+		}
+		else if (material.name().startsWith("POTTED_"))
+		{
+			// Materials Potted elements cannot be in inventory.
+			itemStack = new ItemStack(Material.getMaterial(material.name().replace("POTTED_", "")));
+		}
+		else if (material.name().startsWith("POTTED_"))
+		{
+			// Materials Potted elements cannot be in inventory.
+			itemStack = new ItemStack(Material.getMaterial(material.name().replace("POTTED_", "")));
+		}
+		else if (material.equals(Material.MELON_STEM) || material.equals(Material.ATTACHED_MELON_STEM))
+		{
+			itemStack = new ItemStack(Material.MELON_SEEDS);
+		}
+		else if (material.equals(Material.PUMPKIN_STEM) || material.equals(Material.ATTACHED_PUMPKIN_STEM))
+		{
+			itemStack = new ItemStack(Material.PUMPKIN_SEEDS);
+		}
+		else if (material.equals(Material.TALL_SEAGRASS))
+		{
+			itemStack = new ItemStack(Material.SEAGRASS);
+		}
+		else if (material.equals(Material.CARROTS))
+		{
+			itemStack = new ItemStack(Material.CARROT);
+		}
+		else if (material.equals(Material.BEETROOTS))
+		{
+			itemStack = new ItemStack(Material.BEETROOT);
+		}
+		else if (material.equals(Material.POTATOES))
+		{
+			itemStack = new ItemStack(Material.POTATO);
+		}
+		else if (material.equals(Material.COCOA))
+		{
+			itemStack = new ItemStack(Material.COCOA_BEANS);
+		}
+		else if (material.equals(Material.KELP_PLANT))
+		{
+			itemStack = new ItemStack(Material.KELP);
+		}
+		else if (material.equals(Material.REDSTONE_WIRE))
+		{
+			itemStack = new ItemStack(Material.REDSTONE);
+		}
+		else if (material.equals(Material.TRIPWIRE))
+		{
+			itemStack = new ItemStack(Material.STRING);
+		}
+		else if (material.equals(Material.FROSTED_ICE))
+		{
+			itemStack = new ItemStack(Material.ICE);
+		}
+		else if (material.equals(Material.END_PORTAL) || material.equals(Material.END_GATEWAY) || material.equals(Material.NETHER_PORTAL))
+		{
+			itemStack = new ItemStack(Material.PAPER);
+		}
+		else if (material.equals(Material.BUBBLE_COLUMN) || material.equals(Material.WATER))
+		{
+			itemStack = new ItemStack(Material.WATER_BUCKET);
+		}
+		else if (material.equals(Material.LAVA))
+		{
+			itemStack = new ItemStack(Material.LAVA_BUCKET);
+		}
+		else if (material.equals(Material.FIRE))
+		{
+			itemStack = new ItemStack(Material.FIRE_CHARGE);
+		}
+		else if (material.equals(Material.AIR) || material.equals(Material.CAVE_AIR) || material.equals(Material.VOID_AIR))
+		{
+			itemStack = new ItemStack(Material.GLASS_BOTTLE);
+		}
+		else if (material.equals(Material.PISTON_HEAD) || material.equals(Material.MOVING_PISTON))
+		{
+			itemStack = new ItemStack(Material.PISTON);
+		}
+		else
+		{
+			itemStack = new ItemStack(material);
 		}
 
 		itemStack.setAmount(amount);

--- a/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
+++ b/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
@@ -1,0 +1,222 @@
+package world.bentobox.challenges.utils;
+
+
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
+
+import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+
+
+/**
+ * This class contains static methods that is used through multiple GUIs.
+ */
+public class GuiUtils
+{
+// ---------------------------------------------------------------------
+// Section: Border around GUIs
+// ---------------------------------------------------------------------
+
+
+	/**
+	 * This method creates border of black panes around given panel with 5 rows.
+	 * @param panelBuilder PanelBuilder which must be filled with border blocks.
+	 */
+	public static void fillBorder(PanelBuilder panelBuilder)
+	{
+		GuiUtils.fillBorder(panelBuilder, 5, Material.BLACK_STAINED_GLASS_PANE);
+	}
+
+
+	/**
+	 * This method sets black stained glass pane around Panel with given row count.
+	 * @param panelBuilder object that builds Panel.
+	 * @param rowCount in Panel.
+	 */
+	public static void fillBorder(PanelBuilder panelBuilder, int rowCount)
+	{
+		GuiUtils.fillBorder(panelBuilder, rowCount, Material.BLACK_STAINED_GLASS_PANE);
+	}
+
+
+	/**
+	 * This method sets blocks with given Material around Panel with 5 rows.
+	 * @param panelBuilder object that builds Panel.
+	 * @param material that will be around Panel.
+	 */
+	public static void fillBorder(PanelBuilder panelBuilder, Material material)
+	{
+		GuiUtils.fillBorder(panelBuilder, 5, material);
+	}
+
+
+	/**
+	 * This method sets blocks with given Material around Panel with given row count.
+	 * @param panelBuilder object that builds Panel.
+	 * @param rowCount in Panel.
+	 * @param material that will be around Panel.
+	 */
+	public static void fillBorder(PanelBuilder panelBuilder, int rowCount, Material material)
+	{
+		// Only for useful filling.
+		if (rowCount < 3)
+		{
+			return;
+		}
+
+		for (int i = 0; i < 9 * rowCount; i++)
+		{
+			// First (i < 9) and last (i > 35) rows must be filled
+			// First column (i % 9 == 0) and last column (i % 9 == 8) also must be filled.
+
+			if (i < 9 || i > 9 * (rowCount - 1) || i % 9 == 0 || i % 9 == 8)
+			{
+				panelBuilder.item(i, new PanelItemBuilder().name("&2").icon(material).build());
+			}
+		}
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Entities Visualization Block
+// ---------------------------------------------------------------------
+
+	/**
+	 * This method transforms entity into egg or block that corresponds given entity.
+	 * If entity egg is not found, then it is replaced by block that represents entity or
+	 * barrier block.
+	 * @param entity Entity which egg must be returned.
+	 * @return ItemStack that may be egg for given entity.
+	 */
+	public static ItemStack getEntityEgg(EntityType entity)
+	{
+		return GuiUtils.getEntityEgg(entity, 1);
+	}
+
+
+	/**
+	 * This method transforms entity into egg or block that corresponds given entity.
+	 * If entity egg is not found, then it is replaced by block that represents entity or
+	 * barrier block.
+	 * @param entity Entity which egg must be returned.
+	 * @param amount Amount of ItemStack elements.
+	 * @return ItemStack that may be egg for given entity.
+	 */
+	public static ItemStack getEntityEgg(EntityType entity, int amount)
+	{
+		ItemStack itemStack;
+
+		switch (entity)
+		{
+			case PIG_ZOMBIE:
+				itemStack = new ItemStack(Material.ZOMBIE_PIGMAN_SPAWN_EGG);
+				break;
+			case ENDER_DRAGON:
+				itemStack = new ItemStack(Material.DRAGON_EGG);
+				break;
+			case WITHER:
+				itemStack = new ItemStack(Material.SOUL_SAND);
+				break;
+			case PLAYER:
+				itemStack = new ItemStack(Material.PLAYER_HEAD);
+				break;
+			case MUSHROOM_COW:
+				itemStack = new ItemStack(Material.MOOSHROOM_SPAWN_EGG);
+				break;
+			case SNOWMAN:
+				itemStack = new ItemStack(Material.CARVED_PUMPKIN);
+				break;
+			case IRON_GOLEM:
+				itemStack = new ItemStack(Material.IRON_BLOCK);
+				break;
+			case ARMOR_STAND:
+				itemStack = new ItemStack(Material.ARMOR_STAND);
+				break;
+			default:
+				Material material = Material.getMaterial(entity.name() + "_SPAWN_EGG");
+
+				if (material == null)
+				{
+					itemStack = new ItemStack(Material.BARRIER);
+				}
+				else
+				{
+					itemStack = new ItemStack(material);
+				}
+
+				break;
+		}
+
+		itemStack.setAmount(amount);
+
+		return itemStack;
+	}
+
+
+	/**
+	 * This method transforms entity into player head with skin that corresponds given
+	 * entity. If entity head is not found, then it is replaced by barrier block.
+	 * @param entity Entity which head must be returned.
+	 * @return ItemStack that may be head for given entity.
+	 */
+	public static ItemStack getEntityHead(EntityType entity)
+	{
+		return GuiUtils.getEntityHead(entity, 1);
+	}
+
+
+	/**
+	 * This method transforms entity into player head with skin that corresponds given
+	 * entity. If entity head is not found, then it is replaced by barrier block.
+	 * @param entity Entity which head must be returned.
+	 * @param amount Amount of ItemStack elements.
+	 * @return ItemStack that may be head for given entity.
+	 */
+	public static ItemStack getEntityHead(EntityType entity, int amount)
+	{
+		ItemStack itemStack;
+
+		switch (entity)
+		{
+			case PLAYER:
+				itemStack = new ItemStack(Material.PLAYER_HEAD);
+				break;
+			case WITHER_SKELETON:
+				itemStack = new ItemStack(Material.WITHER_SKELETON_SKULL);
+				break;
+			case ARMOR_STAND:
+				itemStack = new ItemStack(Material.ARMOR_STAND);
+				break;
+			case SKELETON:
+				itemStack = new ItemStack(Material.SKELETON_SKULL);
+				break;
+			case GIANT:
+			case ZOMBIE:
+				itemStack = new ItemStack(Material.ZOMBIE_HEAD);
+				break;
+			case CREEPER:
+				itemStack = new ItemStack(Material.CREEPER_HEAD);
+				break;
+			case ENDER_DRAGON:
+				itemStack = new ItemStack(Material.DRAGON_HEAD);
+				break;
+			default:
+				HeadLib head = HeadLib.getHead(entity.name());
+
+				if (head == null)
+				{
+					itemStack = new ItemStack(Material.BARRIER);
+				}
+				else
+				{
+					itemStack = head.toItemStack();
+				}
+				break;
+		}
+
+		itemStack.setAmount(amount);
+
+		return itemStack;
+	}
+}

--- a/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
+++ b/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
@@ -245,7 +245,7 @@ public class GuiUtils
 		ItemStack itemStack;
 
 		// Process items that cannot be item-stacks.
-		if (material.name().contains("_WALL"))
+		if (material.name().contains("WALL_"))
 		{
 			// Materials that is attached to wall cannot be showed in GUI. But they should be in list.
 			itemStack = new ItemStack(Material.getMaterial(material.name().replace("WALL_", "")));

--- a/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
+++ b/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
@@ -6,7 +6,6 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -384,5 +383,23 @@ public class GuiUtils
 				Arrays.asList(WordUtils.wrap(line, 25).split("\\n"))));
 
 		return result;
+	}
+
+
+	/**
+	 * Simple splitter for all strings in list.
+	 * @param stringList - list of string to be split
+	 * @return list of split strings
+	 */
+	public static List<String> stringSplit(List<String> stringList)
+	{
+		if (stringList.isEmpty())
+		{
+			return stringList;
+		}
+
+		List<String> newList = new ArrayList<>(stringList.size());
+		stringList.stream().map(GuiUtils::stringSplit).forEach(newList::addAll);
+		return newList;
 	}
 }

--- a/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
+++ b/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
@@ -1,11 +1,16 @@
 package world.bentobox.challenges.utils;
 
 
+import org.apache.commons.lang.WordUtils;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
@@ -359,5 +364,25 @@ public class GuiUtils
 
 			return new BorderBlock(itemStack);
 		}
+	}
+
+
+	/**
+	 * Simple splitter
+	 *
+	 * @param string - string to be split
+	 * @return list of split strings
+	 */
+	public static List<String> stringSplit(String string)
+	{
+		string = ChatColor.translateAlternateColorCodes('&', string);
+		// Check length of lines
+		List<String> result = new ArrayList<>();
+
+		Arrays.asList(string.split("\\|")).
+			forEach(line -> result.addAll(
+				Arrays.asList(WordUtils.wrap(line, 25).split("\\n"))));
+
+		return result;
 	}
 }

--- a/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
+++ b/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
@@ -374,13 +374,15 @@ public class GuiUtils
 	 */
 	public static List<String> stringSplit(String string)
 	{
+		// Remove all ending lines from string.
+		string = string.replaceAll("([\\r\\n])", "\\|");
 		string = ChatColor.translateAlternateColorCodes('&', string);
 		// Check length of lines
 		List<String> result = new ArrayList<>();
 
-		Arrays.asList(string.split("\\|")).
-			forEach(line -> result.addAll(
-				Arrays.asList(WordUtils.wrap(line, 25).split("\\n"))));
+		Arrays.stream(string.split("\\|")).
+			map(line -> Arrays.asList(WordUtils.wrap(line, 25).split("\\r\\n"))).
+			forEach(result::addAll);
 
 		return result;
 	}

--- a/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
+++ b/src/main/java/world/bentobox/challenges/utils/GuiUtils.java
@@ -255,11 +255,6 @@ public class GuiUtils
 			// Materials Potted elements cannot be in inventory.
 			itemStack = new ItemStack(Material.getMaterial(material.name().replace("POTTED_", "")));
 		}
-		else if (material.name().startsWith("POTTED_"))
-		{
-			// Materials Potted elements cannot be in inventory.
-			itemStack = new ItemStack(Material.getMaterial(material.name().replace("POTTED_", "")));
-		}
 		else if (material.equals(Material.MELON_STEM) || material.equals(Material.ATTACHED_MELON_STEM))
 		{
 			itemStack = new ItemStack(Material.MELON_SEEDS);

--- a/src/main/java/world/bentobox/challenges/utils/LevelStatus.java
+++ b/src/main/java/world/bentobox/challenges/utils/LevelStatus.java
@@ -1,4 +1,4 @@
-package world.bentobox.challenges;
+package world.bentobox.challenges.utils;
 
 import world.bentobox.challenges.database.object.ChallengeLevel;
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,16 +1,31 @@
-# Challenges Config
-
+# Challenges Configuration ${project.version}
+# This config file is dynamic and saved when the server is shutdown.
+# You cannot edit it while the server is running because changes will
+# be lost! Use in-game settings GUI or edit when server is offline.
+#
+#
 # Reset Challenges - if this is true, player's challenges will reset when they
 # reset an island or if they are kicked or leave a team. Prevents exploiting the
 # challenges by doing them repeatedly.
-resetchallenges: true
-
+resetChallenges: true
+#
 # Broadcast 1st time challenge completion messages to all players.
 # Change to false if the spam becomes too much.
-broadcastmessages: true
-
-# Remove non-repeatable challenges from the challenge GUI when complete
-removecompleteonetimechallenges: false
-
+broadcastMessages: true
+#
+# Remove non-repeatable challenges from the challenge GUI when complete.
+removeCompleteOneTimeChallenges: false
+#
 # Add enchanted glow to completed challenges
-addcompletedglow: true
+addCompletedGlow: true
+#
+# This indicate if free challenges must be at the start (true) or at the end (false) of list.
+freeChallengesFirst: false
+#
+# This list stores GameModes in which Challenges addon should not work.
+# To disable addon it is necessary to write its name in new line that starts with -. Example:
+# disabled-gamemodes:
+#  - BSkyBlock
+disabled-gamemodes: []
+#
+uniqueId: config

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -73,6 +73,7 @@ challenges:
         reward-problem: '&cThere was a problem giving your reward. Ask Admin to check
             log!'
         you-still-need: '&cYou still need [amount] x [item]'
+        not-deployed: '&cChallenge is not deployed.'
     errors:
         challenge-level-not-available: You have not unlocked level to complete this challenge.
         unique-id: Unique ID [id] is already taken. Choose different.

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -135,6 +135,7 @@ challenges:
                 toggle-users: Choose players
                 type: Challenge Type
                 waiver-amount: Waiver Amount
+                import: Import
             choose-challenge-title: Challenges List
             choose-level-title: Levels List
             choose-user-title: Users List

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -6,98 +6,211 @@
 ### Credits ###
 # Tastybento: maintainer
 
-challenges: 
-  admin: 
-    challenge-created: "[challenge] created!"
-    complete: 
-      description: "Mark challenge complete"
-      parameters: "<player> <unique challenge name>"
-      unknown-challenge: "&cUnknown challenge"
-    create: 
-      description: "&6Collect:"
-      description-item-color: "&B"
-      inventory: 
-        description: "create an inventory challenge"
-        parameters: "[challenge name]"
-      surrounding: 
-        description: "create a surrounding challenge"
-        hit-things: "Hit things to add them to the list of things required. Right click when done."
-        parameters: "[challenge name]"
-    description: "challenges admin"
-    error: 
-      no-name: "You must include a challenge name"
-    gui-title: "&aChallenges Admin"
-    import: 
-      description: "import challenges from challenges.yml"
-      imported: "Imported '[challenge]'"
-      levels: "Importing levels: [levels]"
-      no-file: "&cCould not find challenges.yml file to import!"
-      no-levels: "Warning: No levels defined in challenges.yml"
-      no-load: "&cError: Could not load challenges.yml. [message]"
-      number: "Imported [number] challenges"
-      overwriting: "Overwriting '[challenge]'"
-      parameters: "[overwrite]"
-      skipping: "'[challenge]' already exists - skipping"
-    parameters: ""
-    reload: 
-      description: "reload challenges from the database"
-      parameters: ""
-    reset: 
-      description: "Reset challenge to 0 times / incomplete"
-      parameters: "<player> <unique challenge name>"
-    seticon: 
-      description: "sets the challenge icon to inhand item"
-      error: 
-        no-such-challenge: "&cNo such challenge name"
-      parameters: "[challenge name]"
-    you-added: "You added one [thing] to the challenge"
-  challenge: 
-    format: "[description]"
-  complete: "&BComplete"
-  completechallenge: 
-    challange-completed: "Challenge: [challengename] has been completed for [name]"
-  completed-times: "Completed [donetimes] out of [maxtimes]"
-  description: "Open the challenges menu"
-  error: 
-    could-not-save: "&cCould not save the challenge!"
-    island-level: "&cYour island must be level [number] to complete this challenge!"
-    items-not-there: "&cAll required items must be close to you on your island!"
-    no-items-clicked: "&cYou did not click on anything. Cancelling."
-    not-close-enough: "&cYou must be standing within [number] blocks of all required items."
-    not-enough-items: "&cYou do not have enough [items] to complete this challenge!"
-    not-on-island: "&cYou must be on your island to do that!"
-    reward-problem: "&cThere was a problem giving your reward. Ask Admin to check log!"
-    you-still-need: "&cYou still need [amount] x [item]"
-  exp-reward: "&6Exp reward: [reward]"
-  first-time-rewards: "&6First time reward(s)"
-  gui-title: "&aChallenges"
-  help: 
-    command: "/challenges: &fshow challenges"
-    config-reloaded: "Configuration reloaded from file."
-    reset-all-challenges: "resets all of the player's challenges"
-    reset-challenge: "marks a challenge as incomplete"
-    reset-challenge-for-all: "globally resets a challenge for every player with an optional repetition"
-  incomplete: Incomplete
-  item-take-warning: "&cAll required items are|&ctaken when you complete|&cthis challenge!"
-  items-closeby: "&cAll required items|&cmust be close to you|&con your island!"
-  level: "&FLevel: [level]"
-  max-reached: "Max reached [donetimes] out of [maxtimes]"
-  money-reward: "&6Money reward: $[reward]"
-  name: "Challenge Name"
-  name-has-completed: "[name] has completed the [challenge] challenge!"
-  navigation: "Click to see [level] challenges!"
-  not-repeatable: "This challenge is not repeatable!"
-  parameters: "[Level]"
-  repeat-rewards: "&6Repeat reward(s)"
-  repeatable: "This challenge can be repeated [maxtimes] times"
-  resetallchallenges: 
-    success: "[name] has had all challenges reset."
-  resetchallenge: 
-    challenge-reset: "Challenge: [challengename] has been reset for [name]"
-    error-challenge-does-not-exist: "Challenge doesn't exist or isn't yet completed"
-  rewards: "&FReward(s)"
-  to-complete: "Complete [challengesToDo] more [thisLevel] challenges to unlock this level!"
-  you-completed: "You completed the [challenge] challenge!"
-  you-repeated: "You repeated the [challenge] challenge!"
-  not-enough-money: "It is necessary to have [money] on your account to complete the challenge."
-  not-enough-exp: "It is necessary to have [xp] EXP to complete challenge."
+challenges:
+    admin:
+        challenge-created: '[challenge] created!'
+        complete:
+            description: Mark challenge complete
+            parameters: <player> <unique challenge name>
+            unknown-challenge: '&cUnknown challenge'
+        create:
+            description: '&6Collect:'
+            description-item-color: '&B'
+            inventory:
+                description: create an inventory challenge
+                parameters: '[challenge name]'
+            surrounding:
+                description: create a surrounding challenge
+                hit-things: Hit things to add them to the list of things required. Right click when done.
+                parameters: '[challenge name]'
+        description: challenges admin
+        error:
+            no-name: You must include a challenge name
+        gui-title: '&aChallenges Admin'
+        import:
+            add: 'Adding new challenge: [object]'
+            description: import challenges from challenges.yml
+            imported: Imported '[challenge]'
+            levels: 'Importing levels: [levels]'
+            no-file: '&cCould not find challenges.yml file to import!'
+            no-levels: 'Warning: No levels defined in challenges.yml'
+            no-load: '&cError: Could not load challenges.yml. [message]'
+            number: Imported [number] challenges
+            overwriting: Overwriting '[challenge]'
+            parameters: '[overwrite]'
+            skipping: '''[challenge]'' already exists - skipping'
+        parameters: ''
+        reload:
+            description: reload challenges from the database
+            parameters: ''
+        reset:
+            description: Reset challenge to 0 times / incomplete
+            parameters: <player> <unique challenge name>
+        seticon:
+            description: sets the challenge icon to inhand item
+            error:
+                no-such-challenge: '&cNo such challenge name'
+            parameters: '[challenge name]'
+        you-added: You added one [thing] to the challenge
+    blocks-take-warning: Blocks will be removed.
+    challenge:
+        format: '[description]'
+    complete: '&BComplete'
+    completechallenge:
+        challange-completed: 'Challenge: [challengename] has been completed for [name]'
+    completed-times: Completed [donetimes] out of [maxtimes]
+    description: Open the challenges menu
+    entities-kill-warning: Entities will be killed.
+    error:
+        could-not-save: '&cCould not save the challenge!'
+        island-level: '&cYour island must be level [number] to complete this challenge!'
+        items-not-there: '&cAll required items must be close to you on your island!'
+        no-items-clicked: '&cYou did not click on anything. Cancelling.'
+        not-close-enough: '&cYou must be standing within [number] blocks of all required
+            items.'
+        not-enough-items: '&cYou do not have enough [items] to complete this challenge!'
+        not-on-island: '&cYou must be on your island to do that!'
+        reward-problem: '&cThere was a problem giving your reward. Ask Admin to check
+            log!'
+        you-still-need: '&cYou still need [amount] x [item]'
+    errors:
+        challenge-level-not-available: You have not unlocked level to complete this challenge.
+        unique-id: Unique ID [id] is already taken. Choose different.
+        wrong-environment: You are in wrong environment!
+        wrong-icon: Material [icon] is not recognized
+    exp-reward: '&6Exp reward: [reward]'
+    first-time-rewards: '&6First time reward(s)'
+    gui:
+        admin:
+            buttons:
+                add-challenge: Create Challenge
+                add-level: Create Level
+                blocks: Blocks
+                broadcast: Broadcast Messages
+                challenges: Challenges
+                complete: Complete
+                delete-challenge: Delete Challenge
+                delete-level: Delete Level
+                deployed: Deployment status
+                description: Description
+                edit-challenge: Edit Challenge
+                edit-level: Edit Level
+                entities: Entities
+                environment: Environment
+                free-challenges: Free Challenges Position
+                glow: Completion Glowing
+                icon: Icon
+                name: Name
+                order: Order Number
+                permissions: Permissions
+                properties: Properties
+                remove-blocks: Remove Blocks
+                remove-challenge: Remove Challenge
+                remove-entities: Remove Entities
+                remove-exp: Take Experience
+                remove-items: Remove items
+                remove-money: Remove Money
+                remove-on-complete: Remove on completion
+                repeat-count: Repeat Count
+                repeat-reward-command: Repeat Reward Command
+                repeat-reward-exp: Repeat Reward Experience
+                repeat-reward-items: Repeat Reward Items
+                repeat-reward-money: Repeat Reward Money
+                repeat-reward-text: Repeat Reward Text
+                repeatable: Repeatable
+                required-exp: Required Experience
+                required-items: Required items
+                required-level: Required Island Level
+                required-money: Required Money
+                requirements: Requirements
+                reset: Reset
+                reward-command: Reward Command
+                reward-exp: Reward Experience
+                reward-items: Reward Items
+                reward-money: Reward Money
+                reward-text: Reward Text
+                rewards: Rewards
+                search-radius: Search radius
+                settings: Settings
+                toggle-users: Choose players
+                type: Challenge Type
+                waiver-amount: Waiver Amount
+            choose-challenge-title: Challenges List
+            choose-level-title: Levels List
+            choose-user-title: Users List
+            descriptions:
+                broadcast: Broadcast 1st time challenge completion messages to all players.
+                disabled: disabled
+                enabled: enabled
+                free-challenges: This indicate if free challenges must be at the start (true) or at the end (false) of list.
+                glow: Add enchanted glow to completed challenges
+                in_world: In World
+                inventory: This type of challenges allows to define blocks and entities on island requirements.
+                island: This type of challenges allows to define inventory item requirements.
+                nether: Nether
+                normal: Normal
+                online: Online
+                order: Current order [value]
+                other: This type of challenges allows to define Money, Experience or island level requirements.
+                remove-on-complete: Remove non-repeatable challenges from the challenge GUI when complete.
+                repeat-count: 'Current value: [value]'
+                repeat-reward-exp: 'Current value: [value]'
+                repeat-reward-money: 'Current value: [value]'
+                required-exp: Current necessary [value]
+                required-level: 'Current value: [value]'
+                required-money: 'Current value: [value]'
+                reset: Reset Challenges - if this is true, player's challenges will reset when they reset an island or if they are kicked or leave a team
+                reward-exp: 'Current value: [value]'
+                reward-money: 'Current value: [value]'
+                search-radius: Current radius [value]
+                the_end: The End
+                waiver-amount: 'Current value: [value]'
+                with_island: With Island
+            edit-challenge-title: Edit Challenge
+            edit-entities: Manage Entities
+            edit-level-title: Edit Levels
+            manage-blocks: Manage Blocks
+            settings-title: Edit Settings
+        button:
+            add: Add
+            remove-selected: Remove Selected
+        buttons:
+            back: Return
+            next: Next
+            previous: Previous
+        title: '"Challenges GUI"'
+    gui-title: '&aChallenges'
+    help:
+        command: '/challenges: &fshow challenges'
+        config-reloaded: Configuration reloaded from file.
+        reset-all-challenges: resets all of the player's challenges
+        reset-challenge: marks a challenge as incomplete
+        reset-challenge-for-all: globally resets a challenge for every player with an optional repetition
+    incomplete: Incomplete
+    item-take-warning: '&cAll required items are|&ctaken when you complete|&cthis
+        challenge!'
+    items-closeby: '&cAll required items|&cmust be close to you|&con your island!'
+    level: '&FLevel: [level]'
+    max-reached: Max reached [donetimes] out of [maxtimes]
+    maxed-reached: Completed [donetimes] out of [maxtimes]
+    money-reward: '&6Money reward: $[reward]'
+    name: Challenge Name
+    name-has-completed: '[name] has completed the [challenge] challenge!'
+    name-has-completed-level: '[name] completed all challenges in [level]!'
+    navigation: Click to see [level] challenges!
+    not-enough-exp: It is necessary to have [xp] EXP to complete challenge.
+    not-enough-money: It is necessary to have [money] on your account to complete the challenge.
+    not-repeatable: This challenge is not repeatable!
+    parameters: '[Level]'
+    repeat-rewards: '&6Repeat reward(s)'
+    repeatable: This challenge can be repeated [maxtimes] times
+    resetallchallenges:
+        success: '[name] has had all challenges reset.'
+    resetchallenge:
+        challenge-reset: 'Challenge: [challengename] has been reset for [name]'
+        error-challenge-does-not-exist: Challenge doesn't exist or isn't yet completed
+    rewards: '&FReward(s)'
+    to-complete: Complete [challengesToDo] more [thisLevel] challenges to unlock this level!
+    you-completed: You completed the [challenge] challenge!
+    you-completed-level: Congratulations, you complete [level]!
+    you-repeated: You repeated the [challenge] challenge!

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -134,7 +134,7 @@ challenges:
                 search-radius: Search radius
                 settings: Settings
                 toggle-users: Choose players
-                type: Challenge Type
+                type: 'Challenge Type: [value]'
                 waiver-amount: Waiver Amount
                 import: Import
             choose-challenge-title: Challenges List

--- a/src/test/java/world/bentobox/challenges/ChallengesAddonTest.java
+++ b/src/test/java/world/bentobox/challenges/ChallengesAddonTest.java
@@ -35,8 +35,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import world.bentobox.challenges.database.object.Challenges;
-import world.bentobox.challenges.database.object.Challenges.ChallengeType;
+import world.bentobox.challenges.database.object.Challenge;
+import world.bentobox.challenges.database.object.Challenge.ChallengeType;
 
 /**
  * @author tastybento
@@ -81,7 +81,7 @@ public class ChallengesAddonTest {
     public void test() {
         
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        Challenges challenges = new Challenges();
+        Challenge challenges = new Challenge();
         challenges.setChallengeType(ChallengeType.ISLAND);
         Map<Material, Integer> map = new HashMap<>();
         map.put(Material.DIRT, 5);

--- a/src/test/java/world/bentobox/challenges/ParseItemTest.java
+++ b/src/test/java/world/bentobox/challenges/ParseItemTest.java
@@ -26,6 +26,7 @@ import world.bentobox.challenges.ChallengesAddon;
 import world.bentobox.challenges.ParseItem;
 
 @RunWith(PowerMockRunner.class)
+@Deprecated
 public class ParseItemTest {
 
     private static ChallengesAddon addon;


### PR DESCRIPTION
Completely rework Challenges Addon

- Fix issues that does not allow to complete challenges in other dimensions. (#50)
- Fix issues with breaking challenges if admin edit it via admin GUI (#48)
- Add ability to define Challenge order (#46)
- Improve level unlocking calculation (#23)

- Add possibility to set in which GameModes addon should not work.
- Add possibility to set free challenge location (at the top, or at the bottom)
- Add possibility to Add/Edit/Delete Challenges and Levels from GUI.
- Add possibility to Settings from GUI.
- Change challenges and levels to DataBase objects.
- Levels are now based per GameMode (each game mode has their own levels)

- Other small fixes and tweaks.

