### PR TITLE
Implement TOGGLEABLE undeployed view mode (#175)

### DIFF
--- a/src/main/java/world/bentobox/challenges/config/Settings.java
+++ b/src/main/java/world/bentobox/challenges/config/Settings.java
@@ -112,6 +112,8 @@ public class Settings implements ConfigObject
     @ConfigComment("Valid values are:")
     @ConfigComment("    'VISIBLE' - there will be no hidden challenges. All challenges will be viewable in GUI.")
     @ConfigComment("    'HIDDEN' - shows only deployed challenges.")
+    @ConfigComment("    'TOGGLEABLE' - adds a button to the player GUI so each player can show or hide")
+    @ConfigComment("                   undeployed challenges themselves (defaults to shown).")
     @ConfigEntry(path = "gui-settings.undeployed-view-mode")
     private VisibilityMode visibilityMode = VisibilityMode.VISIBLE;
 

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesPanel.java
@@ -102,6 +102,8 @@ public class ChallengesPanel extends CommonPanel
 
         panelBuilder.registerTypeBuilder("UNASSIGNED_CHALLENGES", this::createFreeChallengesButton);
 
+        panelBuilder.registerTypeBuilder("TOGGLE_UNDEPLOYED", this::createToggleUndeployedButton);
+
         panelBuilder.registerTypeBuilder("NEXT", this::createNextButton);
         panelBuilder.registerTypeBuilder("PREVIOUS", this::createPreviousButton);
 
@@ -120,8 +122,9 @@ public class ChallengesPanel extends CommonPanel
             this.manager.isChallengeComplete(this.user, this.world, challenge) &&
             (globalRemoveCompleted || challenge.isRemoveWhenCompleted()));
 
-        // Remove all undeployed challenges if VisibilityMode is set to Hidden.
-        if (this.addon.getChallengesSettings().getVisibilityMode().equals(SettingsUtils.VisibilityMode.HIDDEN))
+        // Remove all undeployed challenges if they should be hidden (HIDDEN mode, or
+        // TOGGLEABLE mode with the player currently hiding them).
+        if (this.hideUndeployedChallenges())
         {
             this.freeChallengeList.removeIf(challenge -> !challenge.isDeployed());
         }
@@ -131,6 +134,21 @@ public class ChallengesPanel extends CommonPanel
         {
             this.freeChallengeList.removeIf(challenge -> challenge.isTeamChallenge() && challenge.isHideIfNoTeam());
         }
+    }
+
+
+    /**
+     * Whether undeployed challenges should be hidden from the viewing player right now.
+     * True when the visibility mode is HIDDEN, or when it is TOGGLEABLE and the player has
+     * chosen to hide them.
+     *
+     * @return {@code true} if undeployed challenges must be filtered out of the GUI.
+     */
+    private boolean hideUndeployedChallenges()
+    {
+        SettingsUtils.VisibilityMode mode = this.addon.getChallengesSettings().getVisibilityMode();
+        return mode == SettingsUtils.VisibilityMode.HIDDEN ||
+            (mode == SettingsUtils.VisibilityMode.TOGGLEABLE && !this.showUndeployed);
     }
 
 
@@ -161,8 +179,9 @@ public class ChallengesPanel extends CommonPanel
                 this.manager.isChallengeComplete(this.user, this.world, challenge) &&
                 (globalRemoveCompleted || challenge.isRemoveWhenCompleted()));
 
-            // Remove all undeployed challenges if VisibilityMode is set to Hidden.
-            if (this.addon.getChallengesSettings().getVisibilityMode().equals(SettingsUtils.VisibilityMode.HIDDEN))
+            // Remove all undeployed challenges if they should be hidden (HIDDEN mode, or
+            // TOGGLEABLE mode with the player currently hiding them).
+            if (this.hideUndeployedChallenges())
             {
                 this.challengeList.removeIf(challenge -> !challenge.isDeployed());
             }
