### PR TITLE
New settings for challenge menu

### DIFF
--- a/src/main/java/world/bentobox/challenges/config/Settings.java
+++ b/src/main/java/world/bentobox/challenges/config/Settings.java
@@ -101,6 +101,12 @@ public class Settings implements ConfigObject
     @ConfigEntry(path = "gui-settings.add-completed-glow")
     private boolean addCompletedGlow = true;
 
+
+    @ConfigComment("")
+    @ConfigComment("Add enchanted glow to completed levels")
+    @ConfigEntry(path = "gui-settings.add-completed-level-glow")
+    private boolean addCompletedLevelGlow = true;
+
     @ConfigComment("")
     @ConfigComment("This variable allows to choose which Challenges users can see in Challenges GUI.")
     @ConfigComment("Valid values are:")
@@ -221,6 +227,15 @@ public class Settings implements ConfigObject
     public boolean isAddCompletedGlow()
     {
         return this.addCompletedGlow;
+    }
+
+
+    /**
+     * @return addCompletedLevelGlow value.
+     */
+    public boolean isAddCompletedLevelGlow()
+    {
+        return this.addCompletedLevelGlow;
     }
 
 
@@ -488,6 +503,14 @@ public class Settings implements ConfigObject
     public void setAddCompletedGlow(boolean addCompletedGlow)
     {
         this.addCompletedGlow = addCompletedGlow;
+    }
+
+    /**
+     * @param addCompletedLevelGlow new addCompletedLevelGlow value.
+     */
+    public void setAddCompletedLevelGlow(boolean addCompletedLevelGlow)
+    {
+        this.addCompletedLevelGlow = addCompletedLevelGlow;
     }
 
 

--- a/src/main/java/world/bentobox/challenges/config/Settings.java
+++ b/src/main/java/world/bentobox/challenges/config/Settings.java
@@ -123,6 +123,20 @@ public class Settings implements ConfigObject
     @ConfigEntry(path = "gui-settings.locked-level-icon")
     private ItemStack lockedLevelIcon = new ItemStack(Material.BOOK);
 
+
+    @ConfigComment("")
+    @ConfigComment("This allows to change default completed level icon. If this option is set")
+    @ConfigComment("to null, the level icon will not be overwritten.")
+    @ConfigEntry(path = "gui-settings.completed-level-icon")
+    private ItemStack completedLevelIcon = null;
+
+
+    @ConfigComment("")
+    @ConfigComment("This allows to change default selected level icon. If this option is set")
+    @ConfigComment("to null, the level icon will not be overwritten.")
+    @ConfigEntry(path = "gui-settings.selected-level-icon")
+    private ItemStack selectedLevelIcon = null;
+
     @ConfigComment("")
     @ConfigComment("This indicate if challenges data will be stored per island (true) or per player (false).")
     @ConfigEntry(path = "store-island-data")
@@ -362,6 +376,34 @@ public class Settings implements ConfigObject
 
 
     /**
+     * This method returns the selectedLevelIcon value.
+     * @return the value of selectedLevelIcon.
+     */
+    public ItemStack getSelectedLevelIcon()
+    {
+        if (selectedLevelIcon != null)
+        {
+            return selectedLevelIcon.clone();
+        }
+        return null;
+    }
+
+
+    /**
+     * This method returns the completedLevelIcon value.
+     * @return the value of completedLevelIcon.
+     */
+    public ItemStack getCompletedLevelIcon()
+    {
+        if (completedLevelIcon != null)
+        {
+            return completedLevelIcon.clone();
+        }
+        return null;
+    }
+
+
+    /**
      * This method returns the showCompletionTitle object.
      * @return the showCompletionTitle object.
      */
@@ -447,6 +489,28 @@ public class Settings implements ConfigObject
     public void setLockedLevelIcon(ItemStack lockedLevelIcon)
     {
         this.lockedLevelIcon = lockedLevelIcon;
+    }
+
+
+    /**
+     * This method sets the selectedLevelIcon value.
+     * @param selectedLevelIcon the selectedLevelIcon new value.
+     *
+     */
+    public void setSelectedLevelIcon(ItemStack selectedLevelIcon)
+    {
+        this.selectedLevelIcon = selectedLevelIcon;
+    }
+
+
+    /**
+     * This method sets the completedLevelIcon value.
+     * @param completedLevelIcon the completedLevelIcon new value.
+     *
+     */
+    public void setCompletedLevelIcon(ItemStack completedLevelIcon)
+    {
+        this.completedLevelIcon = completedLevelIcon;
     }
 
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditSettingsPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditSettingsPanel.java
@@ -117,6 +117,7 @@ public class EditSettingsPanel extends CommonPanel
         panelBuilder.item(28, this.getSettingsButton(Button.BROADCAST));
 
         panelBuilder.item(11, this.getSettingsButton(Button.GLOW_COMPLETED));
