### PR TITLE
Add switch to hide reward items from the GUI list.

### DIFF
--- a/src/main/java/world/bentobox/challenges/database/object/Challenge.java
+++ b/src/main/java/world/bentobox/challenges/database/object/Challenge.java
@@ -928,7 +928,7 @@ public class Challenge implements DataObject
     /**
      * @param hideRewardItems the hideRewardItems to set
      */
-    public void setHideRewardItems(boolean hideRewardItems) {
+    public void setHideRewardItems(Boolean hideRewardItems) {
         this.hideRewardItems = hideRewardItems;
     }
 }

--- a/src/main/java/world/bentobox/challenges/database/object/Challenge.java
+++ b/src/main/java/world/bentobox/challenges/database/object/Challenge.java
@@ -164,6 +164,12 @@ public class Challenge implements DataObject
     private List<ItemStack> rewardItems = new ArrayList<>();
 
     /**
+     * Hide the list of reward items in the GUI
+     */
+    @Expose
+    private Boolean hideRewardItems;
+
+    /**
      * Experience point reward
      */
     @Expose
@@ -857,37 +863,49 @@ public class Challenge implements DataObject
         try
         {
             clone = new Challenge();
+            // Copy primitive and String fields
             clone.setUniqueId(this.uniqueId);
             clone.setFriendlyName(this.friendlyName);
             clone.setDeployed(this.deployed);
-            clone.setDescription(new ArrayList<>(this.description));
-            clone.setIcon(this.icon.clone());
             clone.setOrder(this.order);
-            clone.setChallengeType(ChallengeType.valueOf(this.challengeType.name()));
-            clone.setEnvironment(new HashSet<>(this.environment));
             clone.setLevel(this.level);
+
+            // Clone collections (Strings are immutable so shallow copy is fine)
+            clone.setDescription(new ArrayList<>(this.description));
+            clone.setEnvironment(new HashSet<>(this.environment));
+            clone.setRewardCommands(new ArrayList<>(this.rewardCommands));
+            clone.setIgnoreRewardMetaData(new HashSet<>(this.ignoreRewardMetaData));
+
+            // Clone mutable objects (ItemStacks, etc.)
+            clone.setIcon(this.icon.clone());
+            clone.setRewardItems(this.rewardItems.stream().map(ItemStack::clone)
+                    .collect(Collectors.toCollection(() -> new ArrayList<>(this.rewardItems.size()))));
+            clone.setRepeatItemReward(this.repeatItemReward.stream().map(ItemStack::clone)
+                    .collect(Collectors.toCollection(() -> new ArrayList<>(this.repeatItemReward.size()))));
+            clone.setRepeatRewardCommands(new ArrayList<>(this.repeatRewardCommands));
+
+            // Clone enum field
+            clone.setChallengeType(ChallengeType.valueOf(this.challengeType.name()));
+
+            // Clone boolean and numeric fields
             clone.setRemoveWhenCompleted(this.removeWhenCompleted);
-            clone.setRequirements(this.requirements.copy());
-            clone.setRewardText(this.rewardText);
-            clone.setRewardItems(
-                this.rewardItems.stream().
-                    map(ItemStack::clone).
-                    collect(Collectors.toCollection(() -> new ArrayList<>(this.rewardItems.size()))));
             clone.setRewardExperience(this.rewardExperience);
             clone.setRewardMoney(this.rewardMoney);
-            clone.setRewardCommands(new ArrayList<>(this.rewardCommands));
             clone.setRepeatable(this.repeatable);
+            clone.setTimeout(this.timeout);
             clone.setRepeatRewardText(this.repeatRewardText);
             clone.setMaxTimes(this.maxTimes);
             clone.setRepeatExperienceReward(this.repeatExperienceReward);
-            clone.setRepeatItemReward(
-                this.repeatItemReward.stream().
-                    map(ItemStack::clone).
-                    collect(Collectors.toCollection(() -> new ArrayList<>(this.repeatItemReward.size()))));
             clone.setRepeatMoneyReward(this.repeatMoneyReward);
-            clone.setRepeatRewardCommands(new ArrayList<>(this.repeatRewardCommands));
-            clone.setTimeout(this.timeout);
-            clone.setIgnoreRewardMetaData(new HashSet<>(this.ignoreRewardMetaData));
+
+            // Copy custom objects
+            clone.setRequirements(this.requirements.copy());
+
+            // Clone the remaining String field
+            clone.setRewardText(this.rewardText);
+
+            // Clone the Boolean field
+            clone.setHideRewardItems(this.hideRewardItems);
         }
         catch (Exception e)
         {
@@ -898,5 +916,19 @@ public class Challenge implements DataObject
         }
 
         return clone;
