### PR TITLE
Add default colour for challenge description and reward text

### DIFF
--- a/src/main/java/world/bentobox/challenges/config/Settings.java
+++ b/src/main/java/world/bentobox/challenges/config/Settings.java
@@ -121,6 +121,20 @@ public class Settings implements ConfigObject
     @ConfigEntry(path = "gui-settings.open-anywhere")
     private boolean openAnywhere = false;
 
+    @ConfigComment("")
+    @ConfigComment("Default colour applied to every line of a challenge's own description text, so you")
+    @ConfigComment("do not have to prefix each challenge with the same colour. Uses '&' colour codes or")
+    @ConfigComment("hex (e.g. '&b' or '&#55FFFF'). Leave empty for no default. A colour written in the")
+    @ConfigComment("description itself still overrides this. Does not affect per-challenge locale overrides.")
+    @ConfigEntry(path = "gui-settings.description-color")
+    private String descriptionColor = "";
+
+    @ConfigComment("")
+    @ConfigComment("Default colour applied to every line of a challenge's own reward text (both first-time")
+    @ConfigComment("and repeat reward text). Same format as description-color. Leave empty for no default.")
+    @ConfigEntry(path = "gui-settings.reward-text-color")
+    private String rewardTextColor = "";
+
 
     @ConfigComment("")
     @ConfigComment("This allows to change default locked level icon. This option may be")
@@ -740,5 +754,49 @@ public class Settings implements ConfigObject
     public void setOpenAnywhere(boolean openAnywhere)
     {
         this.openAnywhere = openAnywhere;
+    }
+
+
+    /**
+     * Returns the default colour applied to challenge description text.
+     *
+     * @return the description colour code, or an empty string for no default.
+     */
+    public String getDescriptionColor()
+    {
+        return descriptionColor;
+    }
+
+
+    /**
+     * Sets the default colour applied to challenge description text.
+     *
+     * @param descriptionColor the colour code (e.g. "&b" or "&#55FFFF"), or empty for none.
+     */
+    public void setDescriptionColor(String descriptionColor)
+    {
+        this.descriptionColor = descriptionColor;
+    }
+
+
+    /**
+     * Returns the default colour applied to challenge reward text.
+     *
+     * @return the reward text colour code, or an empty string for no default.
+     */
+    public String getRewardTextColor()
+    {
+        return rewardTextColor;
+    }
+
+
+    /**
+     * Sets the default colour applied to challenge reward text.
+     *
+     * @param rewardTextColor the colour code (e.g. "&b" or "&#55FFFF"), or empty for none.
+     */
+    public void setRewardTextColor(String rewardTextColor)
+    {
+        this.rewardTextColor = rewardTextColor;
     }
 }