@@ -665,6 +684,78 @@ public class ChallengesPanel extends CommonPanel
     }
 
 
+    /**
+     * Creates the button that lets a player show or hide undeployed challenges when the
+     * visibility mode is TOGGLEABLE. In any other visibility mode there is nothing to toggle,
+     * so no button is shown (the slot falls back to the panel background).
+     *
+     * @param template the button template.
+     * @param slot the slot the button occupies.
+     * @return the toggle button, or {@code null} when the mode is not TOGGLEABLE.
+     */
+    @Nullable
+    private PanelItem createToggleUndeployedButton(@NonNull ItemTemplateRecord template, TemplatedPanel.ItemSlot slot)
+    {
+        // Only meaningful in TOGGLEABLE mode. In VISIBLE / HIDDEN there is nothing to toggle.
+        if (this.addon.getChallengesSettings().getVisibilityMode() != SettingsUtils.VisibilityMode.TOGGLEABLE)
+        {
+            return null;
+        }
+
+        PanelItemBuilder builder = new PanelItemBuilder();
+
+        if (template.icon() != null)
+        {
+            builder.icon(template.icon().clone());
+        }
+
+        if (template.title() != null)
+        {
+            builder.name(this.user.getTranslation(this.world, template.title()));
+        }
+
+        if (template.description() != null)
+        {
+            builder.description(this.user.getTranslation(this.world, template.description()));
+        }
+
+        // Show whether undeployed challenges are currently shown or hidden for this player.
+        builder.description(this.user.getTranslation(this.world,
+            this.showUndeployed ?
+                Constants.BUTTON + "toggle-undeployed.shown" :
+                Constants.BUTTON + "toggle-undeployed.hidden"));
+
+        // Add ClickHandler: flip the preference, reset paging, and rebuild.
+        builder.clickHandler((panel, user, clickType, i) ->
+        {
+            this.showUndeployed = !this.showUndeployed;
+            // The visible challenge count changes, so the current page may be out of range.
+            this.challengeIndex = 0;
+            this.build();
+
+            // Always return true.
+            return true;
+        });
+
+        // Collect tooltips.
+        List<String> tooltips = template.actions().stream().
+            filter(action -> action.tooltip() != null).
+            map(action -> this.user.getTranslation(this.world, action.tooltip())).
+            filter(text -> !text.isBlank()).
+            collect(Collectors.toCollection(() -> new ArrayList<>(template.actions().size())));
+
+        // Add tooltips.
+        if (!tooltips.isEmpty())
+        {
+            // Empty line and tooltips.
+            builder.description("");
+            builder.description(tooltips);
+        }
+
+        return builder.build();
+    }
+
+
     @Nullable
     private PanelItem createNextButton(@NonNull ItemTemplateRecord template, TemplatedPanel.ItemSlot slot)
     {
@@ -901,4 +992,12 @@ public class ChallengesPanel extends CommonPanel
      * This indicates last selected level.
      */
     private LevelStatus lastSelectedLevel;
+
+    /**
+     * Per-session preference for the TOGGLEABLE visibility mode: whether this player
+     * currently wants to see undeployed challenges. Defaults to {@code true} (shown), so
+     * TOGGLEABLE behaves like VISIBLE until the player hides them with the toggle button.
+     * Only consulted when the visibility mode is TOGGLEABLE.
+     */
+    private boolean showUndeployed = true;
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -72,8 +72,8 @@ gui-settings:
   # Valid values are:
   #     'VISIBLE' - there will be no hidden challenges. All challenges will be viewable in GUI.
   #     'HIDDEN' - shows only deployed challenges.
-  #     'TOGGLEABLE' - there will be button in GUI that allows users to switch from ALL modes.
-  # TOGGLEABLE - Currently not implemented.
+  #     'TOGGLEABLE' - adds a button to the player GUI so each player can show or hide
+  #                    undeployed challenges themselves (defaults to shown).
   undeployed-view-mode: VISIBLE
   #
   # Allow players to open the challenges GUI without being on their island.

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -80,6 +80,16 @@ challenges:
                 description: |-
                     <gray>Displays a list of
                     <gray>free challenges
+            # Button shown only when undeployed-view-mode is TOGGLEABLE. It lets each player
+            # show or hide the challenges that are not yet deployed.
+            toggle-undeployed:
+                name: "<white><bold>Undeployed Challenges"
+                shown: |-
+                    <gray>Undeployed challenges are
+                    <gray>currently <green>shown<gray>.
+                hidden: |-
+                    <gray>Undeployed challenges are
+                    <gray>currently <red>hidden<gray>.
             # Button that is used to return to previous GUI or exit it completely.
             return:
                 name: "<white><bold>Return"

--- a/src/main/resources/panels/main_panel.yml
+++ b/src/main/resources/panels/main_panel.yml
@@ -82,6 +82,15 @@ main_panel:
           left:
             tooltip: challenges.gui.tips.click-to-next
     6:
+      3:
+        # Only shown when undeployed-view-mode is TOGGLEABLE; hidden in VISIBLE / HIDDEN modes.
+        icon: SPYGLASS
+        title: challenges.gui.buttons.toggle-undeployed.name
+        data:
+          type: TOGGLE_UNDEPLOYED
+        action:
+          left:
+            tooltip: challenges.gui.tips.click-to-toggle
       5:
         icon: IRON_BARS
         title: challenges.gui.buttons.free-challenges.name

--- a/src/test/java/world/bentobox/challenges/panel/user/ChallengesPanelTest.java
+++ b/src/test/java/world/bentobox/challenges/panel/user/ChallengesPanelTest.java
@@ -251,4 +251,69 @@ class ChallengesPanelTest {
         assertTrue(getFreeChallengeList(panel).contains(incomplete),
             "Incomplete challenge should always be visible");
     }
+
+    private void setShowUndeployed(ChallengesPanel panel, boolean value) throws Exception {
+        Field field = ChallengesPanel.class.getDeclaredField("showUndeployed");
+        field.setAccessible(true);
+        field.setBoolean(panel, value);
+    }
+
+    @Test
+    @DisplayName("HIDDEN mode: undeployed challenges are removed")
+    void testHiddenModeRemovesUndeployed() throws Exception {
+        when(settings.isRemoveCompleteOneTimeChallenges()).thenReturn(false);
+        when(settings.getVisibilityMode()).thenReturn(SettingsUtils.VisibilityMode.HIDDEN);
+
+        Challenge deployed = PanelTestHelper.createBasicChallenge("Deployed", true);
+        Challenge undeployed = PanelTestHelper.createBasicChallenge("Undeployed", false);
+        List<Challenge> challenges = new ArrayList<>(List.of(deployed, undeployed));
+        when(manager.getFreeChallenges(world)).thenReturn(challenges);
+
+        ChallengesPanel panel = createPanel();
+        callUpdateFreeChallengeList(panel);
+
+        assertTrue(getFreeChallengeList(panel).contains(deployed), "Deployed challenge stays");
+        assertFalse(getFreeChallengeList(panel).contains(undeployed),
+            "Undeployed challenge is hidden in HIDDEN mode");
+    }
+
+    @Test
+    @DisplayName("TOGGLEABLE mode, showing (default): undeployed challenges are visible")
+    void testToggleableShowingKeepsUndeployed() throws Exception {
+        when(settings.isRemoveCompleteOneTimeChallenges()).thenReturn(false);
+        when(settings.getVisibilityMode()).thenReturn(SettingsUtils.VisibilityMode.TOGGLEABLE);
+
+        Challenge deployed = PanelTestHelper.createBasicChallenge("Deployed", true);
+        Challenge undeployed = PanelTestHelper.createBasicChallenge("Undeployed", false);
+        List<Challenge> challenges = new ArrayList<>(List.of(deployed, undeployed));
+        when(manager.getFreeChallenges(world)).thenReturn(challenges);
+
+        ChallengesPanel panel = createPanel();
+        // Default showUndeployed == true, so undeployed challenges must remain visible.
+        callUpdateFreeChallengeList(panel);
+
+        assertTrue(getFreeChallengeList(panel).contains(deployed), "Deployed challenge stays");
+        assertTrue(getFreeChallengeList(panel).contains(undeployed),
+            "Undeployed challenge is shown in TOGGLEABLE mode when the player has not hidden them");
+    }
+
+    @Test
+    @DisplayName("TOGGLEABLE mode, hidden by player: undeployed challenges are removed")
+    void testToggleableHiddenRemovesUndeployed() throws Exception {
+        when(settings.isRemoveCompleteOneTimeChallenges()).thenReturn(false);
+        when(settings.getVisibilityMode()).thenReturn(SettingsUtils.VisibilityMode.TOGGLEABLE);
+
+        Challenge deployed = PanelTestHelper.createBasicChallenge("Deployed", true);
+        Challenge undeployed = PanelTestHelper.createBasicChallenge("Undeployed", false);
+        List<Challenge> challenges = new ArrayList<>(List.of(deployed, undeployed));
+        when(manager.getFreeChallenges(world)).thenReturn(challenges);
+
+        ChallengesPanel panel = createPanel();
+        setShowUndeployed(panel, false);
+        callUpdateFreeChallengeList(panel);
+
+        assertTrue(getFreeChallengeList(panel).contains(deployed), "Deployed challenge stays");
+        assertFalse(getFreeChallengeList(panel).contains(undeployed),
+            "Undeployed challenge is hidden in TOGGLEABLE mode once the player toggles them off");
+    }
 }


