### PR TITLE
Release 1.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- This allows to change between versions and snapshots. -->
-        <build.version>1.6.0</build.version>
+        <build.version>1.6.1</build.version>
         <build.number>-LOCAL</build.number>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_Challenges</sonar.projectKey>

--- a/src/main/java/world/bentobox/challenges/panel/admin/AdminPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/AdminPanel.java
@@ -496,7 +496,7 @@ public class AdminPanel extends CommonPanel
                     else
                     {
                         Consumer<Boolean> consumer = value -> {
-                            if (value)
+                            if (Boolean.TRUE.equals(value))
                             {
                                 this.addon.getChallengesManager().wipeDatabase(this.wipeAll,
                                     Utils.getGameMode(this.world));
@@ -535,7 +535,7 @@ public class AdminPanel extends CommonPanel
                     else
                     {
                         Consumer<Boolean> consumer = value -> {
-                            if (value)
+                            if (Boolean.TRUE.equals(value))
                             {
                                 this.addon.getChallengesManager().wipeDatabase(this.wipeAll,
                                     Utils.getGameMode(this.world));
@@ -567,7 +567,7 @@ public class AdminPanel extends CommonPanel
                 clickHandler = (panel, user, clickType, slot) -> {
 
                     Consumer<Boolean> consumer = value -> {
-                        if (value)
+                        if (Boolean.TRUE.equals(value))
                         {
                             this.addon.getChallengesManager().wipePlayers(Utils.getGameMode(this.world));
                         }

--- a/src/main/java/world/bentobox/challenges/panel/admin/LibraryPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/LibraryPanel.java
@@ -434,7 +434,7 @@ public class LibraryPanel extends CommonPagedPanel<LibraryEntry>
     {
         Consumer<Boolean> consumer = value ->
         {
-            if (value)
+            if (Boolean.TRUE.equals(value))
             {
                 switch (this.mode)
                 {

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListChallengesPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListChallengesPanel.java
@@ -173,7 +173,7 @@ public class ListChallengesPanel extends CommonPagedPanel<Challenge>
 
             itemBuilder.clickHandler((panel, user1, clickType, i) -> {
                 Consumer<Boolean> consumer = value -> {
-                    if (value)
+                    if (Boolean.TRUE.equals(value))
                     {
                         this.addon.getChallengesManager().deleteChallenge(challenge);
                     }

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListLevelsPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListLevelsPanel.java
@@ -171,7 +171,7 @@ public class ListLevelsPanel extends CommonPagedPanel<ChallengeLevel>
 
             itemBuilder.clickHandler((panel, user1, clickType, i) -> {
                 Consumer<Boolean> consumer = value -> {
-                    if (value)
+                    if (Boolean.TRUE.equals(value))
                     {
                         this.addon.getChallengesManager().deleteChallengeLevel(challengeLevel);
                     }


### PR DESCRIPTION
## Summary

Cuts the 1.6.1 release. Bundles everything on `develop` since the last `master` cut (1.5.3), including the latest hotfix.

**Latest hotfix (1.6.1):**
- Fix NPE in confirmation conversations when abandoned (e.g. inactivity timeout after multiple library-icon clicks). All `Consumer<Boolean>` callsites now use `Boolean.TRUE.equals(value)` so abandons are no-ops instead of throwing.

**Highlights since 1.5.3:**
- Modernised build/runtime: Paper 1.21.11, BentoBox 3.14.0, Java 21, addon API 3.12.0
- Full test-suite migration from PowerMock to JUnit 5 + Mockito + MockBukkit (~150+ new tests across managers, panels, events, listeners, handlers, commands)
- Locale files converted from legacy `&`-codes to MiniMessage
- Modrinth publish workflow + supply-chain-pinned GitHub Actions
- Web library: language filter, word-wrapped descriptions, pending-barrier UI, graceful handling of malformed catalog entries
- Reward text word-wrapped to 30 chars in lore
- Numerous SonarCloud blocker fixes and code-quality cleanups (switch expressions, `isEmpty()`, dedup'd string constants, etc.)

## Test plan

- [ ] `mvn clean verify` passes locally
- [ ] Drop the shaded jar into a BentoBox 3.14.0+ server and confirm `/padmin challenges` opens cleanly
- [ ] Web library: click an entry, type `confirm` -> import succeeds; click an entry and let it time out -> no NPE in console
- [ ] Web library: click an entry multiple times before answering, let extras time out -> no NPE per abandoned conversation
- [ ] Player `/[gm] challenges` lists imported challenges in the matching gamemode

🤖 Generated with [Claude Code](https://claude.com/claude-code)