+        panelBuilder.item(12, this.getSettingsButton(Button.GLOW_COMPLETED_LEVELS));
         panelBuilder.item(20, this.getSettingsButton(Button.REMOVE_COMPLETED));
         panelBuilder.item(29, this.getSettingsButton(Button.VISIBILITY_MODE));
         panelBuilder.item(30, this.getSettingsButton(Button.INCLUDE_UNDEPLOYED));
@@ -327,6 +328,22 @@ public class EditSettingsPanel extends CommonPanel
                     return true;
                 };
                 glow = this.settings.isAddCompletedGlow();
+
+                description.add("");
+                description.add(this.user.getTranslation(Constants.TIPS + "click-to-toggle"));
+            }
+            case GLOW_COMPLETED_LEVELS -> {
+                description.add(this.user.getTranslation(reference +
+                        (this.settings.isAddCompletedLevelGlow() ? "enabled" : "disabled")));
+
+                icon = new ItemStack(Material.GLOWSTONE);
+                clickHandler = (panel, user1, clickType, i) -> {
+                    this.settings.setAddCompletedLevelGlow(!this.settings.isAddCompletedLevelGlow());
+                    panel.getInventory().setItem(i, this.getSettingsButton(button).getItem());
+                    this.addon.saveSettings();
+                    return true;
+                };
+                glow = this.settings.isAddCompletedLevelGlow();
 
                 description.add("");
                 description.add(this.user.getTranslation(Constants.TIPS + "click-to-toggle"));
@@ -568,6 +585,7 @@ public class EditSettingsPanel extends CommonPanel
         PURGE_HISTORY,
         DATA_PER_ISLAND,
         GLOW_COMPLETED,
+        GLOW_COMPLETED_LEVELS,
         LOCKED_LEVEL_ICON,
         SHOW_TITLE,
         TITLE_SHOWTIME,

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesPanel.java
@@ -554,6 +554,20 @@ public class ChallengesPanel extends CommonPanel
                 this.addon.getChallengesSettings().isAddCompletedLevelGlow() &&
                 this.manager.isLevelCompleted(this.user, this.world, level.getLevel()));
 
+        // Change icon for completed level
+        if( level.isUnlocked() &&
+                this.manager.isLevelCompleted(this.user, this.world, level.getLevel()) &&
+                this.addon.getChallengesSettings().getCompletedLevelIcon() != null
+        ) {
+            builder.icon(this.addon.getChallengesSettings().getCompletedLevelIcon().clone());
+        }
+
+        // Change icon for selected level
+        if(level == this.lastSelectedLevel &&
+                this.addon.getChallengesSettings().getSelectedLevelIcon() != null){
+            builder.icon(this.addon.getChallengesSettings().getSelectedLevelIcon().clone());
+        }
+
         // Click Handlers are managed by custom addon buttons.
         return builder.build();
     }

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesPanel.java
@@ -551,7 +551,7 @@ public class ChallengesPanel extends CommonPanel
         // Glow the icon.
         builder.glow(level == this.lastSelectedLevel ||
             level.isUnlocked() &&
-                this.addon.getChallengesSettings().isAddCompletedGlow() &&
+                this.addon.getChallengesSettings().isAddCompletedLevelGlow() &&
                 this.manager.isLevelCompleted(this.user, this.world, level.getLevel()));
 
         // Click Handlers are managed by custom addon buttons.

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -635,10 +635,17 @@ challenges:
                 enabled: "&2 Enabled"
                 disabled: "&c Disabled"
             glow_completed:
-                name: "&f&l Glow Completed"
+                name: "&f&l Glow Completed Challenges"
                 description: |-
                     &7 Applies an enchantment glow
                     &7 to completed challenges.
+                enabled: "&2 Enabled"
+                disabled: "&c Disabled"
+            glow_completed_levels:
+                name: "&f&l Glow Completed Levels"
+                description: |-
+                    &7 Applies an enchantment glow
+                    &7 to completed levels.
                 enabled: "&2 Enabled"
                 disabled: "&c Disabled"
             store_history:


### PR DESCRIPTION
The setting to highlight completed challenges with enchantment glint is now two settings. One to highlight completed challenges, and one to highlight completed levels.
There are now optional level icons that will display inside the challenge menu based on which levels you have completed, and which panel you have selected. By default, these values are null and will not affect the menu.