### PR TITLE
Add include-undeployed to shipped config.yml (#179)

### DIFF
--- a/src/main/java/world/bentobox/challenges/config/Settings.java
+++ b/src/main/java/world/bentobox/challenges/config/Settings.java
@@ -156,8 +156,9 @@ public class Settings implements ConfigObject
     private boolean resetChallenges = true;
 
     @ConfigComment("")
-    @ConfigComment("This option indicates if undepolyed challenges should be counted to level completion.")
-    @ConfigComment("Disabling this option will make it so that only deployed challenges will be counted.")
+    @ConfigComment("This option indicates if undeployed challenges should be counted towards level completion.")
+    @ConfigComment("Disabling this option will make it so that only deployed challenges are counted, so an")
+    @ConfigComment("undeployed challenge will not block a level from being completed.")
     @ConfigComment("Default: true")
     @ConfigEntry(path = "include-undeployed")
     private boolean includeUndeployed = true;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -96,6 +96,12 @@ store-island-data: true
 # challenges by doing them repeatedly.
 reset-challenges: true
 #
+# This option indicates if undeployed challenges should be counted towards level completion.
+# Disabling this option will make it so that only deployed challenges are counted, so an
+# undeployed challenge will not block a level from being completed.
+# Default: true
+include-undeployed: true
+#
 # Broadcast 1st time challenge completion messages to all players.
 # Change to false if the spam becomes too much.
 broadcast-messages: true


### PR DESCRIPTION
Addresses #179

The core of #179 (whether undeployed challenges count towards level completion) is already implemented as `Settings#includeUndeployed`, wired through `ChallengesManager` and the completion-count placeholder, and editable in the admin settings GUI. The one loose end was that the setting was **missing from the shipped `config.yml`**, so admins couldn't discover it without reading the code.

### Changes
- Add `include-undeployed: true` to `config.yml` with a clear description.
- Fix the `undepolyed` typo and clarify the wording in the `Settings` `@ConfigComment`.

BentoBox already back-fills the field at runtime for existing installs; this just makes it visible and documented for fresh installs.

The other suggestion in the issue (a per-challenge "counts towards level" flag) is intentionally not included — the global setting plus deploy/undeploy covers the practical cases without extra GUI/logic complexity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)