### PR TITLE
fix build testing

### DIFF
--- a/src/test/java/world/bentobox/challenges/commands/CompleteChallengeCommandTest.java
+++ b/src/test/java/world/bentobox/challenges/commands/CompleteChallengeCommandTest.java
@@ -203,7 +203,7 @@ public class CompleteChallengeCommandTest {
      */
     @Test
     public void testSetup() {
-        assertEquals("bskyblock.complete", cc.getPermission());
+        assertEquals("bskyblock.challenges", cc.getPermission());
         assertEquals("challenges.commands.user.complete.parameters", cc.getParameters());
         assertEquals("challenges.commands.user.complete.description", cc.getDescription());
         assertTrue(cc.isOnlyPlayer());


### PR DESCRIPTION
since the bskyblock.complete permission was renamed to bskyblock.challenges, this PR updates it in the test file