--- a/src/main/java/world/bentobox/challenges/panel/CommonPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/CommonPanel.java
@@ -143,8 +143,11 @@ public abstract class CommonPanel {
         String description = this.user
                 .getTranslationOrNothing(Constants.CHALLENGES_CHALLENGES + challenge.getUniqueId() + ".description");
         if (description.isEmpty()) {
-            // Combine the challenge description list into a single string and translate color codes
-            description = Util.translateColorCodes(String.join("\n", challenge.getDescription()));
+            // Combine the challenge description list into a single string, apply the configured
+            // default colour to each line, and translate color codes.
+            description = Util.translateColorCodes(Utils.applyDefaultColor(
+                    String.join("\n", challenge.getDescription()),
+                    this.addon.getChallengesSettings().getDescriptionColor()));
         }
         // Replace any [label] placeholder with the actual top label
         description = description.replace("[label]", this.topLabel);
@@ -707,7 +710,9 @@ public abstract class CommonPanel {
                 .getTranslationOrNothing(Constants.CHALLENGES_CHALLENGES + challenge.getUniqueId() + ".repeat-reward-text");
 
         if (rewardText.isEmpty()) {
-            rewardText = wrapToWidth(Util.translateColorCodes(String.join("\n", challenge.getRepeatRewardText())), 30);
+            rewardText = wrapToWidth(Util.translateColorCodes(Utils.applyDefaultColor(
+                    String.join("\n", challenge.getRepeatRewardText()),
+                    this.addon.getChallengesSettings().getRewardTextColor())), 30);
         }
 
         return this.user.getTranslationOrNothing(reference + "lore", Constants.PARAMETER_TEXT, rewardText, Constants.PARAMETER_ITEMS, items,
@@ -786,7 +791,9 @@ public abstract class CommonPanel {
                 .getTranslationOrNothing(Constants.CHALLENGES_CHALLENGES + challenge.getUniqueId() + ".reward-text");
 
         if (rewardText.isEmpty()) {
-            rewardText = wrapToWidth(Util.translateColorCodes(String.join("\n", challenge.getRewardText())), 30);
+            rewardText = wrapToWidth(Util.translateColorCodes(Utils.applyDefaultColor(
+                    String.join("\n", challenge.getRewardText()),
+                    this.addon.getChallengesSettings().getRewardTextColor())), 30);
         }
 
         return this.user.getTranslationOrNothing(reference + "lore", Constants.PARAMETER_TEXT, rewardText, Constants.PARAMETER_ITEMS, items,

--- a/src/main/java/world/bentobox/challenges/utils/Utils.java
+++ b/src/main/java/world/bentobox/challenges/utils/Utils.java
@@ -1047,4 +1047,42 @@ public class Utils
 
 		return returnString;
 	}
+
+
+	/**
+	 * Prefixes every line of the given text with a default colour code so the colour applies
+	 * to each rendered lore line, not only the first (each lore line is rendered
+	 * independently). A colour written at the start of a line still overrides the default,
+	 * because a later colour code wins over an earlier one. The text is returned unchanged
+	 * when the colour is blank or the text is empty.
+	 *
+	 * <p>The colour is applied before {@code Util.translateColorCodes}, so it uses the same
+	 * '&amp;' colour codes (or hex, e.g. {@code &#55FFFF}) as the challenge text itself.
+	 *
+	 * @param text the text whose lines should be coloured (may contain '\n').
+	 * @param color the default colour code; blank means no change.
+	 * @return the text with the colour prefixed to each line.
+	 */
+	public static String applyDefaultColor(String text, String color)
+	{
+		if (color == null || color.isBlank() || text == null || text.isEmpty())
+		{
+			return text;
+		}
+
+		String[] lines = text.split("\n", -1);
+		StringBuilder builder = new StringBuilder(text.length() + lines.length * color.length());
+
+		for (int i = 0; i < lines.length; i++)
+		{
+			if (i > 0)
+			{
+				builder.append('\n');
+			}
+
+			builder.append(color).append(lines[i]);
+		}
+
+		return builder.toString();
+	}
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -80,6 +80,16 @@ gui-settings:
   # Note: Challenges completion still requires being on the island when world protection is enabled.
   open-anywhere: false
   #
+  # Default colour applied to every line of a challenge's own description text, so you
+  # do not have to prefix each challenge with the same colour. Uses '&' colour codes or
+  # hex (e.g. '&b' or '&#55FFFF'). Leave empty for no default. A colour written in the
+  # description itself still overrides this. Does not affect per-challenge locale overrides.
+  description-color: ''
+  #
+  # Default colour applied to every line of a challenge's own reward text (both first-time
+  # and repeat reward text). Same format as description-color. Leave empty for no default.
+  reward-text-color: ''
+  #
   # This allows to change default locked level icon. This option may be
   # overwritten by each challenge level. If challenge level has specified
   # their locked level icon, then it will be used, instead of this one.

--- a/src/test/java/world/bentobox/challenges/utils/UtilsTest.java
+++ b/src/test/java/world/bentobox/challenges/utils/UtilsTest.java
@@ -156,4 +156,40 @@ class UtilsTest {
         assertEquals(VisibilityMode.VISIBLE, Utils.getPreviousValue(VisibilityMode.values(), VisibilityMode.HIDDEN));
         assertEquals(VisibilityMode.HIDDEN, Utils.getPreviousValue(VisibilityMode.values(), VisibilityMode.TOGGLEABLE));
     }
+
+    @Test
+    void testApplyDefaultColorBlankColorReturnsTextUnchanged() {
+        assertEquals("Hello", Utils.applyDefaultColor("Hello", ""));
+        assertEquals("Hello", Utils.applyDefaultColor("Hello", "   "));
+        assertEquals("Hello", Utils.applyDefaultColor("Hello", null));
+    }
+
+    @Test
+    void testApplyDefaultColorEmptyOrNullTextReturnedUnchanged() {
+        assertEquals("", Utils.applyDefaultColor("", "&b"));
+        assertNull(Utils.applyDefaultColor(null, "&b"));
+    }
+
+    @Test
+    void testApplyDefaultColorSingleLinePrefixed() {
+        assertEquals("&bHello", Utils.applyDefaultColor("Hello", "&b"));
+    }
+
+    @Test
+    void testApplyDefaultColorPrefixesEveryLine() {
+        assertEquals("&bLine1\n&bLine2\n&bLine3",
+            Utils.applyDefaultColor("Line1\nLine2\nLine3", "&b"));
+    }
+
+    @Test
+    void testApplyDefaultColorPreservesBlankLines() {
+        // Blank lines still get the prefix, and no trailing/leading lines are dropped.
+        assertEquals("&bLine1\n&b\n&bLine2",
+            Utils.applyDefaultColor("Line1\n\nLine2", "&b"));
+    }
+
+    @Test
+    void testApplyDefaultColorSupportsHexColor() {
+        assertEquals("&#55FFFFHello", Utils.applyDefaultColor("Hello", "&#55FFFF"));
+    }
 }


### PR DESCRIPTION
Replaces the closed #340 (see the closing note there for why the original couldn't be merged — MiniMessage migration broke its legacy-colour wrapping and `&b` prefixing).

This keeps the genuinely useful idea from that PR — a **default text colour** so admins don't have to prefix every challenge's description/reward text with the same colour code — reimplemented to work with the current pipeline.

### What it adds
Two new `gui-settings`, both **empty by default** (no behaviour change):
- `description-color` — colour applied to each line of a challenge's own description text.
- `reward-text-color` — colour applied to each line of a challenge's own first-time and repeat reward text.

`Utils.applyDefaultColor(text, color)` prefixes **every line** (so multi-line text stays coloured on each lore line) and runs **before** `Util.translateColorCodes`, so it uses the same `&` / hex codes (e.g. `&b`, `&#55FFFF`) as the challenge text. A colour written in the text itself still overrides the default (a later code wins). Only the challenge's own data-field text is affected — per-challenge locale overrides are left alone (admins colour those directly).

### Deliberately left out
The `lore-length` line-wrapping half of #340 is **not** included:
- It used `WordUtils.wrap` + `ChatColor.getLastColors`, which miscount/mangle MiniMessage tags.
- Its default (25) reintroduced the space-less-language (CJK) wrapping problems it was removed for.
- The panel already wraps reward text via `wrapToWidth()`.

### Tests
`UtilsTest` covers `applyDefaultColor`: blank/null colour → unchanged, empty/null text → unchanged, single-line and multi-line prefixing, blank-line preservation, and hex colours. Full suite green (508 tests).

Closes the loop on #340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)