### PR TITLE
Improve #329: tell players how to answer confirmation prompts

### DIFF
--- a/src/main/java/world/bentobox/challenges/panel/ConversationUtils.java
+++ b/src/main/java/world/bentobox/challenges/panel/ConversationUtils.java
@@ -117,8 +117,9 @@ public class ConversationUtils
             {
                 // Close input GUI.
                 user.closeInventory();
-                // There are no editable message. Just return question.
-                return question;
+                // Append a standard instruction so players know they must type
+                // 'confirm' (or 'cancel') in chat rather than clicking anything.
+                return ConversationUtils.appendConfirmationInstruction(user, question);
             }
         };
 
@@ -132,6 +133,22 @@ public class ConversationUtils
                 .
             buildConversation(user.getPlayer()).
             begin();
+    }
+
+
+    /**
+     * Appends the localised confirmation instruction ("Type 'confirm' ... or 'cancel' ...")
+     * to a confirmation question so players know they must answer in chat. If the locale
+     * string is empty (e.g. a translator cleared it) the question is returned unchanged.
+     *
+     * @param user User whose locale the instruction is taken from.
+     * @param question The confirmation question being asked.
+     * @return The question with the instruction appended on a new line, or the question alone.
+     */
+    static String appendConfirmationInstruction(User user, String question)
+    {
+        String instruction = user.getTranslationOrNothing(Constants.CONFIRM_INSTRUCTION);
+        return instruction.isEmpty() ? question : question + "\n" + instruction;
     }
 
 

--- a/src/main/java/world/bentobox/challenges/utils/Constants.java
+++ b/src/main/java/world/bentobox/challenges/utils/Constants.java
@@ -265,6 +265,8 @@ public class Constants
 
     public static final String CANCELLED = CONVERSATIONS + "cancelled";
 
+    public static final String CONFIRM_INSTRUCTION = CONVERSATIONS + "confirm-instruction";
+
     public static final String PREFIX = CONVERSATIONS + "prefix";
 
 // ---------------------------------------------------------------------

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -1218,6 +1218,7 @@ challenges:
         cancel-string: "cancel"
         exit-string: "cancel, exit, quit"
         cancelled: "<red>Conversation cancelled!"
+        confirm-instruction: "<gray>Type '<green>confirm<gray>' in chat to proceed, or '<red>cancel<gray>' to abort."
         input-number: "<yellow>Please enter a number in the chat."
         input-seconds: "<yellow>Please enter a number of seconds in the chat."
         numeric-only: "<red>The given [value] is not a number!"

--- a/src/test/java/world/bentobox/challenges/panel/ConversationUtilsTest.java
+++ b/src/test/java/world/bentobox/challenges/panel/ConversationUtilsTest.java
@@ -1,5 +1,6 @@
 package world.bentobox.challenges.panel;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -86,6 +87,24 @@ class ConversationUtilsTest {
         Consumer<Boolean> consumer = mock(Consumer.class);
         ConversationUtils.createConfirmation(consumer, user, "Are you sure?", null);
         verify(user).getPlayer();
+    }
+
+    @Test
+    void testConfirmationInstructionAppended() {
+        when(user.getTranslationOrNothing(
+            world.bentobox.challenges.utils.Constants.CONFIRM_INSTRUCTION))
+            .thenReturn("Type confirm to proceed");
+        String result = ConversationUtils.appendConfirmationInstruction(user, "Are you sure?");
+        assertEquals("Are you sure?\nType confirm to proceed", result);
+    }
+
+    @Test
+    void testConfirmationInstructionEmptyFallsBackToQuestion() {
+        when(user.getTranslationOrNothing(
+            world.bentobox.challenges.utils.Constants.CONFIRM_INSTRUCTION))
+            .thenReturn("");
+        String result = ConversationUtils.appendConfirmationInstruction(user, "Are you sure?");
+        assertEquals("Are you sure?", result);
     }
 
     @Test


### PR DESCRIPTION
Fixes #329

### Problem
The import/reset/wipe confirmation asks a yes/no question but silently rejects anything except the locale's confirm/deny words. Players (reasonably) don't know they have to type `confirm` in chat — the prompt never tells them.

### Fix
`ConversationUtils.createConfirmation()` now appends a standard instruction line to the question, driven by a new `challenges.conversations.confirm-instruction` locale string:

> Type 'confirm' in chat to proceed, or 'cancel' to abort.

One change improves every confirmation (import, reset, wipe, …). Because it's a locale string, translators can localise both the sentence and their own confirm/deny words. If a translator clears the string, the question is shown unchanged.

### Test
Extracted the assembly into `appendConfirmationInstruction(User, String)` and added `ConversationUtilsTest` coverage for the appended case and the empty-locale fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)