### PR TITLE
Clean up low-priority SonarCloud issues

### DIFF
--- a/src/main/java/world/bentobox/challenges/commands/CompleteChallengeCommand.java
+++ b/src/main/java/world/bentobox/challenges/commands/CompleteChallengeCommand.java
@@ -122,7 +122,7 @@ public class CompleteChallengeCommand extends CompositeCommand
             break;
         case 4:
             // Suggest a number of completions.
-            if (lastString.isEmpty() || lastString.matches("[0-9]*"))
+            if (lastString.isEmpty() || lastString.matches("\\d*"))
             {
                 returnList.add("<number>");
             }

--- a/src/main/java/world/bentobox/challenges/database/object/requirements/IslandRequirements.java
+++ b/src/main/java/world/bentobox/challenges/database/object/requirements/IslandRequirements.java
@@ -207,9 +207,11 @@ public class IslandRequirements extends Requirements
         clone.setRequiredMaterialTags(new HashMap<>(this.requiredMaterialTags));
         clone.setRequiredFluidTags(new HashMap<>(this.requiredFluidTags));
         clone.setRequiredEntityTypeTags(new HashMap<>(this.requiredEntityTypeTags));
-        clone.setRequiredBlocks(new HashMap<>(this.requiredBlocks));
+        clone.setRequiredBlocks(this.requiredBlocks.isEmpty() ?
+                new EnumMap<>(Material.class) : new EnumMap<>(this.requiredBlocks));
         clone.setRemoveBlocks(this.removeBlocks);
-        clone.setRequiredEntities(new HashMap<>(this.requiredEntities));
+        clone.setRequiredEntities(this.requiredEntities.isEmpty() ?
+                new EnumMap<>(EntityType.class) : new EnumMap<>(this.requiredEntities));
         clone.setRemoveEntities(this.removeEntities);
 
         clone.setSearchRadius(this.searchRadius);

--- a/src/main/java/world/bentobox/challenges/database/object/requirements/StatisticRequirements.java
+++ b/src/main/java/world/bentobox/challenges/database/object/requirements/StatisticRequirements.java
@@ -106,13 +106,6 @@ public class StatisticRequirements extends Requirements
     }
 
 
-    @Override
-    public boolean isValid()
-    {
-        // TODO - do something here?
-        return super.isValid();
-    }
-
     /**
      * @return the statisticList
      */