+    }
+
+    /**
+     * @return the hideRewardItems
+     */
+    public boolean isHideRewardItems() {
+        return Objects.requireNonNullElse(hideRewardItems, false);
+    }
+
+    /**
+     * @param hideRewardItems the hideRewardItems to set
+     */
+    public void setHideRewardItems(boolean hideRewardItems) {
+        this.hideRewardItems = hideRewardItems;
     }
 }

--- a/src/main/java/world/bentobox/challenges/panel/CommonPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/CommonPanel.java
@@ -661,7 +661,7 @@ public abstract class CommonPanel {
 
         String items;
 
-        if (!challenge.getRewardItems().isEmpty()) {
+        if (!challenge.getRewardItems().isEmpty() && !challenge.isHideRewardItems()) {
             StringBuilder builder = new StringBuilder();
             builder.append(this.user.getTranslationOrNothing(reference + "item-title"));
             Utils.groupEqualItems(challenge.getRewardItems(), challenge.getIgnoreRewardMetaData()).stream()

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengePanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengePanel.java
@@ -150,6 +150,7 @@ public class EditChallengePanel extends CommonPanel {
         panelBuilder.listener(new IconChanger());
 
         panelBuilder.item(10, this.createButton(Button.NAME));
+        panelBuilder.item(13, this.createButton(Button.HIDE_REWARD_ITEMS));
         panelBuilder.item(16, this.createButton(Button.DEPLOYED));
 
         panelBuilder.item(19, this.createButton(Button.ICON));
@@ -376,6 +377,30 @@ public class EditChallengePanel extends CommonPanel {
             description.add("");
             description.add(this.user.getTranslation(Constants.TIPS + "click-to-change"));
         }
+        case HIDE_REWARD_ITEMS -> {
+            description.add(this.user
+                    .getTranslation(reference + (this.challenge.isHideRewardItems() ? "hide" : "show")));
+
+            icon = new ItemStack(Material.LEVER);
+            clickHandler = (panel, user, clickType, slot) -> {
+                if (this.challenge.isValid()) {
+                    this.challenge.setHideRewardItems(!challenge.isHideRewardItems()); // Toggle
+                } else {
+                    Utils.sendMessage(this.user, this.world, Constants.CONVERSATIONS + "invalid-challenge",
+                            Constants.PARAMETER_CHALLENGE, this.challenge.getFriendlyName());
+                    this.challenge.setDeployed(false);
+                }
+
+                this.build();
+                return true;
+            };
+            glow = this.challenge.isDeployed();
+
+            description.add("");
+            description.add(this.user.getTranslation(Constants.TIPS + "click-to-toggle"));
+
+        }
+
         case DEPLOYED -> {
             description
                     .add(this.user.getTranslation(reference + (this.challenge.isDeployed() ? "enabled" : "disabled")));
@@ -1651,7 +1676,7 @@ public class EditChallengePanel extends CommonPanel {
      * Represents different buttons that could be in menus.
      */
     private enum Button {
-        NAME, DEPLOYED, ICON, DESCRIPTION, ORDER, ENVIRONMENT, REMOVE_ON_COMPLETE,
+        NAME, DEPLOYED, ICON, DESCRIPTION, ORDER, ENVIRONMENT, REMOVE_ON_COMPLETE, HIDE_REWARD_ITEMS,
     }
 
     /**

--- a/src/main/java/world/bentobox/challenges/tasks/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/tasks/TryToComplete.java
@@ -1513,8 +1513,8 @@ public class TryToComplete
                 cr.add(new ChallengeResult().setMeetsRequirements().setCompleteFactor(factor));
             }
         }
-        // Check results -- all must pass
-        if (cr.stream().allMatch(result -> result.meetsRequirements)) {
+        // Check results -- there must be some and all must pass
+        if (!cr.isEmpty() && cr.stream().allMatch(result -> result.meetsRequirements)) {
             // Return any of them, because they pass
             return cr.getFirst();
         }

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -209,6 +209,13 @@ challenges:
                 name: "&f&l Rewards"
                 description: |-
                     &7 View the rewards properties.
+            hide_reward_items:
+              name: "&f&l Hide Reward Items"
+              description: |-
+                 &7 Toggle whether reward items
+                 &7 are shown or not in GUI.
+              hide: "&2 Hide"
+              show: "&c Show"
             deployed:
                 name: "&f&l Deployment"
                 description: |-


### PR DESCRIPTION
The admin may want to hide the rewards and just use the reward description. If the number of rewards is very long, it can be a problem to list them all.