### PR TITLE
Release 1.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <!-- Non-minecraft related dependencies -->
         <junit.version>5.10.2</junit.version>
         <mockito.version>5.11.0</mockito.version>
-        <mock-bukkit.version>v1.21-SNAPSHOT</mock-bukkit.version>
+        <mock-bukkit.version>4.110.0</mock-bukkit.version>
         <!-- More visible way how to change dependency versions -->
         <paper.version>1.21.11-R0.1-SNAPSHOT</paper.version>
         <bentobox.version>3.14.0</bentobox.version>
@@ -205,8 +205,8 @@
         </dependency>
         <!-- MockBukkit -->
         <dependency>
-            <groupId>com.github.MockBukkit</groupId>
-            <artifactId>MockBukkit</artifactId>
+            <groupId>org.mockbukkit.mockbukkit</groupId>
+            <artifactId>mockbukkit-v1.21</artifactId>
             <version>${mock-bukkit.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- This allows to change between versions and snapshots. -->
-        <build.version>1.6.1</build.version>
+        <build.version>1.6.2</build.version>
         <build.number>-LOCAL</build.number>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_Challenges</sonar.projectKey>

--- a/src/main/java/world/bentobox/challenges/managers/ChallengesImportManager.java
+++ b/src/main/java/world/bentobox/challenges/managers/ChallengesImportManager.java
@@ -736,17 +736,27 @@ public class ChallengesImportManager
         }
         catch (Exception e)
         {
-            this.addon.getPlugin().logStacktrace(e);
-            if (user != null && user.isPlayer())
-            {
-                Utils.sendMessage(user, world, Constants.ERRORS + "import-failed",
-                    "[message]", e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
-            }
+            reportImportFailure(user, world, e);
             return;
         }
 
         manager.saveChallenges();
         manager.saveLevels();
+    }
+
+
+    /**
+     * Logs the stacktrace and, if a player triggered the import, surfaces a chat error
+     * so they know to look at the server console.
+     */
+    private void reportImportFailure(User user, World world, Exception e)
+    {
+        this.addon.getPlugin().logStacktrace(e);
+        if (user != null && user.isPlayer())
+        {
+            Utils.sendMessage(user, world, Constants.ERRORS + "import-failed",
+                "[message]", e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+        }
     }
 
 
@@ -818,12 +828,7 @@ public class ChallengesImportManager
         }
         catch (Exception e)
         {
-            this.addon.getPlugin().logStacktrace(e);
-            if (user != null && user.isPlayer())
-            {
-                Utils.sendMessage(user, world, Constants.ERRORS + "import-failed",
-                    "[message]", e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
-            }
+            reportImportFailure(user, world, e);
             return;
         }
 

--- a/src/main/java/world/bentobox/challenges/managers/ChallengesImportManager.java
+++ b/src/main/java/world/bentobox/challenges/managers/ChallengesImportManager.java
@@ -737,6 +737,11 @@ public class ChallengesImportManager
         catch (Exception e)
         {
             this.addon.getPlugin().logStacktrace(e);
+            if (user != null && user.isPlayer())
+            {
+                Utils.sendMessage(user, world, Constants.ERRORS + "import-failed",
+                    "[message]", e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+            }
             return;
         }
 
@@ -814,6 +819,11 @@ public class ChallengesImportManager
         catch (Exception e)
         {
             this.addon.getPlugin().logStacktrace(e);
+            if (user != null && user.isPlayer())
+            {
+                Utils.sendMessage(user, world, Constants.ERRORS + "import-failed",
+                    "[message]", e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+            }
             return;
         }
 

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -1232,6 +1232,7 @@ challenges:
         island-level: "<red>Your island must be at least level [number] to complete this challenge!"
         no-load: "<red>Error: Could not load [file]. Error: [message]."
         load-error: "<red>Error: Cannot load [value]."
+        import-failed: "<red>Could not import challenges: [message]. Check the server console for details."
         no-rank: "<red>You do not have a high enough rank to do that."
         cannot-remove-items: "<red>Some items cannot be removed from your inventory!"
         exist-challenges-or-levels: "<red>Challenges already exist in your world. Cannot proceed!"

--- a/src/test/java/world/bentobox/challenges/ChallengesAddonTest.java
+++ b/src/test/java/world/bentobox/challenges/ChallengesAddonTest.java
@@ -42,11 +42,14 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
+
+import world.bentobox.challenges.panel.PanelTestHelper;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
@@ -101,6 +104,15 @@ public class ChallengesAddonTest {
     @BeforeEach
     public void setUp() throws Exception {
         closeable = MockitoAnnotations.openMocks(this);
+        // Force Bukkit's Tag.<clinit> to run against a real MockBukkit ServerMock before
+        // we install the Mockito static mock below. Without this, Tag.<clinit> can later
+        // fire while Bukkit is statically mocked, permanently null-ing every Tag constant
+        // for the JVM and corrupting any subsequent test that creates an ItemStack
+        // (e.g. CommonPagedPanelTest -> ItemType.<clinit> -> MaterialTags.<clinit> ->
+        //  Objects.requireNonNull(Tag.ALL_SIGNS) -> NPE).
+        MockBukkit.mock();
+        PanelTestHelper.primeBukkitRegistry();
+        MockBukkit.unmock();
         // Set up plugin
         WhiteBox.setInternalState(BentoBox.class, "instance", plugin);
         when(plugin.getLogger()).thenReturn(Logger.getAnonymousLogger());

--- a/src/test/java/world/bentobox/challenges/panel/CommonPagedPanelTest.java
+++ b/src/test/java/world/bentobox/challenges/panel/CommonPagedPanelTest.java
@@ -116,6 +116,7 @@ class CommonPagedPanelTest {
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
         ServerMock mbServer = MockBukkit.mock();
+        PanelTestHelper.primeBukkitRegistry();
 
         when(addon.getChallengesManager()).thenReturn(manager);
         PanelTestHelper.setupUserTranslations(user);

--- a/src/test/java/world/bentobox/challenges/panel/CommonPanelTest.java
+++ b/src/test/java/world/bentobox/challenges/panel/CommonPanelTest.java
@@ -78,6 +78,7 @@ class CommonPanelTest {
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
         ServerMock mbServer = MockBukkit.mock();
+        PanelTestHelper.primeBukkitRegistry();
 
         when(addon.getChallengesManager()).thenReturn(manager);
         PanelTestHelper.setupUserTranslations(user);

--- a/src/test/java/world/bentobox/challenges/panel/ConversationUtilsTest.java
+++ b/src/test/java/world/bentobox/challenges/panel/ConversationUtilsTest.java
@@ -45,6 +45,7 @@ class ConversationUtilsTest {
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
         ServerMock mbServer = MockBukkit.mock();
+        PanelTestHelper.primeBukkitRegistry();
 
         when(user.getTranslation(anyString())).thenAnswer(
             (Answer<String>) inv -> inv.getArgument(0, String.class));

--- a/src/test/java/world/bentobox/challenges/panel/PanelTestHelper.java
+++ b/src/test/java/world/bentobox/challenges/panel/PanelTestHelper.java
@@ -23,6 +23,23 @@ import world.bentobox.challenges.database.object.requirements.InventoryRequireme
 public class PanelTestHelper {
 
     /**
+     * Force Bukkit's material registry to be populated while MockBukkit's mock
+     * server is active. Call this immediately after `MockBukkit.mock()`.
+     *
+     * <p>Why: `org.bukkit.inventory.ItemType.&lt;clinit&gt;` iterates over Material and
+     * looks each entry up in the registry. If it runs before MockBukkit has populated
+     * the registry (e.g., when a panel test that doesn't extend AbstractChallengesTest
+     * runs first on CI's filesystem ordering), it throws NoSuchElementException, and
+     * ItemStackMock stays in an errored state for the rest of the JVM — poisoning every
+     * subsequent test. Touching `Tag.LEAVES` forces the registry to populate before
+     * ItemType loads.
+     */
+    public static void primeBukkitRegistry() {
+        @SuppressWarnings("unused")
+        var unused = org.bukkit.Tag.LEAVES;
+    }
+
+    /**
      * Set up user translation mocks to return the key for any invocation.
      * Uses a lenient default answer that returns the first String argument
      * for any method that returns String.

--- a/src/test/java/world/bentobox/challenges/panel/admin/AdminPanelTest.java
+++ b/src/test/java/world/bentobox/challenges/panel/admin/AdminPanelTest.java
@@ -54,6 +54,7 @@ class AdminPanelTest {
     void setUp() throws Exception {
         closeable = MockitoAnnotations.openMocks(this);
         ServerMock mbServer = MockBukkit.mock();
+        PanelTestHelper.primeBukkitRegistry();
 
         when(addon.getChallengesManager()).thenReturn(manager);
         PanelTestHelper.setupUserTranslations(user);

--- a/src/test/java/world/bentobox/challenges/panel/admin/ListChallengesPanelTest.java
+++ b/src/test/java/world/bentobox/challenges/panel/admin/ListChallengesPanelTest.java
@@ -47,6 +47,7 @@ class ListChallengesPanelTest {
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
         ServerMock mbServer = MockBukkit.mock();
+        PanelTestHelper.primeBukkitRegistry();
 
         when(addon.getChallengesManager()).thenReturn(manager);
         PanelTestHelper.setupUserTranslations(user);

--- a/src/test/java/world/bentobox/challenges/panel/user/GameModePanelTest.java
+++ b/src/test/java/world/bentobox/challenges/panel/user/GameModePanelTest.java
@@ -58,6 +58,7 @@ class GameModePanelTest {
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
         ServerMock mbServer = MockBukkit.mock();
+        PanelTestHelper.primeBukkitRegistry();
 
         when(addon.getChallengesManager()).thenReturn(manager);
         PanelTestHelper.setupUserTranslations(user);

--- a/src/test/java/world/bentobox/challenges/panel/user/MultiplePanelTest.java
+++ b/src/test/java/world/bentobox/challenges/panel/user/MultiplePanelTest.java
@@ -53,6 +53,7 @@ class MultiplePanelTest {
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
         ServerMock mbServer = MockBukkit.mock();
+        PanelTestHelper.primeBukkitRegistry();
 
         PanelTestHelper.setupUserTranslations(user);
         when(user.getWorld()).thenReturn(world);


### PR DESCRIPTION
## Summary

Patch release that surfaces import errors to admins instead of swallowing them silently.

**Why:** A recent incident with the translated Poseidon library entries had `description` stored as a string instead of `List<String>`, which made Gson reject the payload with a `JsonSyntaxException`. `ChallengesImportManager` caught it, wrote a stacktrace to the server console, and returned — leaving admins staring at "successfully imported" in chat and "no challenges available" right after, with no clue that anything went wrong or where to look. The weblink data has since been fixed (BentoBoxWorld/weblink#21), but the addon would happily go on hiding the next bad payload the same way.

**Fix:** Both `importDatabaseFile` and `loadDownloadedChallenges` now send `challenges.errors.import-failed` to the triggering player after logging the stacktrace, including the exception's short message so they know to look at the console.

## Test plan

- [x] `mvn clean verify` passes
- [x] Drop a malformed challenges JSON onto disk and `/[gm] admin challenges import <file>` — chat shows the new red error message
- [x] Confirm the server console still has the full stacktrace
- [x] Happy-path import (web library, valid file) still works and shows the existing "Adding new object" messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)