--- a/src/main/java/world/bentobox/challenges/managers/ChallengesImportManager.java
+++ b/src/main/java/world/bentobox/challenges/managers/ChallengesImportManager.java
@@ -12,7 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -400,7 +400,7 @@ public class ChallengesImportManager
      */
     private Map<Material, Integer> createMaterialMap(ConfigurationSection section)
     {
-        Map<Material, Integer> materialMaps = new HashMap<>();
+        Map<Material, Integer> materialMaps = new EnumMap<>(Material.class);
 
         if (section != null)
         {
@@ -426,7 +426,7 @@ public class ChallengesImportManager
      */
     private Map<EntityType, Integer> createEntityMap(ConfigurationSection section)
     {
-        Map<EntityType, Integer> entityMap = new HashMap<>();
+        Map<EntityType, Integer> entityMap = new EnumMap<>(EntityType.class);
 
         if (section != null)
         {

--- a/src/main/java/world/bentobox/challenges/panel/CommonPagedPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/CommonPagedPanel.java
@@ -110,7 +110,7 @@ public abstract class CommonPagedPanel<T> extends CommonPanel
             index++;
         }
 
-        if (size > MAX_ELEMENTS && !(1.0 * size / MAX_ELEMENTS <= this.pageIndex + 1))
+        if (size > MAX_ELEMENTS && 1.0 * size / MAX_ELEMENTS > this.pageIndex + 1)
         {
             panelBuilder.item(26, this.getButton(CommonButtons.NEXT));
 

--- a/src/main/java/world/bentobox/challenges/panel/ConversationUtils.java
+++ b/src/main/java/world/bentobox/challenges/panel/ConversationUtils.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.bukkit.ChatColor;
 import org.bukkit.conversations.ConversationAbandonedListener;
@@ -142,13 +142,13 @@ public class ConversationUtils
      * consumer for failure message.
      *
      * @param consumer Consumer that accepts player output text.
-     * @param validation Function that validates if input value is acceptable.
+     * @param validation Predicate that validates if input value is acceptable.
      * @param question Message that will be displayed in chat when player triggers conversion.
      * @param failTranslationLocation Message that will be displayed on failed operation.
      * @param user User who is targeted with current confirmation.
      */
     public static void createIDStringInput(Consumer<String> consumer,
-        Function<String, Boolean> validation,
+        Predicate<String> validation,
         User user,
         @NotNull String question,
         @Nullable String successMessage,
@@ -189,7 +189,7 @@ public class ConversationUtils
             @Override
             protected boolean isInputValid(@NotNull ConversationContext context, @NotNull String input)
             {
-                return validation.apply(input);
+                return validation.test(input);
             }
 
 
@@ -391,7 +391,7 @@ public class ConversationUtils
             {
                 if (context.getSessionData(SESSION_CONSTANT) instanceof List description)
                 {
-                    consumer.accept((List<String>) description);
+                    consumer.accept(description);
                     return successMessage;
                 }
                 else
@@ -452,7 +452,7 @@ public class ConversationUtils
 
                 if (context.getSessionData(SESSION_CONSTANT) instanceof List list)
                 {
-                    desc = (List<String>) list;
+                    desc = list;
                 }
                 if (input != null) {
                     desc.add(ChatColor.translateAlternateColorCodes('&', input));

--- a/src/main/java/world/bentobox/challenges/panel/admin/AdminPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/AdminPanel.java
@@ -5,7 +5,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -263,7 +263,7 @@ public class AdminPanel extends CommonPanel
                     };
 
                     // This function checks if generator with a given ID already exist.
-                    Function<String, Boolean> validationFunction = uniqueId ->
+                    Predicate<String> validationFunction = uniqueId ->
                         !this.addon.getChallengesManager().containsChallenge(gameModePrefix + Utils.sanitizeInput(uniqueId));
 
                     // Call a conversation API to get input string.
@@ -307,7 +307,7 @@ public class AdminPanel extends CommonPanel
                     };
 
                     // This function checks if generator with a given ID already exist.
-                    Function<String, Boolean> validationFunction = uniqueId ->
+                    Predicate<String> validationFunction = uniqueId ->
                         !this.addon.getChallengesManager().containsLevel(gameModePrefix + Utils.sanitizeInput(uniqueId));
 
                     // Call a conversation API to get input string.
@@ -420,7 +420,7 @@ public class AdminPanel extends CommonPanel
                     };
 
                     // This function checks if file can be created.
-                    Function<String, Boolean> validationFunction = fileName ->
+                    Predicate<String> validationFunction = fileName ->
                     {
                         String sanitizedName = Utils.sanitizeInput(fileName);
                         return !new File(this.addon.getDataFolder(),

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengePanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengePanel.java
@@ -534,7 +534,7 @@ public class EditChallengePanel extends CommonPanel {
             icon = new ItemStack(Material.DROPPER);
             clickHandler = (panel, user, clickType, slot) -> {
                 EnvironmentSelector.open(this.user, this.challenge.getEnvironment(), (status, value) -> {
-                    if (status) {
+                    if (Boolean.TRUE.equals(status)) {
                         this.challenge.setEnvironment(value);
                     }
 
@@ -1017,7 +1017,7 @@ public class EditChallengePanel extends CommonPanel {
             icon = new ItemStack(Material.CHEST);
             clickHandler = (panel, user, clickType, slot) -> {
                 ItemSelector.open(this.user, requirements.getRequiredItems(), (status, value) -> {
-                    if (status) {
+                    if (Boolean.TRUE.equals(status)) {
                         requirements.setRequiredItems(value);
                     }
 
@@ -1075,7 +1075,7 @@ public class EditChallengePanel extends CommonPanel {
                 }
 
                 MultiBlockSelector.open(this.user, MultiBlockSelector.Mode.ANY, collection, (status, materials) -> {
-                    if (status) {
+                    if (Boolean.TRUE.equals(status)) {
                         materials.addAll(requirements.getIgnoreMetaData());
                         requirements.setIgnoreMetaData(new HashSet<>(materials));
                     }
@@ -1103,7 +1103,7 @@ public class EditChallengePanel extends CommonPanel {
                 collection.removeAll(requirements.getIgnoreMetaData());
 
                 MultiBlockSelector.open(this.user, MultiBlockSelector.Mode.ANY, collection, (status, materials) -> {
-                    if (status) {
+                    if (Boolean.TRUE.equals(status)) {
                         requirements.getIgnoreMetaData().removeAll(materials);
                     }
 
@@ -1370,7 +1370,7 @@ public class EditChallengePanel extends CommonPanel {
             icon = new ItemStack(Material.CHEST);
             clickHandler = (panel, user, clickType, slot) -> {
                 ItemSelector.open(this.user, this.challenge.getRewardItems(), (status, value) -> {
-                    if (status) {
+                    if (Boolean.TRUE.equals(status)) {
                         this.challenge.setRewardItems(value);
                     }
 
@@ -1583,7 +1583,7 @@ public class EditChallengePanel extends CommonPanel {
             icon = new ItemStack(Material.CHEST);
             clickHandler = (panel, user, clickType, slot) -> {
                 ItemSelector.open(this.user, this.challenge.getRewardItems(), (status, value) -> {
-                    if (status) {
+                    if (Boolean.TRUE.equals(status)) {
                         this.challenge.setRepeatItemReward(value);
                     }
 
@@ -1711,7 +1711,7 @@ public class EditChallengePanel extends CommonPanel {
                 }
 
                 MultiBlockSelector.open(this.user, MultiBlockSelector.Mode.ANY, collection, (status, materials) -> {
-                    if (status) {
+                    if (Boolean.TRUE.equals(status)) {
                         materials.addAll(this.challenge.getIgnoreRewardMetaData());
                         this.challenge.setIgnoreRewardMetaData(new HashSet<>(materials));
                     }
@@ -1739,7 +1739,7 @@ public class EditChallengePanel extends CommonPanel {
                 collection.removeAll(this.challenge.getIgnoreRewardMetaData());
 
                 MultiBlockSelector.open(this.user, MultiBlockSelector.Mode.ANY, collection, (status, materials) -> {
-                    if (status) {
+                    if (Boolean.TRUE.equals(status)) {
                         this.challenge.getIgnoreRewardMetaData().removeAll(materials);
                     }
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditLevelPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditLevelPanel.java
@@ -420,7 +420,7 @@ public class EditLevelPanel extends CommonPagedPanel<Challenge>
                     ItemSelector.open(this.user,
                         this.challengeLevel.getRewardItems(),
                         (status, value) -> {
-                            if (status)
+                            if (Boolean.TRUE.equals(status))
                             {
                                 this.challengeLevel.setRewardItems(value);
                             }
@@ -577,7 +577,7 @@ public class EditLevelPanel extends CommonPagedPanel<Challenge>
                         collection,
                         (status, materials) ->
                         {
-                            if (status)
+                            if (Boolean.TRUE.equals(status))
                             {
                                 materials.addAll(this.challengeLevel.getIgnoreRewardMetaData());
                                 this.challengeLevel.setIgnoreRewardMetaData(new HashSet<>(materials));
@@ -611,7 +611,7 @@ public class EditLevelPanel extends CommonPagedPanel<Challenge>
                         collection,
                         (status, materials) ->
                         {
-                            if (status)
+                            if (Boolean.TRUE.equals(status))
                             {
                                 this.challengeLevel.getIgnoreRewardMetaData().removeAll(materials);
                             }
@@ -806,7 +806,7 @@ public class EditLevelPanel extends CommonPagedPanel<Challenge>
                         Material.BLUE_STAINED_GLASS_PANE,
                         challengeDescriptionMap,
                         (status, valueSet) -> {
-                            if (status)
+                            if (Boolean.TRUE.equals(status))
                             {
                                 valueSet.forEach(challenge ->
                                     manager.addChallengeToLevel(challenge, this.challengeLevel));
@@ -842,7 +842,7 @@ public class EditLevelPanel extends CommonPagedPanel<Challenge>
                         Material.RED_STAINED_GLASS_PANE,
                         challengeDescriptionMap,
                         (status, valueSet) -> {
-                            if (status)
+                            if (Boolean.TRUE.equals(status))
                             {
                                 valueSet.forEach(challenge ->
                                     manager.removeChallengeFromLevel(challenge, this.challengeLevel));

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListUsersPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListUsersPanel.java
@@ -119,10 +119,9 @@ public class ListUsersPanel extends CommonPagedPanel<Player>
         else
         {
             this.filterElements = this.onlineUsers.stream().
-                filter(element -> {
+                filter(element ->
                     // If element name is set and name contains search field, then do not filter out.
-                    return element.getDisplayName().toLowerCase().contains(this.searchString.toLowerCase());
-                }).
+                    element.getDisplayName().toLowerCase().contains(this.searchString.toLowerCase())).
                 distinct().
                 collect(Collectors.toList());
         }
@@ -214,14 +213,14 @@ public class ListUsersPanel extends CommonPagedPanel<Player>
                             collect(Collectors.toMap(challenge -> challenge,
                                 challenge -> this.generateChallengeDescription(challenge, User.getInstance(player)),
                                 (a, b) -> b,
-                                () -> new LinkedHashMap<>(challengeList.size())));
+                                () -> LinkedHashMap.newLinkedHashMap(challengeList.size())));
 
                         // Open select gui
                         ChallengeSelector.open(this.user,
                             Material.LIME_STAINED_GLASS_PANE,
                             challengeDescriptionMap,
                             (status, valueSet) -> {
-                                if (status)
+                                if (Boolean.TRUE.equals(status))
                                 {
                                     valueSet.forEach(challenge ->
                                         manager.setChallengeComplete(player.getUniqueId(),
@@ -243,14 +242,14 @@ public class ListUsersPanel extends CommonPagedPanel<Player>
                             collect(Collectors.toMap(challenge -> challenge,
                                 challenge -> this.generateChallengeDescription(challenge, User.getInstance(player)),
                                 (a, b) -> b,
-                                () -> new LinkedHashMap<>(challengeList.size())));
+                                () -> LinkedHashMap.newLinkedHashMap(challengeList.size())));
 
                         // Open select gui
                         ChallengeSelector.open(this.user,
                             Material.ORANGE_STAINED_GLASS_PANE,
                             challengeDescriptionMap,
                             (status, valueSet) -> {
-                                if (status)
+                                if (Boolean.TRUE.equals(status))
                                 {
                                     valueSet.forEach(challenge ->
                                         this.manager.resetChallenge(player.getUniqueId(),

--- a/src/main/java/world/bentobox/challenges/panel/admin/ManageAdvancementsPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ManageAdvancementsPanel.java
@@ -101,11 +101,10 @@ public class ManageAdvancementsPanel extends CommonPagedPanel<Advancement>
 		else
 		{
             this.filterElements = this.advancementsList.stream().
-				filter(element -> {
+				filter(element ->
 					// If element name is set and name contains search field, then do not filter out.
-                        return PlainTextComponentSerializer.plainText().serialize(element.getDisplay().title()).toLowerCase(Locale.ENGLISH)
-                                .contains(this.searchString.toLowerCase(Locale.ENGLISH));
-				}).
+                    PlainTextComponentSerializer.plainText().serialize(element.getDisplay().title()).toLowerCase(Locale.ENGLISH)
+                                .contains(this.searchString.toLowerCase(Locale.ENGLISH))).
 				distinct().
 				collect(Collectors.toList());
 		}
@@ -161,7 +160,7 @@ public class ManageAdvancementsPanel extends CommonPagedPanel<Advancement>
 				{
                     SingleAdvancementSelector.open(this.user, (status, advancement) ->
 						{
-							if (status)
+							if (Boolean.TRUE.equals(status))
 							{
                             this.advancementsList.add(advancement);
 							}

--- a/src/main/java/world/bentobox/challenges/panel/admin/ManageBlockGroupsPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ManageBlockGroupsPanel.java
@@ -113,11 +113,10 @@ public class ManageBlockGroupsPanel extends CommonPagedPanel<Tag<Material>>
 		else
 		{
 			this.filterElements = this.materialList.stream().
-				filter(element -> {
+				filter(element ->
 					// If element name is set and name contains search field, then do not filter out.
-                        return element.getKey().getKey().toLowerCase(Locale.ENGLISH)
-                                .contains(this.searchString.toLowerCase(Locale.ENGLISH));
-				}).
+                    element.getKey().getKey().toLowerCase(Locale.ENGLISH)
+                                .contains(this.searchString.toLowerCase(Locale.ENGLISH))).
 				distinct().
 				collect(Collectors.toList());
 		}
@@ -175,7 +174,7 @@ public class ManageBlockGroupsPanel extends CommonPagedPanel<Tag<Material>>
 						new HashSet<>(this.materialList),
 						(status, materials) ->
 						{
-							if (status)
+							if (Boolean.TRUE.equals(status))
 							{
 								materials.forEach(material ->
 								{

--- a/src/main/java/world/bentobox/challenges/panel/admin/ManageBlocksPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ManageBlocksPanel.java
@@ -133,7 +133,7 @@ public class ManageBlocksPanel extends AbstractManageEnumPanel<Material> {
                 // Open a multi-selection tool to add new materials.
                 MultiBlockSelector.open(this.user, MultiBlockSelector.Mode.BLOCKS, new HashSet<>(this.itemList),
                         (status, materials) -> {
-                            if (status) {
+                            if (Boolean.TRUE.equals(status)) {
                                 // For each selected material, add it to the map with a default count.
                                 materials.forEach(material -> {
                                     this.itemsMap.put(material, 1);

--- a/src/main/java/world/bentobox/challenges/panel/admin/ManageEntitiesPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ManageEntitiesPanel.java
@@ -139,7 +139,7 @@ public class ManageEntitiesPanel extends AbstractManageEnumPanel<EntityType> {
                 // Open a multi-selection tool to add new entities.
                 MultiEntitySelector.open(this.user, MultiEntitySelector.Mode.ALIVE, this.itemsMap.keySet(),
                         (status, entities) -> {
-                            if (status) {
+                            if (Boolean.TRUE.equals(status)) {
                                 // For each selected entity, add it to the map with a default count.
                                 entities.forEach(entity -> {
                                     this.itemsMap.put(entity, 1);

--- a/src/main/java/world/bentobox/challenges/panel/admin/ManageEntityGroupsPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ManageEntityGroupsPanel.java
@@ -116,11 +116,10 @@ public class ManageEntityGroupsPanel extends CommonPagedPanel<Tag<EntityType>>
 		else
 		{
 			this.filterElements = this.materialList.stream().
-				filter(element -> {
+				filter(element ->
 					// If element name is set and name contains search field, then do not filter out.
-                        return element.getKey().getKey().toLowerCase(Locale.ENGLISH)
-                                .contains(this.searchString.toLowerCase(Locale.ENGLISH));
-				}).
+                    element.getKey().getKey().toLowerCase(Locale.ENGLISH)
+                                .contains(this.searchString.toLowerCase(Locale.ENGLISH))).
 				distinct().
 				collect(Collectors.toList());
 		}
@@ -178,7 +177,7 @@ public class ManageEntityGroupsPanel extends CommonPagedPanel<Tag<EntityType>>
 						new HashSet<>(this.materialList),
 						(status, materials) ->
 						{
-							if (status)
+							if (Boolean.TRUE.equals(status))
 							{
 								materials.forEach(material ->
 								{

--- a/src/main/java/world/bentobox/challenges/panel/admin/ManageStatisticsPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ManageStatisticsPanel.java
@@ -109,11 +109,10 @@ public class ManageStatisticsPanel extends CommonPagedPanel<StatisticRec>
 		else
 		{
 			this.filterElements = this.statisticsList.stream().
-				filter(element -> {
+				filter(element ->
 					// If element name is set and name contains search field, then do not filter out.
-                        return element.statistic().getKey().getKey().toLowerCase(Locale.ENGLISH)
-                                .contains(this.searchString.toLowerCase(Locale.ENGLISH));
-				}).
+                    element.statistic().getKey().getKey().toLowerCase(Locale.ENGLISH)
+                                .contains(this.searchString.toLowerCase(Locale.ENGLISH))).
 				distinct().
 				collect(Collectors.toList());
 		}
@@ -169,7 +168,7 @@ public class ManageStatisticsPanel extends CommonPagedPanel<StatisticRec>
 				{
                     StatisticSelector.open(this.user, (status, statistic) ->
 						{
-							if (status)
+							if (Boolean.TRUE.equals(status))
 							{
                             StatisticRec newItem = new StatisticRec(statistic, null, null, 0, false);
                             this.statisticsList.add(newItem);
@@ -467,7 +466,7 @@ public class ManageStatisticsPanel extends CommonPagedPanel<StatisticRec>
             icon = new ItemStack(req.statistic() == null ? Material.BARRIER : Material.PAPER);
             clickHandler = (panel, user, clickType, slot) -> {
                 StatisticSelector.open(this.user, (status, statistic) -> {
-                    if (status) {
+                    if (Boolean.TRUE.equals(status)) {
                         // Replace the old with the new
                         statisticsList.removeIf(sr -> sr.equals(req));
                         statisticsList.add(new StatisticRec(statistic, null, null, 0, false));
@@ -532,7 +531,7 @@ public class ManageStatisticsPanel extends CommonPagedPanel<StatisticRec>
             icon = req.material() == null ? new ItemStack(Material.BARRIER) : new ItemStack(req.material());
             clickHandler = (panel, user, clickType, slot) -> {
                 SingleBlockSelector.open(this.user, SingleBlockSelector.Mode.BLOCKS, (status, block) -> {
-                    if (status) {
+                    if (Boolean.TRUE.equals(status)) {
                         // Replace the old with the new
                         statisticsList.removeIf(sr -> sr.equals(req));
                         statisticsList.add(new StatisticRec(req.statistic(), req.entity(), block, req.amount(),
@@ -557,7 +556,7 @@ public class ManageStatisticsPanel extends CommonPagedPanel<StatisticRec>
             icon = req.material() == null ? new ItemStack(Material.BARRIER) : new ItemStack(req.material());
             clickHandler = (panel, user, clickType, slot) -> {
                 SingleBlockSelector.open(this.user, SingleBlockSelector.Mode.ITEMS, (status, block) -> {
-                    if (status) {
+                    if (Boolean.TRUE.equals(status)) {
                         // Replace the old with the new
                         statisticsList.removeIf(sr -> sr.equals(req));
                         statisticsList.add(new StatisticRec(req.statistic(), req.entity(), block, req.amount(),
@@ -582,7 +581,7 @@ public class ManageStatisticsPanel extends CommonPagedPanel<StatisticRec>
                     : new ItemStack(PanelUtils.getEntityEgg(req.entity()));
             clickHandler = (panel, user, clickType, slot) -> {
                 SingleEntitySelector.open(this.user, (status, entity) -> {
-                    if (status) {
+                    if (Boolean.TRUE.equals(status)) {
                         // Replace the old with the new
                         statisticsList.removeIf(sr -> sr.equals(req));
                         statisticsList.add(new StatisticRec(req.statistic(), entity, req.material(), req.amount(),

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesPanel.java
@@ -672,36 +672,36 @@ public class ChallengesPanel extends CommonPanel
 
         int nextPageIndex;
 
-        switch (target)
+        if (Constants.CHALLENGE_BUILDER_KEY.equals(target))
         {
-            case Constants.CHALLENGE_BUILDER_KEY -> {
-                int size = this.challengeList.size();
+            int size = this.challengeList.size();
 
-                if (size <= slot.amountMap().getOrDefault(Constants.CHALLENGE_BUILDER_KEY, 1) ||
-                    1.0 * size / slot.amountMap().getOrDefault(Constants.CHALLENGE_BUILDER_KEY, 1) <= this.challengeIndex + 1)
-                {
-                    // There are no next elements
-                    return null;
-                }
-
-                nextPageIndex = this.challengeIndex + 2;
-            }
-            case Constants.LEVEL_BUILDER_KEY -> {
-                int size = this.levelList.size();
-
-                if (size <= slot.amountMap().getOrDefault(Constants.LEVEL_BUILDER_KEY, 1) ||
-                    1.0 * size / slot.amountMap().getOrDefault(Constants.LEVEL_BUILDER_KEY, 1) <= this.levelIndex + 1)
-                {
-                    // There are no next elements
-                    return null;
-                }
-
-                nextPageIndex = this.levelIndex + 2;
-            }
-            default -> {
-                // If not assigned to any type, return null.
+            if (size <= slot.amountMap().getOrDefault(Constants.CHALLENGE_BUILDER_KEY, 1) ||
+                1.0 * size / slot.amountMap().getOrDefault(Constants.CHALLENGE_BUILDER_KEY, 1) <= this.challengeIndex + 1)
+            {
+                // There are no next elements
                 return null;
             }
+
+            nextPageIndex = this.challengeIndex + 2;
+        }
+        else if (Constants.LEVEL_BUILDER_KEY.equals(target))
+        {
+            int size = this.levelList.size();
+
+            if (size <= slot.amountMap().getOrDefault(Constants.LEVEL_BUILDER_KEY, 1) ||
+                1.0 * size / slot.amountMap().getOrDefault(Constants.LEVEL_BUILDER_KEY, 1) <= this.levelIndex + 1)
+            {
+                // There are no next elements
+                return null;
+            }
+
+            nextPageIndex = this.levelIndex + 2;
+        }
+        else
+        {
+            // If not assigned to any type, return null.
+            return null;
         }
 
         PanelItemBuilder builder = new PanelItemBuilder();
@@ -710,7 +710,7 @@ public class ChallengesPanel extends CommonPanel
         {
             ItemStack clone = template.icon().clone();
 
-            if ((Boolean) template.dataMap().getOrDefault("indexing", false))
+            if (Boolean.TRUE.equals(template.dataMap().getOrDefault("indexing", false)))
             {
                 clone.setAmount(nextPageIndex);
             }
@@ -733,10 +733,13 @@ public class ChallengesPanel extends CommonPanel
         builder.clickHandler((panel, user, clickType, i) ->
         {
             // Next button ignores click type currently.
-            switch (target)
+            if (Constants.CHALLENGE_BUILDER_KEY.equals(target))
             {
-                case Constants.CHALLENGE_BUILDER_KEY -> this.challengeIndex++;
-                case Constants.LEVEL_BUILDER_KEY -> this.levelIndex++;
+                this.challengeIndex++;
+            }
+            else if (Constants.LEVEL_BUILDER_KEY.equals(target))
+            {
+                this.levelIndex++;
             }
 
             this.build();
@@ -803,7 +806,7 @@ public class ChallengesPanel extends CommonPanel
         {
             ItemStack clone = template.icon().clone();
 
-            if ((Boolean) template.dataMap().getOrDefault("indexing", false))
+            if (Boolean.TRUE.equals(template.dataMap().getOrDefault("indexing", false)))
             {
                 clone.setAmount(previousPageIndex);
             }
@@ -826,10 +829,13 @@ public class ChallengesPanel extends CommonPanel
         builder.clickHandler((panel, user, clickType, i) ->
         {
             // Next button ignores click type currently.
-            switch (target)
+            if (Constants.CHALLENGE_BUILDER_KEY.equals(target))
             {
-                case Constants.CHALLENGE_BUILDER_KEY -> this.challengeIndex--;
-                case Constants.LEVEL_BUILDER_KEY -> this.levelIndex--;
+                this.challengeIndex--;
+            }
+            else if (Constants.LEVEL_BUILDER_KEY.equals(target))
+            {
+                this.levelIndex--;
             }
 
             this.build();

--- a/src/main/java/world/bentobox/challenges/panel/user/GameModePanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/GameModePanel.java
@@ -241,7 +241,7 @@ public class GameModePanel extends CommonPanel
         {
             ItemStack clone = template.icon().clone();
 
-            if ((Boolean) template.dataMap().getOrDefault("indexing", false))
+            if (Boolean.TRUE.equals(template.dataMap().getOrDefault("indexing", false)))
             {
                 clone.setAmount(nextPageIndex);
             }
@@ -317,7 +317,7 @@ public class GameModePanel extends CommonPanel
         {
             ItemStack clone = template.icon().clone();
 
-            if ((Boolean) template.dataMap().getOrDefault("indexing", false))
+            if (Boolean.TRUE.equals(template.dataMap().getOrDefault("indexing", false)))
             {
                 clone.setAmount(previousPageIndex);
             }

--- a/src/main/java/world/bentobox/challenges/panel/util/ChallengeSelector.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/ChallengeSelector.java
@@ -35,7 +35,7 @@ public class ChallengeSelector extends PagedSelector<Challenge>
 		this.border = border;
 
 		this.elements = challengesDescriptionMap.keySet().stream().toList();
-		this.selectedElements = new HashSet<>(this.elements.size());
+		this.selectedElements = HashSet.newHashSet(this.elements.size());
 		this.filterElements = this.elements;
 	}
 
@@ -85,13 +85,12 @@ public class ChallengeSelector extends PagedSelector<Challenge>
 		else
 		{
 			this.filterElements = this.elements.stream().
-				filter(element -> {
+				filter(element ->
 					// If element name is set and name contains search field, then do not filter out.
-					return element.getUniqueId().toLowerCase().
+                    element.getUniqueId().toLowerCase().
 						contains(this.searchString.toLowerCase()) ||
 						element.getFriendlyName().toLowerCase().
-							contains(this.searchString.toLowerCase());
-				}).
+							contains(this.searchString.toLowerCase())).
 				distinct().
 				collect(Collectors.toList());
 		}

--- a/src/main/java/world/bentobox/challenges/panel/util/PagedSelector.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/PagedSelector.java
@@ -99,7 +99,7 @@ public abstract class PagedSelector<T>
 
         // Add next page button if there are more than MAX_ELEMENTS objects and pageIndex + 1 is
         // larger or equal to the max page count.
-        if (size > MAX_ELEMENTS && !(1.0 * size / MAX_ELEMENTS <= this.pageIndex + 1))
+        if (size > MAX_ELEMENTS && 1.0 * size / MAX_ELEMENTS > this.pageIndex + 1)
         {
             panelBuilder.item(26, this.getButton(CommonButtons.NEXT));
 

--- a/src/main/java/world/bentobox/challenges/panel/util/SingleAdvancementSelector.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SingleAdvancementSelector.java
@@ -117,10 +117,9 @@ public class SingleAdvancementSelector extends PagedSelector<Advancement>
         if (this.searchString == null || this.searchString.isBlank()) {
             this.filterElements = this.elements;
         } else {
-            this.filterElements = this.elements.stream().filter(element -> {
+            this.filterElements = this.elements.stream().filter(element ->
                 // If element name is set and name contains search field, then do not filter out.
-                return PlainTextComponentSerializer.plainText().serialize(element.getDisplay().title()).toLowerCase().contains(this.searchString.toLowerCase());
-            }).distinct().collect(Collectors.toList());
+                    PlainTextComponentSerializer.plainText().serialize(element.getDisplay().title()).toLowerCase().contains(this.searchString.toLowerCase())).distinct().collect(Collectors.toList());
         }
     }
 

--- a/src/main/java/world/bentobox/challenges/panel/util/SingleBlockSelector.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SingleBlockSelector.java
@@ -48,19 +48,11 @@ public class SingleBlockSelector extends PagedSelector<Material>
 
 		this.elements = Arrays.stream(Material.values()).
 			filter(material -> !excluded.contains(material)).
-			filter(material -> {
-				switch (mode)
-				{
-					case BLOCKS -> {
-						return material.isBlock();
-					}
-					case ITEMS -> {
-						return material.isItem();
-					}
-					default -> {
-						return true;
-					}
-				}
+			filter(material -> switch (mode)
+			{
+				case BLOCKS -> material.isBlock();
+				case ITEMS -> material.isItem();
+				default -> true;
 			}).
 			// Sort by name
 			sorted(Comparator.comparing(Material::name)).
@@ -143,10 +135,9 @@ public class SingleBlockSelector extends PagedSelector<Material>
 		else
 		{
 			this.filterElements = this.elements.stream().
-				filter(element -> {
+				filter(element ->
 					// If element name is set and name contains search field, then do not filter out.
-					return element.name().toLowerCase().contains(this.searchString.toLowerCase());
-				}).
+                    element.name().toLowerCase().contains(this.searchString.toLowerCase())).
 				distinct().
 				collect(Collectors.toList());
 		}

--- a/src/main/java/world/bentobox/challenges/panel/util/SingleEntitySelector.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/SingleEntitySelector.java
@@ -137,10 +137,9 @@ public class SingleEntitySelector extends PagedSelector<EntityType>
         if (this.searchString == null || this.searchString.isBlank()) {
             this.filterElements = this.elements;
         } else {
-            this.filterElements = this.elements.stream().filter(element -> {
+            this.filterElements = this.elements.stream().filter(element ->
                 // If element name is set and name contains search field, then do not filter out.
-                return element.name().toLowerCase().contains(this.searchString.toLowerCase());
-            }).distinct().collect(Collectors.toList());
+                    element.name().toLowerCase().contains(this.searchString.toLowerCase())).distinct().collect(Collectors.toList());
         }
     }
 

--- a/src/main/java/world/bentobox/challenges/panel/util/StatisticSelector.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/StatisticSelector.java
@@ -96,10 +96,9 @@ public class StatisticSelector extends PagedSelector<Statistic>
 		else
 		{
 			this.filterElements = this.elements.stream().
-				filter(element -> {
+				filter(element ->
 					// If element name is set and name contains search field, then do not filter out.
-					return element.name().toLowerCase().contains(this.searchString.toLowerCase());
-				}).
+                    element.name().toLowerCase().contains(this.searchString.toLowerCase())).
 				distinct().
 				collect(Collectors.toList());
 		}

--- a/src/main/java/world/bentobox/challenges/tasks/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/tasks/TryToComplete.java
@@ -103,7 +103,7 @@ public class TryToComplete
     /**
      * Variable that will be used to avoid multiple empty object generation.
      */
-    private final ChallengeResult EMPTY_RESULT = new ChallengeResult();
+    private final ChallengeResult emptyResult = new ChallengeResult();
 
     // ---------------------------------------------------------------------
     // Section: Builder
@@ -652,18 +652,18 @@ public class TryToComplete
         if (!this.challenge.isDeployed())
         {
             Utils.sendMessage(this.user, this.world, Constants.ERRORS + "not-deployed");
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
         else if (maxTimes < 1)
         {
             Utils.sendMessage(this.user, this.world, Constants.ERRORS + "not-valid-integer");
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
         else if (Util.getWorld(this.world) != Util.getWorld(this.user.getWorld()) ||
                 !this.challenge.matchGameMode(Utils.getGameMode(this.world)))
         {
             Utils.sendMessage(this.user, this.world, "general.errors.wrong-world");
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
         // Player is not on island
         else if (this.user.getLocation() == null ||
@@ -671,34 +671,34 @@ public class TryToComplete
                 !this.addon.getIslands().locationIsOnIsland(this.user.getPlayer(), this.user.getLocation()))
         {
             Utils.sendMessage(this.user, this.world, Constants.MESSAGES + "not-on-island");
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
         // Check player permission
         else if (!this.addon.getIslands().getIslandAt(this.user.getLocation()).
                 map(i -> i.isAllowed(this.user, ChallengesAddon.CHALLENGES_ISLAND_PROTECTION)).orElse(false))
         {
             Utils.sendMessage(this.user, this.world, Constants.MESSAGES + "no-rank");
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
         // Check if user has unlocked challenges level.
         else if (!this.challenge.getLevel().equals(ChallengesManager.FREE) &&
                 !this.manager.isLevelUnlocked(this.user, this.world, this.manager.getLevel(this.challenge.getLevel())))
         {
             Utils.sendMessage(this.user, this.world, Constants.ERRORS + "challenge-level-not-available");
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
         // Check max times
         else if (this.challenge.isRepeatable() && this.challenge.getMaxTimes() > 0 &&
                 this.manager.getChallengeTimes(this.user, this.world, this.challenge) >= this.challenge.getMaxTimes())
         {
             Utils.sendMessage(this.user, this.world, Constants.ERRORS + "not-repeatable");
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
         // Check repeatability
         else if (!this.challenge.isRepeatable() && this.manager.isChallengeComplete(this.user, this.world, this.challenge))
         {
             Utils.sendMessage(this.user, this.world, Constants.ERRORS + "not-repeatable");
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
         // Check if timeout is not broken
         else if (this.manager.isBreachingTimeOut(this.user, this.world, this.challenge))
@@ -709,26 +709,26 @@ public class TryToComplete
             Utils.sendMessage(this.user, this.world, Constants.ERRORS + "timeout",
                     "[timeout]", Utils.parseDuration(Duration.ofMillis(this.challenge.getTimeout()), this.user),
                     "[wait-time]", Utils.parseDuration(Duration.ofMillis(missing), this.user));
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
         // Check environment
         else if (!this.challenge.getEnvironment().isEmpty() &&
                 !this.challenge.getEnvironment().contains(this.user.getWorld().getEnvironment()))
         {
             Utils.sendMessage(this.user, this.world, Constants.ERRORS + "wrong-environment");
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
         // Check permission
         else if (!this.checkPermissions())
         {
             Utils.sendMessage(this.user, this.world, Constants.ERRORS + "no-permission");
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
         // Check team presence gate for team challenges.
         else if (this.challenge.isTeamChallenge() && !this.hasRequiredTeamPresence())
         {
             // Error message already sent by hasRequiredTeamPresence().
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
         else if (type.equals(ChallengeType.INVENTORY_TYPE))
         {
@@ -748,7 +748,7 @@ public class TryToComplete
         }
         else
         {
-            result = EMPTY_RESULT;
+            result = emptyResult;
         }
 
         // Mark if challenge is completed.
@@ -929,7 +929,7 @@ public class TryToComplete
     {
         if (maxTimes <= 0)
         {
-            return EMPTY_RESULT;
+            return emptyResult;
         }
 
         // Team challenge variants.
@@ -961,7 +961,7 @@ public class TryToComplete
                 {
                     Utils.sendMessage(this.user, this.world, Constants.ERRORS + "not-enough-items",
                             "[items]", Utils.prettifyObject(required, this.user));
-                    return EMPTY_RESULT;
+                    return emptyResult;
                 }
 
                 maxTimes = Math.min(maxTimes, numInInventory / required.getAmount());
@@ -1005,7 +1005,7 @@ public class TryToComplete
             {
                 Utils.sendMessage(this.user, this.world, Constants.ERRORS + "not-enough-items",
                         "[items]", Utils.prettifyObject(required, this.user));
-                return EMPTY_RESULT;
+                return emptyResult;
             }
 
             maxTimes = Math.min(maxTimes, total / required.getAmount());
@@ -1046,7 +1046,7 @@ public class TryToComplete
                             Constants.PARAMETER_NAME, member.getName(),
                             Constants.PARAMETER_AMOUNT, String.valueOf(share),
                             Constants.PARAMETER_ITEM, Utils.prettifyObject(required, this.user));
-                    return EMPTY_RESULT;
+                    return emptyResult;
                 }
             }
         }
@@ -1195,7 +1195,7 @@ public class TryToComplete
     {
         if (factor <= 0)
         {
-            return EMPTY_RESULT;
+            return emptyResult;
         }
 
         // Init location in player position.
@@ -1222,7 +1222,7 @@ public class TryToComplete
 
             if (island == null) {
                 // Just in case. Should never hit because there is a check if the player is on this island further up
-                return EMPTY_RESULT;
+                return emptyResult;
             }
 
             if (boundingBox.getMinX() < island.getMinX())
@@ -1258,7 +1258,7 @@ public class TryToComplete
                         " | Center: " + island.getCenter() +
                         " | Range: " + range);
 
-                return EMPTY_RESULT;
+                return emptyResult;
             }
         }
 
@@ -1368,7 +1368,7 @@ public class TryToComplete
         tagsFound.clear();
         blockQueue.clear();
 
-        return EMPTY_RESULT;
+        return emptyResult;
     }
 
     // Interface to get elements at a specific location
@@ -1389,7 +1389,7 @@ public class TryToComplete
             return new ChallengeResult().setMeetsRequirements().setCompleteFactor(factor);
         }
         Map<Material, Integer> blocks = new EnumMap<>(requiredMap);
-        Map<Material, Integer> blocksFound = new HashMap<>(requiredMap.size());
+        Map<Material, Integer> blocksFound = new EnumMap<>(Material.class);
 
         // This queue will contain only blocks with the required type ordered by distance till player.
         Queue<Block> blockFromWorld = new PriorityQueue<>((o1, o2) -> {
@@ -1454,7 +1454,7 @@ public class TryToComplete
         blocksFound.clear();
         blockFromWorld.clear();
 
-        return EMPTY_RESULT;
+        return emptyResult;
     }
 
 
@@ -1472,7 +1472,7 @@ public class TryToComplete
         }
 
         // Collect all entities that could be removed.
-        Map<EntityType, Integer> entitiesFound = new HashMap<>();
+        Map<EntityType, Integer> entitiesFound = new EnumMap<>(EntityType.class);
         Map<EntityType, Integer> minimalRequirements = new EnumMap<>(requiredMap);
 
         // Create queue that contains all required entities ordered by distance till player.
@@ -1527,7 +1527,7 @@ public class TryToComplete
         minimalRequirements.clear();
         entityQueue.clear();
 
-        return EMPTY_RESULT;
+        return emptyResult;
     }
 
 
@@ -1590,7 +1590,7 @@ public class TryToComplete
      */
     private ChallengeResult checkOthers(int factor) {
         if (factor <= 0) {
-            return EMPTY_RESULT;
+            return emptyResult;
         }
 
         OtherRequirements requirements = this.getOtherRequirements();
@@ -1652,7 +1652,7 @@ public class TryToComplete
             return new ChallengeResult().setMeetsRequirements().setCompleteFactor(factor);
         }
 
-        return EMPTY_RESULT;
+        return emptyResult;
     }
 
     // ---------------------------------------------------------------------
@@ -1666,7 +1666,7 @@ public class TryToComplete
      */
     private ChallengeResult checkStatistic(int factor) {
         if (factor <= 0) {
-            return EMPTY_RESULT;
+            return emptyResult;
         }
 
         StatisticRequirements requirements = this.challenge.getRequirements();
@@ -1675,7 +1675,7 @@ public class TryToComplete
 
         if (requirements.getRequiredStatistics().isEmpty()) {
             // Sanity check.
-            return EMPTY_RESULT;
+            return emptyResult;
         }
         // Team aggregate (Combined Effort): sum the increase since baseline across online members.
         boolean teamAggregate = this.challenge.isTeamChallenge() && this.challenge.isAggregateTeam();
@@ -1729,7 +1729,7 @@ public class TryToComplete
             // Return any of them, because they pass
             return cr.getFirst();
         }
-        return EMPTY_RESULT;
+        return emptyResult;
     }
 
     // ---------------------------------------------------------------------

--- a/src/test/java/world/bentobox/challenges/commands/CompleteChallengeCommandTest.java
+++ b/src/test/java/world/bentobox/challenges/commands/CompleteChallengeCommandTest.java
@@ -208,7 +208,7 @@ class CompleteChallengeCommandTest {
     void testExecuteUserStringListOfStringNoArgs() {
         assertFalse(cc.execute(user, "complete", Collections.emptyList()));
         mockedUtils.verify(() -> Utils.sendMessage(user, world, Constants.ERRORS + "no-name"));
-        verify(user).sendMessage(eq("commands.help.header"), eq(TextVariables.LABEL), eq("BSkyBlock"));
+        verify(user).sendMessage("commands.help.header", TextVariables.LABEL, "BSkyBlock");
     }
 
     @Test
@@ -216,7 +216,7 @@ class CompleteChallengeCommandTest {
         when(chm.getChallenge(anyString())).thenReturn(null);
         assertFalse(cc.execute(user, "complete", Collections.singletonList("mychal")));
         mockedUtils.verify(() -> Utils.sendMessage(user, world, Constants.ERRORS + "unknown-challenge"));
-        verify(user).sendMessage(eq("commands.help.header"), eq(TextVariables.LABEL), eq("BSkyBlock"));
+        verify(user).sendMessage("commands.help.header", TextVariables.LABEL, "BSkyBlock");
     }
 
     @Test

--- a/src/test/java/world/bentobox/challenges/panel/CommonPagedPanelTest.java
+++ b/src/test/java/world/bentobox/challenges/panel/CommonPagedPanelTest.java
@@ -69,7 +69,6 @@ class CommonPagedPanelTest {
 
         @Override
         protected void updateFilters() {
-            boolean filterUpdated = true;
         }
 
         @Override

--- a/src/test/java/world/bentobox/challenges/panel/ConversationUtilsTest.java
+++ b/src/test/java/world/bentobox/challenges/panel/ConversationUtilsTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -92,7 +92,7 @@ class ConversationUtilsTest {
     void testCreateIDStringInput() {
         @SuppressWarnings("unchecked")
         Consumer<String> consumer = mock(Consumer.class);
-        Function<String, Boolean> validation = input -> true;
+        Predicate<String> validation = input -> true;
         ConversationUtils.createIDStringInput(consumer, validation, user,
             "Enter ID:", "Created!", "challenges.conversations.object-already-exists");
         verify(user).getPlayer();

--- a/src/test/java/world/bentobox/challenges/tasks/TryToCompleteTest.java
+++ b/src/test/java/world/bentobox/challenges/tasks/TryToCompleteTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -291,8 +292,8 @@ class TryToCompleteTest extends AbstractChallengesTest {
         when(itemStackMock3.getType()).thenReturn(Material.EMERALD_BLOCK);
         when(itemStackMock3.getAmount()).thenReturn(15);
         when(itemStackMock3.clone()).thenReturn(itemStackMock3);
-        when(itemStackMock3.isSimilar(eq(itemStackMock))).thenReturn(true);
-        when(itemStackMock.isSimilar(eq(itemStackMock3))).thenReturn(true);
+        when(itemStackMock3.isSimilar(itemStackMock)).thenReturn(true);
+        when(itemStackMock.isSimilar(itemStackMock3)).thenReturn(true);
 
         req.setRequiredItems(Arrays.asList(itemStackMock, itemStackMock2));
         challenge.setRequirements(req);
@@ -355,7 +356,7 @@ class TryToCompleteTest extends AbstractChallengesTest {
     void testCompleteChallengesAddonUserChallengeWorldStringStringIslandFailMultipleEntities() {
         challenge.setChallengeType(ChallengeType.ISLAND_TYPE);
         IslandRequirements req = new IslandRequirements();
-        Map<EntityType, Integer> requiredEntities = new HashMap<>();
+        Map<EntityType, Integer> requiredEntities = new EnumMap<>(EntityType.class);
         requiredEntities.put(EntityType.GHAST, 3);
         requiredEntities.put(EntityType.CHICKEN, 5);
         requiredEntities.put(EntityType.PUFFERFISH, 1);
@@ -375,7 +376,7 @@ class TryToCompleteTest extends AbstractChallengesTest {
     void testCompleteChallengesAddonUserChallengeWorldStringStringIslandFailPartialMultipleEntities() {
         challenge.setChallengeType(ChallengeType.ISLAND_TYPE);
         IslandRequirements req = new IslandRequirements();
-        Map<EntityType, Integer> requiredEntities = new HashMap<>();
+        Map<EntityType, Integer> requiredEntities = new EnumMap<>(EntityType.class);
         requiredEntities.put(EntityType.GHAST, 3);
         requiredEntities.put(EntityType.CHICKEN, 5);
         requiredEntities.put(EntityType.PUFFERFISH, 1);
@@ -401,7 +402,7 @@ class TryToCompleteTest extends AbstractChallengesTest {
     void testCompleteChallengesAddonUserChallengeWorldStringStringIslandSuccess() {
         challenge.setChallengeType(ChallengeType.ISLAND_TYPE);
         IslandRequirements req = new IslandRequirements();
-        Map<EntityType, Integer> requiredEntities = new HashMap<>();
+        Map<EntityType, Integer> requiredEntities = new EnumMap<>(EntityType.class);
         requiredEntities.put(EntityType.PUFFERFISH, 1);
         req.setRequiredEntities(requiredEntities);
         req.setSearchRadius(1);
@@ -426,7 +427,7 @@ class TryToCompleteTest extends AbstractChallengesTest {
         when(netherWorld.getEnvironment()).thenReturn(Environment.NETHER);
         challenge.setChallengeType(ChallengeType.ISLAND_TYPE);
         IslandRequirements req = new IslandRequirements();
-        Map<EntityType, Integer> requiredEntities = new HashMap<>();
+        Map<EntityType, Integer> requiredEntities = new EnumMap<>(EntityType.class);
         requiredEntities.put(EntityType.PUFFERFISH, 1);
         req.setRequiredEntities(requiredEntities);
         req.setSearchRadius(1);
@@ -597,7 +598,7 @@ class TryToCompleteTest extends AbstractChallengesTest {
         when(plugin.getHooks()).thenReturn(mock(world.bentobox.bentobox.managers.HooksManager.class));
         when(plugin.getHooks().getHook("PlaceholderAPI")).thenReturn(Optional.empty());
         assertTrue(TryToComplete.complete(addon, user, challenge, world, topLabel, permissionPrefix));
-        verify(vault).withdraw(eq(user), eq(50.0));
+        verify(vault).withdraw(user, 50.0);
     }
 
     @Test
@@ -737,7 +738,7 @@ class TryToCompleteTest extends AbstractChallengesTest {
         VaultHook vault = mockEconomy(true, 1000.0);
         when(inv.addItem(any())).thenReturn(new HashMap<>());
         assertTrue(TryToComplete.complete(addon, user, challenge, world, topLabel, permissionPrefix));
-        verify(vault).deposit(eq(user), eq(100.0));
+        verify(vault).deposit(user, 100.0);
     }
 
     @Test
@@ -756,7 +757,7 @@ class TryToCompleteTest extends AbstractChallengesTest {
         VaultHook vault = mockEconomy(true, 1000.0);
         when(inv.addItem(any())).thenReturn(new HashMap<>());
         assertTrue(TryToComplete.complete(addon, user, challenge, world, topLabel, permissionPrefix));
-        verify(vault).deposit(eq(user), eq(25.0));
+        verify(vault).deposit(user, 25.0);
     }
 
     @Test
@@ -809,7 +810,7 @@ class TryToCompleteTest extends AbstractChallengesTest {
         lvl.setRewardExperience(200);
         // Stub both overloads: getLevel(String) used in checkIfCanCompleteChallenge,
         // getLevel(Challenge) used in build() for level completion check
-        when(cm.getLevel(eq(GAME_MODE_NAME + "_novice"))).thenReturn(lvl);
+        when(cm.getLevel(GAME_MODE_NAME + "_novice")).thenReturn(lvl);
         when(cm.getLevel(any(Challenge.class))).thenReturn(lvl);
         when(cm.isLevelCompleted(any(), any(), any())).thenReturn(false);
         when(cm.validateLevelCompletion(any(), any(), any())).thenReturn(true);
@@ -826,7 +827,7 @@ class TryToCompleteTest extends AbstractChallengesTest {
         ChallengeLevel lvl = new ChallengeLevel();
         lvl.setUniqueId(GAME_MODE_NAME + "_novice");
         lvl.setFriendlyName("Novice");
-        when(cm.getLevel(eq(GAME_MODE_NAME + "_novice"))).thenReturn(lvl);
+        when(cm.getLevel(GAME_MODE_NAME + "_novice")).thenReturn(lvl);
         when(cm.getLevel(any(Challenge.class))).thenReturn(lvl);
         when(cm.isLevelCompleted(any(), any(), any())).thenReturn(true);
         when(inv.addItem(any())).thenReturn(new HashMap<>());


### PR DESCRIPTION
Clears the open **LOW**-severity SonarCloud issues (tech debt), no behaviour changes. Full suite green (458 tests).

| Rule | Fix |
|------|-----|
| **S5411** | Boxed `Boolean` in conditions → null-safe `Boolean.TRUE.equals(...)` (selector `(status, …)` callbacks and `(Boolean)` casts) |
| **S1602** | Single-return block lambdas → expression lambdas |
| **S1640** | `HashMap` with `Material`/`EntityType` keys → `EnumMap` |
| **S6068** | Drop redundant Mockito `eq()` wrappers where all args are `eq()` |
| **S6485** | `new HashSet<>(n)` / `new LinkedHashMap<>(n)` → `HashSet.newHashSet` / `LinkedHashMap.newLinkedHashMap` |
| **S1905** | Remove redundant `List` casts |
| **S1940** | `!(a <= b)` → `a > b` |
| **S1301** | Small `switch` → `if`/`else` |
| **S1481** | Remove unused local variable |
| **S1185** | Remove `StatisticRequirements.isValid` override that only called `super` |
| **S4276** | `Function<String, Boolean>` → `Predicate<String>` (validation) |
| **S6353** | `[0-9]` → `\d` |
| **S116** | Rename `EMPTY_RESULT` field → `emptyResult` |

**Not fixed (1):** S1612 (method reference for `toLegacyText`) — the suggested `BaseComponent::toLegacyText` is ambiguous with the `toLegacyText(BaseComponent...)` varargs overload and does not compile, so the explicit lambda is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)