### PR TITLE
Add setting to open the challenges GUI while off-island

### DIFF
--- a/src/main/java/world/bentobox/challenges/commands/ChallengesPlayerCommand.java
+++ b/src/main/java/world/bentobox/challenges/commands/ChallengesPlayerCommand.java
@@ -66,10 +66,11 @@ public class ChallengesPlayerCommand extends CompositeCommand
             Utils.sendMessage(user, this.getWorld(), "general.errors.no-island");
             return false;
         } else if (ChallengesAddon.CHALLENGES_WORLD_PROTECTION.isSetForWorld(this.getWorld()) &&
+                !((ChallengesAddon) this.getAddon()).getChallengesSettings().isOpenAnywhere() &&
                 !this.getIslands().locationIsOnIsland(user.getPlayer(), user.getLocation()))
         {
             // Do not open gui if player is not on the island, but challenges requires island for
-            // completion.
+            // completion, unless open-anywhere is enabled.
             Utils.sendMessage(user, this.getWorld(), Constants.ERRORS + "not-on-island");
             return false;
         }

--- a/src/main/java/world/bentobox/challenges/config/Settings.java
+++ b/src/main/java/world/bentobox/challenges/config/Settings.java
@@ -115,6 +115,12 @@ public class Settings implements ConfigObject
     @ConfigEntry(path = "gui-settings.undeployed-view-mode")
     private VisibilityMode visibilityMode = VisibilityMode.VISIBLE;
 
+    @ConfigComment("")
+    @ConfigComment("Allow players to open the challenges GUI without being on their island.")
+    @ConfigComment("Note: Challenges completion still requires being on the island when world protection is enabled.")
+    @ConfigEntry(path = "gui-settings.open-anywhere")
+    private boolean openAnywhere = false;
+
 
     @ConfigComment("")
     @ConfigComment("This allows to change default locked level icon. This option may be")
@@ -711,5 +717,27 @@ public class Settings implements ConfigObject
     public void setIncludeUndeployed(boolean includeUndeployed)
     {
         this.includeUndeployed = includeUndeployed;
+    }
+
+
+    /**
+     * Is open anywhere boolean.
+     *
+     * @return the boolean
+     */
+    public boolean isOpenAnywhere()
+    {
+        return openAnywhere;
+    }
+
+
+    /**
+     * Sets open anywhere.
+     *
+     * @param openAnywhere whether to allow opening GUI from anywhere
+     */
+    public void setOpenAnywhere(boolean openAnywhere)
+    {
+        this.openAnywhere = openAnywhere;
     }
 }

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditSettingsPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditSettingsPanel.java
@@ -121,6 +121,7 @@ public class EditSettingsPanel extends CommonPanel
         panelBuilder.item(20, this.getSettingsButton(Button.REMOVE_COMPLETED));
         panelBuilder.item(29, this.getSettingsButton(Button.VISIBILITY_MODE));
         panelBuilder.item(30, this.getSettingsButton(Button.INCLUDE_UNDEPLOYED));
+        panelBuilder.item(32, this.getSettingsButton(Button.OPEN_ANYWHERE));
 
         panelBuilder.item(21, this.getSettingsButton(Button.LOCKED_LEVEL_ICON));
 
@@ -485,6 +486,22 @@ public class EditSettingsPanel extends CommonPanel
                 description.add("");
                 description.add(this.user.getTranslation(Constants.CLICK_TO_TOGGLE));
             }
+            case OPEN_ANYWHERE -> {
+                description.add(this.user.getTranslation(reference +
+                    (this.settings.isOpenAnywhere() ? Constants.ENABLED_KEY : Constants.DISABLED_KEY)));
+
+                icon = new ItemStack(Material.ELYTRA);
+                clickHandler = (panel, user1, clickType, i) -> {
+                    this.settings.setOpenAnywhere(!this.settings.isOpenAnywhere());
+                    panel.getInventory().setItem(i, this.getSettingsButton(button).getItem());
+                    this.addon.saveSettings();
+                    return true;
+                };
+                glow = this.settings.isOpenAnywhere();
+
+                description.add("");
+                description.add(this.user.getTranslation(Constants.CLICK_TO_TOGGLE));
+            }
             default -> {
                 icon = new ItemStack(Material.PAPER);
                 clickHandler = null;
@@ -596,7 +613,11 @@ public class EditSettingsPanel extends CommonPanel
         /**
          * This allows to switch between different challenges visibility modes.
          */
-        VISIBILITY_MODE
+        VISIBILITY_MODE,
+        /**
+         * This allows players to open the GUI without being on their island.
+         */
+        OPEN_ANYWHERE
     }
 
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -76,6 +76,10 @@ gui-settings:
   # TOGGLEABLE - Currently not implemented.
   undeployed-view-mode: VISIBLE
   #
