### PR TITLE
Add string comparison for PAPI placeholders #366

### DIFF
--- a/src/main/java/world/bentobox/challenges/database/object/requirements/CheckPapi.java
+++ b/src/main/java/world/bentobox/challenges/database/object/requirements/CheckPapi.java
@@ -183,6 +183,10 @@ public class CheckPapi {
             String leftOperand = leftSB.toString().trim();
             String rightOperand = rightSB.toString().trim();
 
+            if (rightOperand.isEmpty()) {
+                return false;
+            }
+
             // Evaluate the condition:
             // If both operands can be parsed as numbers, use numeric comparison;
             // otherwise, perform string comparison.

--- a/src/main/java/world/bentobox/challenges/database/object/requirements/CheckPapi.java
+++ b/src/main/java/world/bentobox/challenges/database/object/requirements/CheckPapi.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.bukkit.entity.Player;
 
 import me.clip.placeholderapi.PlaceholderAPI;
+import world.bentobox.bentobox.BentoBox;
 
 public class CheckPapi {
 
@@ -155,7 +156,9 @@ public class CheckPapi {
             // Parse left operand.
             StringBuilder leftSB = new StringBuilder();
             if (!hasNext()) {
-                throw new RuntimeException("Expected left operand but reached end of expression");
+                BentoBox.getInstance()
+                        .logError("Challenges PAPI formula error: Expected left operand but reached end of expression");
+                return false;
             }
             // Collect tokens for the left operand until an operator is encountered.
             while (hasNext() && !isOperator(peek())) {
@@ -210,7 +213,8 @@ public class CheckPapi {
                 case ">":
                     return leftNum > rightNum;
                 default:
-                    throw new RuntimeException("Unsupported operator: " + operator);
+                    BentoBox.getInstance().logError("Challenges PAPI formula error: Unsupported operator: " + operator);
+                    return false;
                 }
             } else {
                 // String comparison.
@@ -232,7 +236,8 @@ public class CheckPapi {
                 case ">":
                     return leftOperand.compareTo(rightOperand) > 0;
                 default:
-                    throw new RuntimeException("Unsupported operator: " + operator);
+                    BentoBox.getInstance().logError("Challenges PAPI formula error: Unsupported operator: " + operator);
+                    return false;
                 }
             }
         }

--- a/src/test/java/world/bentobox/challenges/database/object/requirements/CheckPapiTest.java
+++ b/src/test/java/world/bentobox/challenges/database/object/requirements/CheckPapiTest.java
@@ -1,0 +1,102 @@
+package world.bentobox.challenges.database.object.requirements;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.bukkit.entity.Player;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import me.clip.placeholderapi.PlaceholderAPI;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(PlaceholderAPI.class)
+public class CheckPapiTest {
+
+    @Mock
+    private Player player;
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(PlaceholderAPI.class, Mockito.RETURNS_MOCKS);
+        // Return back the input string
+        when(PlaceholderAPI.setPlaceholders(eq(player), anyString()))
+                .thenAnswer((Answer<String>) invocation -> invocation.getArgument(1, String.class));
+    }
+
+    @Test
+    public void testNumericEquality() {
+        // Using numeric equality comparisons.
+        assertTrue(CheckPapi.evaluate(player, "40 == 40"));
+        assertFalse(CheckPapi.evaluate(player, "40 == 50"));
+        assertTrue(CheckPapi.evaluate(player, "100 = 100"));
+        assertFalse(CheckPapi.evaluate(player, "100 = 101"));
+    }
+
+    @Test
+    public void testNumericComparison() {
+        assertTrue(CheckPapi.evaluate(player, "40 > 20"));
+        assertFalse(CheckPapi.evaluate(player, "20 > 40"));
+        assertTrue(CheckPapi.evaluate(player, "20 < 40"));
+        assertFalse(CheckPapi.evaluate(player, "40 < 20"));
+        assertTrue(CheckPapi.evaluate(player, "30 <= 30"));
+        assertFalse(CheckPapi.evaluate(player, "31 <= 30"));
+        assertTrue(CheckPapi.evaluate(player, "30 >= 30"));
+        assertFalse(CheckPapi.evaluate(player, "29 >= 30"));
+        // Extra tokens beyond a valid expression.
+        assertTrue(CheckPapi.evaluate(player, "40 > 20 extra"));
+
+    }
+
+    @Test
+    public void testStringEquality() {
+        // String comparisons with multi-word operands.
+        assertTrue(CheckPapi.evaluate(player, "john smith == john smith"));
+        assertFalse(CheckPapi.evaluate(player, "john smith == jane doe"));
+        // Using inequality operators.
+        assertTrue(CheckPapi.evaluate(player, "john smith <> jane doe"));
+        assertFalse(CheckPapi.evaluate(player, "john smith <> john smith"));
+    }
+
+    @Test
+    public void testStringLexicographicalComparison() {
+        // Lexicographical comparison using string compareTo semantics.
+        assertTrue(CheckPapi.evaluate(player, "apple < banana"));
+        assertTrue(CheckPapi.evaluate(player, "banana > apple"));
+        assertTrue(CheckPapi.evaluate(player, "cat >= cat"));
+        assertTrue(CheckPapi.evaluate(player, "cat <= cat"));
+    }
+
+    @Test
+    public void testMultipleConditionsAndOr() {
+        // AND has higher precedence than OR.
+        // "john smith == john smith AND 40 > 20" should be true.
+        assertTrue(CheckPapi.evaluate(player, "john smith == john smith AND 40 > 20"));
+        // "john smith == jane doe OR 40 > 20" should be true because second condition is true.
+        assertTrue(CheckPapi.evaluate(player, "john smith == jane doe OR 40 > 20"));
+        // "john smith == jane doe AND 40 > 20" should be false because first condition fails.
+        assertFalse(CheckPapi.evaluate(player, "john smith == jane doe AND 40 > 20"));
+        // Mixed AND and OR: AND is evaluated first.
+        // Equivalent to: (john smith == jane doe) OR ((40 > 20) AND (10 < 20))
+        assertTrue(CheckPapi.evaluate(player, "john smith == jane doe OR 40 > 20 AND 10 < 20"));
+    }
+
+    @Test
+    public void testInvalidFormula() {
+        // Missing operator between operands.
+        assertFalse(CheckPapi.evaluate(player, "40 40"));
+        // Incomplete condition.
+        assertFalse(CheckPapi.evaluate(player, "40 >"));
+    }
+
+}


### PR DESCRIPTION
Evaluates the given formula by first replacing PAPI placeholders using the provided Player, then parsing and evaluating one or more conditions. The formula may contain conditions comparing numeric or string values. Operands may contain spaces. 

Supported comparison operators (case sensitive) are:

*  "=" or "==" for equality
*  "<>" or "!=" for inequality
*  "<=" and ">=" for less than or equal and greater than or equal
*  "<" and ">" for less than and greater than

For strings:

* "=" for case insensitive equality
*  "==" for case-sensitive equality
*  "<>" for case-insensitive inequality
*  "!=" for case sensitive inequality

Boolean connectors "AND" and "OR" (case insensitive) combine multiple conditions; AND has higher precedence than OR.

Examples:

` %aoneblock_my_island_lifetime_count% >= 1000 AND %aoneblock_my_island_level% >= 100`
`john smith == tasty bento AND 40 > 20`
