### PR TITLE
lore-length readded + Ability to set some GUI default colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ local.properties
 checkstyle.xml
 classes/
 /.DS_Store
+
+#Netbeans
+nbactions.xml

--- a/src/main/java/world/bentobox/challenges/config/Settings.java
+++ b/src/main/java/world/bentobox/challenges/config/Settings.java
@@ -111,6 +111,12 @@ public class Settings implements ConfigObject
 
 
     @ConfigComment("")
+    @ConfigComment("This allows to change lore description line length. By default it is 25, but some server")
+    @ConfigComment("owners may like it to be larger. Set it to -1 to disable it.")
+    @ConfigEntry(path = "gui-settings.lore-length")
+    private int loreLength = 25;
+    
+    @ConfigComment("")
     @ConfigComment("This allows to change default locked level icon. This option may be")
     @ConfigComment("overwritten by each challenge level. If challenge level has specified")
     @ConfigComment("their locked level icon, then it will be used, instead of this one.")
@@ -384,6 +390,17 @@ public class Settings implements ConfigObject
     {
         return this.visibilityMode;
     }
+    
+    
+    
+     /**
+     * This method returns the loreLength value.
+     * @return the value of loreLength.
+     */
+    public int getLoreLength()
+    {
+        return this.loreLength;
+    }
 
 
 // ---------------------------------------------------------------------
@@ -602,6 +619,16 @@ public class Settings implements ConfigObject
     public void setVisibilityMode(VisibilityMode visibilityMode)
     {
         this.visibilityMode = visibilityMode;
+    }
+    
+    /**
+     * This method sets the loreLength value.
+     * @param loreLength the loreLength new value.
+     *
+     */
+    public void setLoreLength(int loreLength)
+    {
+        this.loreLength = loreLength;
     }
 
 

--- a/src/main/java/world/bentobox/challenges/panel/CommonPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/CommonPanel.java
@@ -11,6 +11,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.bukkit.Bukkit;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -131,13 +132,20 @@ public abstract class CommonPanel {
         final String reference = Constants.DESCRIPTIONS + "challenge.";
 
         // Get description from custom translations
-        String description = this.user
-                .getTranslationOrNothing("challenges.challenges." + challenge.getUniqueId() + ".description");
+        String description = this.user.getTranslationOrNothing("challenges.challenges." + challenge.getUniqueId() + ".description");
 
         if (description.isEmpty()) {
             // Get data from object in single string.
             description = Util.translateColorCodes(String.join("\n", challenge.getDescription()));
         }
+        
+        String descriptionColor = this.user.getTranslationOrNothing(reference + "description.color");
+        
+        description = descriptionColor + description;
+        
+        if (this.addon.getChallengesSettings().getLoreLength() > -1 ) {
+            description = Utils.stringSplit(description, this.addon.getChallengesSettings().getLoreLength());
+        }        
 
         // Non-memory optimal code used for easier debugging and nicer code layout for
         // my eye :)
@@ -586,12 +594,20 @@ public abstract class CommonPanel {
         }
 
         String rewardText = this.user
-                .getTranslationOrNothing("challenges.challenges." + challenge.getUniqueId() + ".repeat-reward-text");
+                .getTranslationOrNothing("challenges.challenges." + challenge.getUniqueId() + ".repeat-reward-text");        
 
         if (rewardText.isEmpty()) {
             rewardText = Util.translateColorCodes(String.join("\n", challenge.getRepeatRewardText()));
         }
-
+        
+        String rewardTextColor = this.user.getTranslationOrNothing(reference + "text-color");
+        
+        rewardText = rewardTextColor + rewardText;
+        
+        if (this.addon.getChallengesSettings().getLoreLength() > -1 ) {
+            rewardText = Utils.stringSplit(rewardText, this.addon.getChallengesSettings().getLoreLength());
+        }  
+        
         return this.user.getTranslationOrNothing(reference + "lore", "[text]", rewardText, "[items]", items,
                 "[experience]", experience, "[money]", money, "[commands]", commands);
     }