### PR DESCRIPTION
Finishes #175

The `undeployed-view-mode` setting has always offered three modes, but `TOGGLEABLE` was never implemented (config.yml literally said *"Currently not implemented"*). Selecting it behaved like `VISIBLE`, because the player panel only filtered undeployed challenges when the mode was `HIDDEN`.

### What this adds
In `TOGGLEABLE` mode the player GUI now shows a **toggle button** (a spyglass in the free-challenges row) that each player uses to show or hide undeployed challenges *for themselves*:

- The preference is per-session and defaults to **shown**, so `TOGGLEABLE` starts out identical to `VISIBLE` (matches the "hype upcoming challenges" use-case from the issue thread).
- Clicking the button flips the preference, resets paging, and rebuilds the GUI.
- `VISIBLE` and `HIDDEN` are unchanged — the button only appears in `TOGGLEABLE` mode (the type builder returns `null` otherwise, so the slot falls back to the panel background).

### Implementation
- `ChallengesPanel`: `showUndeployed` session field; a single `hideUndeployedChallenges()` helper now drives filtering in **both** `updateFreeChallengeList` and `updateChallengeList` (covers `HIDDEN` and `TOGGLEABLE`-hidden); `createToggleUndeployedButton`.
- `main_panel.yml`: `TOGGLE_UNDEPLOYED` button slot.
- `en-US.yml`: button name + shown/hidden state lines (reuses the existing `click-to-toggle` tip).
- `config.yml` / `Settings`: document `TOGGLEABLE` properly.

### Tests
`ChallengesPanelTest`: `HIDDEN` removes undeployed; `TOGGLEABLE` shown (default) keeps them; `TOGGLEABLE` hidden removes them. Full suite green (505 tests).

### Note for existing servers
The button lives in the panel template, so servers with an already-copied `panels/main_panel.yml` won't see the new slot until they regenerate it (delete the file) or add the `TOGGLE_UNDEPLOYED` button themselves — the standard behaviour for template changes. Fresh installs get it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)