### PR TITLE
Fixes enchanted book meta not displayed

### DIFF
--- a/src/main/java/world/bentobox/challenges/utils/Utils.java
+++ b/src/main/java/world/bentobox/challenges/utils/Utils.java
@@ -823,7 +823,7 @@ public class Utils
 
 		StringBuilder builder = new StringBuilder();
 
-		enchantmentMeta.getEnchants().forEach((enchantment, level) -> {
+		enchantmentMeta.getStoredEnchants().forEach((enchantment, level) -> {
 			builder.append("\n");
 			builder.append(user.getTranslationOrNothing(Constants.ITEM_STACKS + "meta.enchant-meta",
 				"[type]", prettifyObject(enchantment, user),


### PR DESCRIPTION
Apparently in Spigot EnchantmentStorage has a map that is not used for enchantment storing. Nice.

Fixes #327