### PR TITLE
Run level-completion check when challenges are completed by admins

### DIFF
--- a/src/main/java/world/bentobox/challenges/commands/admin/CompleteCommand.java
+++ b/src/main/java/world/bentobox/challenges/commands/admin/CompleteCommand.java
@@ -108,6 +108,8 @@ public class CompleteCommand extends CompositeCommand
 					this.addon.getChallengesManager().setChallengeComplete(
 						targetUUID, this.getWorld(), challenge, user.getUniqueId());
 
+					// Try to complete the level if all challenges are done
+					this.addon.getChallengesManager().tryCompleteLevelAdmin(target, this.getWorld(), challenge);
 
 					if (user.isPlayer())
 					{

--- a/src/main/java/world/bentobox/challenges/managers/ChallengesManager.java
+++ b/src/main/java/world/bentobox/challenges/managers/ChallengesManager.java
@@ -1775,6 +1775,111 @@ public class ChallengesManager
 
 
     /**
+     * This method attempts to complete a level for a user by validating all challenges
+     * in the level are complete. If the level is completable, it marks the level as complete
+     * and fires a LevelCompletedEvent.
+     *
+     * @param user User who completed the level.
+     * @param world World where level must be completed.
+     * @param challenge Challenge whose level should be checked.
+     * @return The completed ChallengeLevel if level was completed, null otherwise.
+     */
+    @Nullable
+    public ChallengeLevel tryCompleteLevel(User user, World world, Challenge challenge)
+    {
+        ChallengeLevel level = this.getCompletableLevel(user, world, challenge);
+        if (level != null)
+        {
+            this.setLevelComplete(user, world, level);
+        }
+        return level;
+    }
+
+
+    /**
+     * This method attempts to complete a level for a user via admin action.
+     * Similar to tryCompleteLevel but fires an admin LevelCompletedEvent.
+     *
+     * @param user User who had the level completed by admin.
+     * @param world World where level must be completed.
+     * @param challenge Challenge whose level should be checked.
+     * @return The completed ChallengeLevel if level was completed, null otherwise.
+     */
+    @Nullable
+    public ChallengeLevel tryCompleteLevelAdmin(User user, World world, Challenge challenge)
+    {
+        ChallengeLevel level = this.getCompletableLevel(user, world, challenge);
+        if (level != null)
+        {
+            this.setLevelCompleteAdmin(user, world, level);
+        }
+        return level;
+    }
+
+
+    /**
+     * Helper method that checks if a level is completable (all challenges done, not already
+     * completed, and not a free level).
+     *
+     * @param user User to check for.
+     * @param world World to check in.
+     * @param challenge Challenge whose level to check.
+     * @return The ChallengeLevel if completable, null otherwise.
+     */
+    @Nullable
+    private ChallengeLevel getCompletableLevel(User user, World world, Challenge challenge)
+    {
+        String levelID = challenge.getLevel();
+        if (levelID.equals(ChallengesManager.FREE))
+        {
+            return null;
+        }
+
+        ChallengeLevel level = this.getLevel(challenge);
+        if (level == null)
+        {
+            return null;
+        }
+
+        if (this.isLevelCompleted(user, world, level))
+        {
+            return null;
+        }
+
+        if (!this.validateLevelCompletion(user, world, level))
+        {
+            return null;
+        }
+
+        return level;
+    }
+
+
+    /**
+     * Helper method to set a level as complete by admin and fire an admin event.
+     *
+     * @param user User who had the level completed.
+     * @param world World where level was completed.
+     * @param level Level to mark as complete.
+     */
+    private void setLevelCompleteAdmin(User user, World world, ChallengeLevel level)
+    {
+        String storageID = this.getDataUniqueID(user, Util.getWorld(world));
+
+        this.setLevelComplete(storageID, level.getUniqueId());
+        this.addLogEntry(storageID, new LogEntry.Builder("COMPLETE_LEVEL").
+                data(USER_ID, user.getUniqueId().toString()).
+                data("level", level.getUniqueId()).build());
+
+        // Fire admin event that admin completes level
+        Bukkit.getPluginManager().callEvent(
+                new LevelCompletedEvent(level.getUniqueId(),
+                        user.getUniqueId(),
+                        true));
+    }
+
+
+    /**
      * This method returns LevelStatus object for given challenge level.
      * @param uniqueId UUID of user who need to be validated.
      * @param world World where level must be validated.

--- a/src/main/java/world/bentobox/challenges/panel/admin/ListUsersPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/ListUsersPanel.java
@@ -222,11 +222,16 @@ public class ListUsersPanel extends CommonPagedPanel<Player>
                             (status, valueSet) -> {
                                 if (Boolean.TRUE.equals(status))
                                 {
-                                    valueSet.forEach(challenge ->
+                                    valueSet.forEach(challenge -> {
                                         manager.setChallengeComplete(player.getUniqueId(),
                                             this.world,
                                             challenge,
-                                            this.user.getUniqueId()));
+                                            this.user.getUniqueId());
+                                        // Try to complete the level if all challenges are done
+                                        manager.tryCompleteLevelAdmin(User.getInstance(player.getUniqueId()),
+                                            this.world,
+                                            challenge);
+                                    });
                                 }
 
                             this.build();

--- a/src/main/java/world/bentobox/challenges/tasks/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/tasks/TryToComplete.java
@@ -364,60 +364,54 @@ public class TryToComplete
         this.manager.setChallengeComplete(this.user, this.world, this.challenge, result.getFactor());
 
         // Check level completion for non-free challenges
-        if (!result.wasCompleted() &&
-                !this.challenge.getLevel().equals(ChallengesManager.FREE))
+        if (!result.wasCompleted())
         {
-            ChallengeLevel level = this.manager.getLevel(this.challenge);
+            ChallengeLevel level = this.manager.tryCompleteLevel(this.user, this.world, this.challenge);
 
-            if (level != null && !this.manager.isLevelCompleted(this.user, this.world, level))
+            if (level != null)
             {
-                if (this.manager.validateLevelCompletion(this.user, this.world, level))
+                // Item rewards
+                for (ItemStack reward : level.getRewardItems())
                 {
-                    // Item rewards
-                    for (ItemStack reward : level.getRewardItems())
-                    {
-                        // Clone is necessary because otherwise it will chane reward itemstack
-                        // amount.
-                        this.user.getInventory().addItem(reward.clone()).forEach((k, v) ->
-                        this.user.getWorld().dropItem(this.user.getLocation(), v));
-                    }
+                    // Clone is necessary because otherwise it will chane reward itemstack
+                    // amount.
+                    this.user.getInventory().addItem(reward.clone()).forEach((k, v) ->
+                    this.user.getWorld().dropItem(this.user.getLocation(), v));
+                }
 
-                    // Money Reward
-                    if (this.addon.isEconomyProvided())
-                    {
-                        this.addon.getEconomyProvider().deposit(this.user, level.getRewardMoney());
-                    }
+                // Money Reward
+                if (this.addon.isEconomyProvided())
+                {
+                    this.addon.getEconomyProvider().deposit(this.user, level.getRewardMoney());
+                }
 
-                    // Experience Reward
-                    this.user.getPlayer().giveExp(level.getRewardExperience());
+                // Experience Reward
+                this.user.getPlayer().giveExp(level.getRewardExperience());
 
-                    // Run commands
-                    this.runCommands(level.getRewardCommands());
+                // Run commands
+                this.runCommands(level.getRewardCommands());
 
-                    Utils.sendMessage(this.user,
-                            this.world, Constants.MESSAGES + "you-completed-level", Constants.PARAMETER_VALUE,
-                            level.getFriendlyName());
+                Utils.sendMessage(this.user,
+                        this.world, Constants.MESSAGES + "you-completed-level", Constants.PARAMETER_VALUE,
+                        level.getFriendlyName());
 
-                    if (this.addon.getChallengesSettings().isBroadcastMessages())
-                    {
-                        Bukkit.getOnlinePlayers().stream().
-                        map(User::getInstance).forEach(user -> Utils.sendMessage(user,
-                                this.world,
-                                Constants.MESSAGES + "name-has-completed-level",
-                                Constants.PARAMETER_NAME, this.user.getName(),
-                                Constants.PARAMETER_VALUE, level.getFriendlyName()));
-                    }
+                if (this.addon.getChallengesSettings().isBroadcastMessages())
+                {
+                    Bukkit.getOnlinePlayers().stream().
+                    map(User::getInstance).forEach(user -> Utils.sendMessage(user,
+                            this.world,
+                            Constants.MESSAGES + "name-has-completed-level",
+                            Constants.PARAMETER_NAME, this.user.getName(),
+                            Constants.PARAMETER_VALUE, level.getFriendlyName()));
+                }
 
-                    this.manager.setLevelComplete(this.user, this.world, level);
-
-                    // sends title to player on level completion
-                    if (this.addon.getChallengesSettings().isShowCompletionTitle())
-                    {
-                        this.user.getPlayer().sendTitle(
-                                this.parseLevel(this.user.getTranslation("challenges.titles.level-title"), level),
-                                this.parseLevel(this.user.getTranslation("challenges.titles.level-subtitle"), level),
-                                10, this.addon.getChallengesSettings().getTitleShowtime(), 20);
-                    }
+                // sends title to player on level completion
+                if (this.addon.getChallengesSettings().isShowCompletionTitle())
+                {
+                    this.user.getPlayer().sendTitle(
+                            this.parseLevel(this.user.getTranslation("challenges.titles.level-title"), level),
+                            this.parseLevel(this.user.getTranslation("challenges.titles.level-subtitle"), level),
+                            10, this.addon.getChallengesSettings().getTitleShowtime(), 20);
                 }
             }
         }

--- a/src/test/java/world/bentobox/challenges/tasks/TryToCompleteTest.java
+++ b/src/test/java/world/bentobox/challenges/tasks/TryToCompleteTest.java
@@ -809,14 +809,17 @@ class TryToCompleteTest extends AbstractChallengesTest {
         lvl.setFriendlyName("Novice");
         lvl.setRewardExperience(200);
         // Stub both overloads: getLevel(String) used in checkIfCanCompleteChallenge,
-        // getLevel(Challenge) used in build() for level completion check
+        // getLevel(Challenge) used in tryCompleteLevel()
         when(cm.getLevel(GAME_MODE_NAME + "_novice")).thenReturn(lvl);
         when(cm.getLevel(any(Challenge.class))).thenReturn(lvl);
         when(cm.isLevelCompleted(any(), any(), any())).thenReturn(false);
         when(cm.validateLevelCompletion(any(), any(), any())).thenReturn(true);
+        // Mock tryCompleteLevel to return the level (which triggers reward logic)
+        when(cm.tryCompleteLevel(any(), any(), any())).thenReturn(lvl);
         when(inv.addItem(any())).thenReturn(new HashMap<>());
         assertTrue(TryToComplete.complete(addon, user, challenge, world, topLabel, permissionPrefix));
-        verify(cm).setLevelComplete(any(), any(), eq(lvl));
+        // Verify that tryCompleteLevel was called to complete the level
+        verify(cm).tryCompleteLevel(any(), any(), eq(challenge));
         verify(player).giveExp(200);
     }
 
@@ -830,9 +833,12 @@ class TryToCompleteTest extends AbstractChallengesTest {
         when(cm.getLevel(GAME_MODE_NAME + "_novice")).thenReturn(lvl);
         when(cm.getLevel(any(Challenge.class))).thenReturn(lvl);
         when(cm.isLevelCompleted(any(), any(), any())).thenReturn(true);
+        // Mock tryCompleteLevel to return null since level is already completed
+        when(cm.tryCompleteLevel(any(), any(), any())).thenReturn(null);
         when(inv.addItem(any())).thenReturn(new HashMap<>());
         assertTrue(TryToComplete.complete(addon, user, challenge, world, topLabel, permissionPrefix));
-        verify(cm, never()).setLevelComplete(any(), any(), any());
+        // Verify tryCompleteLevel was called but didn't complete the level (returned null)
+        verify(cm).tryCompleteLevel(any(), any(), eq(challenge));
     }
 
     @Test


### PR DESCRIPTION
Fixes #385

## Problem
Normal completion (`TryToComplete`) validates level completion after marking a challenge complete. The admin command (`CompleteCommand`) and the admin GUI (`ListUsersPanel`) called `setChallengeComplete` directly and skipped that check — so a level whose last challenge was admin-completed never registered as complete.

## Fix
Level-completion logic is extracted into `ChallengesManager`:
- `tryCompleteLevel(user, world, challenge)` — validates (skips free/already-complete levels), marks complete, fires the normal `LevelCompletedEvent`; returns the level so `TryToComplete` can keep handling rewards/messages/titles exactly as before.
- `tryCompleteLevelAdmin(...)` — same validation/marking but fires `LevelCompletedEvent` with `admin=true`, mirroring `setLevelComplete`'s pattern.

Both admin paths now call `tryCompleteLevelAdmin` after marking the challenge complete.

Design note: admin-driven level completion records state and fires the admin event but deliberately gives no level rewards or titles — consistent with admin challenge completion, which also gives no rewards, and safe for offline targets.

## Tests
`TryToCompleteTest` updated for the refactored path (57 tests). Full suite: 458 passed, 0 failures.

## In-game verification
1. Create a level with one challenge; complete it via `/[admin] challenges complete <player> <challenge>`.
2. Open `/challenges` as the player — the level should now show as completed (previously it stayed incomplete).
3. Repeat via the admin GUI user list; same result.
4. Complete a level normally — rewards, messages, and title behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKxodNE4h3TsSHMqDEeC8v