@@ -670,6 +686,14 @@ public abstract class CommonPanel {
         if (rewardText.isEmpty()) {
             rewardText = Util.translateColorCodes(String.join("\n", challenge.getRewardText()));
         }
+        
+        String rewardTextColor = this.user.getTranslationOrNothing(reference + "text-color");
+        
+        rewardText = rewardTextColor + rewardText;
+        
+        if (this.addon.getChallengesSettings().getLoreLength() > -1 ) {
+            rewardText = Utils.stringSplit(rewardText, this.addon.getChallengesSettings().getLoreLength());
+        }     
 
         return this.user.getTranslationOrNothing(reference + "lore", "[text]", rewardText, "[items]", items,
                 "[experience]", experience, "[money]", money, "[commands]", commands);

--- a/src/main/java/world/bentobox/challenges/utils/Utils.java
+++ b/src/main/java/world/bentobox/challenges/utils/Utils.java
@@ -3,9 +3,11 @@ package world.bentobox.challenges.utils;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import org.apache.commons.lang3.text.WordUtils;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -922,4 +924,37 @@ public class Utils
 
 		return returnString;
 	}
+        
+        /**
+         * This method splits a string in lines with a maximum length
+         *
+         * @param maxLength that each line can be.
+         * @return a list of the splitted lines.
+         */
+        public static List<String> stringSplitList(String string, int maxLength) {
+            // Remove all ending lines from string.
+            string = string.replaceAll("([\\r\\n])", "\\|");
+            string = ChatColor.translateAlternateColorCodes('&', string);
+            // Check length of lines
+            List<String> result = new ArrayList<>();
+
+            Arrays.stream(string.split("\\|")).
+                    map(line -> Arrays.asList(WordUtils.wrap(line, maxLength).split(System.getProperty("line.separator")))).
+                    forEach(result::addAll);
+
+            // Fix colors, as splitting my lost that information.
+            for (int i = 0, resultSize = result.size(); i < resultSize; i++) {
+                if (i > 0) {
+                    String lastColor = ChatColor.getLastColors(result.get(i - 1));
+                    result.set(i, lastColor + result.get(i));
+                }
+            }
+
+            return result;
+        }
+
+        public static String stringSplit(String string, int maxLength) {
+            List<String> splitted = stringSplitList(string, maxLength);
+            return String.join("\n", splitted);
+        }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -83,6 +83,10 @@ gui-settings:
     ==: org.bukkit.inventory.ItemStack
     v: 2730
     type: BARRIER
+  #
+  # This allows to change lore description line length. By default it is 25, but some server
+  # owners may like it to be larger. Set it to -1 to disable it.
+  lore-length: 25
 #
 # This indicate if challenges data will be stored per island (true) or per player (false).
 store-island-data: true

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -867,6 +867,9 @@ challenges:
                     [cooldown]
                     [requirements]
                     [rewards]
+                description:
+                    # Formatting applied to description text ([description])
+                    color: '&b'
                 # Contains a text generated inside [status] lore
                 status:
                     # Status message for completed unrepeatable challenge
@@ -988,6 +991,8 @@ challenges:
                         [experience]
                         [money]
                         [commands]
+                    # Formatting applied to reward text ([text])
+                    text-color: '&b'
                     # Title that will be used if there are list of items for rewards
                     item-title: "&7 Items:"
                     # Listing of an item that are rewards multiple times.


### PR DESCRIPTION
I think lore-length was a great addition. I know it was removed because of problems with some languages. That's why I've made it to be disabled if the user changes it to -1.

I've also added the ability to use default colors for challenge description text and rewards text. When you have a lot of challenges it is very tedious to start every text with the same color.

Tested and working.

```
            challenge:
                # The main part that generates description text.
                # [description] comes from challenge.description
                lore: |-
                    [description]
                    [status]
                    [cooldown]
                    [requirements]
                    [rewards]
                description:
                    # Formatting applied to description text ([description])
                    color: '&b'
```


```
rewards:
                    # [text] comes from challenge.rewardText and challenge.repeatRewardText
                    lore: |-
                        &7&l Rewards:
                        [text]
                        [items]
                        [experience]
                        [money]
                        [commands]
                    # Formatting applied to reward text ([text])
                    text-color: '&b'
```