+  # Allow players to open the challenges GUI without being on their island.
+  # Note: Challenges completion still requires being on the island when world protection is enabled.
+  open-anywhere: false
+  #
   # This allows to change default locked level icon. This option may be
   # overwritten by each challenge level. If challenge level has specified
   # their locked level icon, then it will be used, instead of this one.

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -770,6 +770,14 @@ challenges:
                     <gray>should be counted towards level completion.
                 enabled: "<dark_green>Enabled"
                 disabled: "<red>Disabled"
+            open_anywhere:
+                name: "<white><bold>Open GUI Anywhere"
+                description: |-
+                    <gray>Allows players to open the challenges GUI
+                    <gray>from anywhere. Completion still requires
+                    <gray>being on the island when protected.
+                enabled: "<dark_green>Enabled"
+                disabled: "<red>Disabled"
             download:
                 name: "<white><bold>Download Libraries"
                 description: |-

--- a/src/test/java/world/bentobox/challenges/commands/ChallengesCommandTest.java
+++ b/src/test/java/world/bentobox/challenges/commands/ChallengesCommandTest.java
@@ -247,4 +247,25 @@ class ChallengesCommandTest {
         assertEquals(1, cc.getSubCommands(true).size());
     }
 
+    @Test
+    void testCanExecuteOffIslandWithProtectionAndNoOpenAnywhere() {
+        // Player is off island and world protection is on, but openAnywhere is false
+        when(im.locationIsOnIsland(any(Player.class), any())).thenReturn(false);
+        // Note: Since CHALLENGES_WORLD_PROTECTION flag has default setting true,
+        // and TestWorldSetting.getWorldFlags() returns an empty map by default,
+        // the flag will check as enabled. We test behavior when it's restricted.
+        assertFalse(cc.canExecute(user, "challenges", Collections.emptyList()));
+        verify(user).getTranslation(world, "challenges.errors.not-on-island");
+    }
+
+    @Test
+    void testCanExecuteOffIslandWithProtectionAndOpenAnywhere() {
+        // Player is off island but openAnywhere is enabled
+        when(im.locationIsOnIsland(any(Player.class), any())).thenReturn(false);
+        Settings settings = (Settings) addon.getChallengesSettings();
+        settings.setOpenAnywhere(true);
+        assertTrue(cc.canExecute(user, "challenges", Collections.emptyList()));
+        verify(user, never()).getTranslation(world, "challenges.errors.not-on-island");
+    }
+
 }


### PR DESCRIPTION
Fixes #349

## What
New opt-in setting `gui-settings.open-anywhere` (default `false`) that lets players open `/challenges` without standing on their island.

## How
- `ChallengesPlayerCommand.canExecute()` skips **only** the location-on-island check when the setting is enabled. The "player has no island" check is unchanged.
- Completion protection is untouched: `TryToComplete` still enforces being on the island when world protection is on, so this setting only affects viewing.
- Toggle added to the admin settings GUI (`EditSettingsPanel`), with en-US locale strings; entry documented in `config.yml`.

## Tests
Two new cases in `ChallengesCommandTest`: off-island with setting off → refused; off-island with setting on → allowed. Full suite green (460 tests, 0 failures).

## In-game verification
1. Enable `open-anywhere` (config or admin GUI), run `/challenges` from spawn — GUI opens.
2. Try completing an island-bound challenge from spawn — still refused with the not-on-island message.
3. Disable the setting — `/challenges` from spawn is refused again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKxodNE4h3TsSHMqDEeC8v