### PR TITLE
Add biome requirement to island challenges (#335)

### DIFF
--- a/src/main/java/world/bentobox/challenges/database/object/requirements/IslandRequirements.java
+++ b/src/main/java/world/bentobox/challenges/database/object/requirements/IslandRequirements.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.bukkit.Fluid;
 import org.bukkit.Material;
@@ -78,6 +79,15 @@ public class IslandRequirements extends Requirements
      */
     @Expose
     private int searchRadius = 10;
+
+    /**
+     * Namespaced keys (e.g. "minecraft:plains") of biomes the player must be standing in to
+     * complete the challenge. Stored as key strings rather than Biome objects so serialization
+     * is version-robust (Biome is a registry-backed type) and unknown biomes simply never match.
+     * Empty means no biome restriction.
+     */
+    @Expose
+    private Set<String> requiredBiomes = new HashSet<>();
 
     // ---------------------------------------------------------------------
     // Section: Getters and Setters
@@ -182,6 +192,25 @@ public class IslandRequirements extends Requirements
         this.searchRadius = searchRadius;
     }
 
+
+    /**
+     * @return the namespaced keys of biomes the player must stand in (empty for no restriction).
+     */
+    public Set<String> getRequiredBiomes() {
+        if (this.requiredBiomes == null) {
+            this.requiredBiomes = new HashSet<>();
+        }
+        return requiredBiomes;
+    }
+
+
+    /**
+     * @param requiredBiomes the required biome keys to set.
+     */
+    public void setRequiredBiomes(Set<String> requiredBiomes) {
+        this.requiredBiomes = requiredBiomes;
+    }
+
     /**
      * Method isValid returns if given requirement data is valid or not.
      *
@@ -215,6 +244,7 @@ public class IslandRequirements extends Requirements
         clone.setRemoveEntities(this.removeEntities);
 
         clone.setSearchRadius(this.searchRadius);
+        clone.setRequiredBiomes(new HashSet<>(this.getRequiredBiomes()));
 
         return clone;
     }

--- a/src/main/java/world/bentobox/challenges/panel/CommonPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/CommonPanel.java
@@ -398,6 +398,17 @@ public abstract class CommonPanel {
             entities.insert(0, this.user.getTranslationOrNothing(reference + "entities-title"));
         }
 
+        // Required biomes
+        StringBuilder biomes = new StringBuilder();
+        if (!requirement.getRequiredBiomes().isEmpty()) {
+            biomes.append(this.user.getTranslationOrNothing(reference + "biomes-title"));
+            requirement.getRequiredBiomes().stream().sorted().forEach(biomeKey -> {
+                biomes.append("\n");
+                biomes.append(this.user.getTranslationOrNothing(reference + "biome-value", "[biome]",
+                        Utils.prettifyBiome(biomeKey)));
+            });
+        }
+
         String searchRadius = this.user.getTranslationOrNothing(reference + "search-radius", Constants.PARAMETER_NUMBER,
                 String.valueOf(requirement.getSearchRadius()));
 
@@ -409,7 +420,7 @@ public abstract class CommonPanel {
                 : "";
 
         return this.user.getTranslationOrNothing(reference + "lore", "[blocks]", blocks.toString(), "[entities]",
-                entities.toString(),
+                entities.toString(), "[biomes]", biomes.toString(),
                 "[warning-block]", warningBlocks, "[warning-entity]", warningEntities, "[search-radius]", searchRadius);
     }
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengePanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengePanel.java
@@ -743,8 +743,13 @@ public class EditChallengePanel extends CommonPanel {
         }
         // Buttons for Island Requirements
         case REQUIRED_ENTITIES, REMOVE_ENTITIES, REQUIRED_BLOCKS, REMOVE_BLOCKS, SEARCH_RADIUS,
-                REQUIRED_MATERIALTAGS, REQUIRED_ENTITYTAGS, REQUIRED_BIOMES -> {
+                REQUIRED_MATERIALTAGS, REQUIRED_ENTITYTAGS -> {
             return this.createIslandRequirementButton(button);
+        }
+        // Biome requirement is a self-contained island requirement, kept out of the large
+        // createIslandRequirementButton switch.
+        case REQUIRED_BIOMES -> {
+            return this.createBiomeRequirementButton();
         }
         // Buttons for Inventory Requirements
         case REQUIRED_ITEMS, REMOVE_ITEMS, ADD_IGNORED_META, REMOVE_IGNORED_META -> {
@@ -929,48 +934,6 @@ public class EditChallengePanel extends CommonPanel {
             description.add("");
             description.add(this.user.getTranslation(Constants.CLICK_TO_CHANGE));
         }
-        case REQUIRED_BIOMES -> {
-            if (requirements.getRequiredBiomes().isEmpty()) {
-                description.add(this.user.getTranslation(reference + "none"));
-            } else {
-                description.add(this.user.getTranslation(reference + Constants.TITLE_KEY));
-                requirements.getRequiredBiomes()
-                        .forEach(biomeKey -> description.add(this.user.getTranslation(reference + "list", "[biome]",
-                                Utils.prettifyBiome(biomeKey))));
-            }
-
-            icon = new ItemStack(Material.GRASS_BLOCK);
-            clickHandler = (panel, user, clickType, slot) -> {
-                if (clickType.isRightClick()) {
-                    // Right click clears the biome list.
-                    requirements.getRequiredBiomes().clear();
-                    this.build();
-                } else {
-                    // Left click opens the selector, hiding already-chosen biomes.
-                    Set<Biome> excluded = requirements.getRequiredBiomes().stream()
-                            .map(key -> Registry.BIOME.get(NamespacedKey.fromString(key)))
-                            .filter(Objects::nonNull).collect(Collectors.toSet());
-
-                    MultiBiomeSelector.open(this.user, excluded, (status, biomes) -> {
-                        if (Boolean.TRUE.equals(status) && biomes != null) {
-                            biomes.forEach(biome -> requirements.getRequiredBiomes()
-                                    .add(MultiBiomeSelector.biomeKey(biome)));
-                        }
-
-                        this.build();
-                    });
-                }
-                return true;
-            };
-            glow = false;
-
-            description.add("");
-            description.add(this.user.getTranslation(Constants.TIPS + "click-to-add"));
-
-            if (!requirements.getRequiredBiomes().isEmpty()) {
-                description.add(this.user.getTranslation(Constants.TIPS + "right-click-to-clear"));
-            }
-        }
         default -> {
             icon = new ItemStack(Material.PAPER);
             clickHandler = null;
@@ -979,6 +942,68 @@ public class EditChallengePanel extends CommonPanel {
         }
         return new PanelItemBuilder().icon(icon).name(name).description(description).glow(glow)
                 .clickHandler(clickHandler).build();
+    }
+
+
+    /**
+     * Creates the "Required Biomes" button for island challenges. Left-click opens the biome
+     * selector (hiding already-chosen biomes); right-click clears the list.
+     *
+     * @return the PanelItem for the biome requirement button.
+     */
+    private PanelItem createBiomeRequirementButton() {
+        final String reference = Constants.BUTTON + RequirementButton.REQUIRED_BIOMES.name().toLowerCase() + ".";
+        final String name = this.user.getTranslation(reference + "name");
+        final IslandRequirements requirements = this.challenge.getRequirements();
+        final List<String> description = new ArrayList<>();
+        description.add(this.user.getTranslation(reference + Constants.DESCRIPTION_KEY));
+
+        if (requirements.getRequiredBiomes().isEmpty()) {
+            description.add(this.user.getTranslation(reference + "none"));
+        } else {
+            description.add(this.user.getTranslation(reference + Constants.TITLE_KEY));
+            requirements.getRequiredBiomes().forEach(biomeKey -> description.add(
+                    this.user.getTranslation(reference + "list", "[biome]", Utils.prettifyBiome(biomeKey))));
+        }
+
+        description.add("");
+        description.add(this.user.getTranslation(Constants.CLICK_TO_ADD));
+
+        if (!requirements.getRequiredBiomes().isEmpty()) {
+            description.add(this.user.getTranslation(Constants.TIPS + "right-click-to-clear"));
+        }
+
+        return new PanelItemBuilder().icon(new ItemStack(Material.GRASS_BLOCK)).name(name).description(description)
+                .glow(false).clickHandler((panel, user, clickType, slot) -> {
+                    if (clickType.isRightClick()) {
+                        requirements.getRequiredBiomes().clear();
+                        this.build();
+                    } else {
+                        this.openBiomeSelector(requirements);
+                    }
+                    return true;
+                }).build();
+    }
+
+
+    /**
+     * Opens the biome selector for the given island requirements, excluding already-chosen
+     * biomes, and adds the chosen biomes back to the requirement before rebuilding the panel.
+     *
+     * @param requirements the island requirements being edited.
+     */
+    private void openBiomeSelector(IslandRequirements requirements) {
+        Set<Biome> excluded = requirements.getRequiredBiomes().stream()
+                .map(key -> Registry.BIOME.get(NamespacedKey.fromString(key)))
+                .filter(Objects::nonNull).collect(Collectors.toSet());
+
+        MultiBiomeSelector.open(this.user, excluded, (status, biomes) -> {
+            if (Boolean.TRUE.equals(status) && biomes != null) {
+                biomes.forEach(biome -> requirements.getRequiredBiomes().add(MultiBiomeSelector.biomeKey(biome)));
+            }
+
+            this.build();
+        });
     }
 
     /**
@@ -1138,7 +1163,7 @@ public class EditChallengePanel extends CommonPanel {
             glow = false;
 
             description.add("");
-            description.add(this.user.getTranslation(Constants.TIPS + "click-to-add"));
+            description.add(this.user.getTranslation(Constants.CLICK_TO_ADD));
         }
         case REMOVE_IGNORED_META -> {
             icon = new ItemStack(Material.RED_SHULKER_BOX);
@@ -1843,7 +1868,7 @@ public class EditChallengePanel extends CommonPanel {
             glow = false;
 
             description.add("");
-            description.add(this.user.getTranslation(Constants.TIPS + "click-to-add"));
+            description.add(this.user.getTranslation(Constants.CLICK_TO_ADD));
         }
         case REMOVE_IGNORED_META -> {
             icon = new ItemStack(Material.RED_SHULKER_BOX);

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengePanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengePanel.java
@@ -7,12 +7,16 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.World;
+import org.bukkit.block.Biome;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.ItemStack;
@@ -35,6 +39,7 @@ import world.bentobox.challenges.panel.CommonPanel;
 import world.bentobox.challenges.panel.ConversationUtils;
 import world.bentobox.challenges.panel.util.EnvironmentSelector;
 import world.bentobox.challenges.panel.util.ItemSelector;
+import world.bentobox.challenges.panel.util.MultiBiomeSelector;
 import world.bentobox.challenges.panel.util.MultiBlockSelector;
 import world.bentobox.challenges.utils.Constants;
 import world.bentobox.challenges.utils.Utils;
@@ -190,6 +195,7 @@ public class EditChallengePanel extends CommonPanel {
 
 
         panelBuilder.item(23, this.createRequirementButton(RequirementButton.SEARCH_RADIUS));
+        panelBuilder.item(24, this.createRequirementButton(RequirementButton.REQUIRED_BIOMES));
         panelBuilder.item(25, this.createRequirementButton(RequirementButton.REQUIRED_PERMISSIONS));
     }
 
@@ -737,7 +743,7 @@ public class EditChallengePanel extends CommonPanel {
         }
         // Buttons for Island Requirements
         case REQUIRED_ENTITIES, REMOVE_ENTITIES, REQUIRED_BLOCKS, REMOVE_BLOCKS, SEARCH_RADIUS,
-                REQUIRED_MATERIALTAGS, REQUIRED_ENTITYTAGS -> {
+                REQUIRED_MATERIALTAGS, REQUIRED_ENTITYTAGS, REQUIRED_BIOMES -> {
             return this.createIslandRequirementButton(button);
         }
         // Buttons for Inventory Requirements
@@ -922,6 +928,48 @@ public class EditChallengePanel extends CommonPanel {
 
             description.add("");
             description.add(this.user.getTranslation(Constants.CLICK_TO_CHANGE));
+        }
+        case REQUIRED_BIOMES -> {
+            if (requirements.getRequiredBiomes().isEmpty()) {
+                description.add(this.user.getTranslation(reference + "none"));
+            } else {
+                description.add(this.user.getTranslation(reference + Constants.TITLE_KEY));
+                requirements.getRequiredBiomes()
+                        .forEach(biomeKey -> description.add(this.user.getTranslation(reference + "list", "[biome]",
+                                Utils.prettifyBiome(biomeKey))));
+            }
+
+            icon = new ItemStack(Material.GRASS_BLOCK);
+            clickHandler = (panel, user, clickType, slot) -> {
+                if (clickType.isRightClick()) {
+                    // Right click clears the biome list.
+                    requirements.getRequiredBiomes().clear();
+                    this.build();
+                } else {
+                    // Left click opens the selector, hiding already-chosen biomes.
+                    Set<Biome> excluded = requirements.getRequiredBiomes().stream()
+                            .map(key -> Registry.BIOME.get(NamespacedKey.fromString(key)))
+                            .filter(Objects::nonNull).collect(Collectors.toSet());
+
+                    MultiBiomeSelector.open(this.user, excluded, (status, biomes) -> {
+                        if (Boolean.TRUE.equals(status) && biomes != null) {
+                            biomes.forEach(biome -> requirements.getRequiredBiomes()
+                                    .add(MultiBiomeSelector.biomeKey(biome)));
+                        }
+
+                        this.build();
+                    });
+                }
+                return true;
+            };
+            glow = false;
+
+            description.add("");
+            description.add(this.user.getTranslation(Constants.TIPS + "click-to-add"));
+
+            if (!requirements.getRequiredBiomes().isEmpty()) {
+                description.add(this.user.getTranslation(Constants.TIPS + "right-click-to-clear"));
+            }
         }
         default -> {
             icon = new ItemStack(Material.PAPER);
@@ -1926,7 +1974,7 @@ public class EditChallengePanel extends CommonPanel {
         REQUIRED_LEVEL, REQUIRED_MONEY, REMOVE_MONEY, STATISTIC, STATISTIC_BLOCKS, STATISTIC_ITEMS,
         STATISTIC_ENTITIES,
         STATISTIC_AMOUNT, REMOVE_STATISTIC, REQUIRED_MATERIALTAGS, REQUIRED_ENTITYTAGS, REQUIRED_STATISTICS,
-        REMOVE_STATISTICS, REQUIRED_PAPI, REQUIRED_ADVANCEMENTS,
+        REMOVE_STATISTICS, REQUIRED_PAPI, REQUIRED_ADVANCEMENTS, REQUIRED_BIOMES,
     }
 
     // ---------------------------------------------------------------------

--- a/src/main/java/world/bentobox/challenges/panel/util/MultiBiomeSelector.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/MultiBiomeSelector.java
@@ -1,5 +1,6 @@
 package world.bentobox.challenges.panel.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -58,10 +59,11 @@ public class MultiBiomeSelector extends UnifiedMultiSelector<Biome> {
 
     @Override
     protected List<Biome> getElements() {
+        // A mutable list is required: UnifiedMultiSelector's constructor sorts it in place.
         return StreamSupport.stream(Registry.BIOME.spliterator(), false)
                 .filter(biome -> excluded == null || !excluded.contains(biome))
                 .sorted(Comparator.comparing(MultiBiomeSelector::biomeKey))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     @Override

--- a/src/main/java/world/bentobox/challenges/panel/util/MultiBiomeSelector.java
+++ b/src/main/java/world/bentobox/challenges/panel/util/MultiBiomeSelector.java
@@ -1,0 +1,142 @@
+package world.bentobox.challenges.panel.util;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.bukkit.Material;
+import org.bukkit.Registry;
+import org.bukkit.block.Biome;
+import org.bukkit.inventory.ItemStack;
+
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.challenges.utils.Utils;
+
+/**
+ * A multi-selector GUI for choosing biomes. Extends the unified multi-selector base and
+ * supplies the biome-specific details (element list, icons, display names).
+ *
+ * <p>Biomes are a registry-backed type in modern Minecraft, so they are handled by their
+ * namespaced key rather than as an enum.
+ */
+public class MultiBiomeSelector extends UnifiedMultiSelector<Biome> {
+
+    private final Set<Biome> excluded;
+
+    private MultiBiomeSelector(User user, Set<Biome> excluded,
+            BiConsumer<Boolean, Collection<Biome>> consumer) {
+        super(user, Mode.ANY, consumer);
+        this.excluded = excluded;
+    }
+
+    /**
+     * Opens the biome selector.
+     *
+     * @param user     the user who opens the GUI.
+     * @param excluded biomes to hide from the list (e.g. ones already selected).
+     * @param consumer callback receiving the confirmation flag and the chosen biomes.
+     */
+    public static void open(User user, Set<Biome> excluded,
+            BiConsumer<Boolean, Collection<Biome>> consumer) {
+        new MultiBiomeSelector(user, excluded, consumer).build();
+    }
+
+    /**
+     * Opens the biome selector with no exclusions.
+     *
+     * @param user     the user who opens the GUI.
+     * @param consumer callback receiving the confirmation flag and the chosen biomes.
+     */
+    public static void open(User user, BiConsumer<Boolean, Collection<Biome>> consumer) {
+        new MultiBiomeSelector(user, new HashSet<>(), consumer).build();
+    }
+
+    @Override
+    protected List<Biome> getElements() {
+        return StreamSupport.stream(Registry.BIOME.spliterator(), false)
+                .filter(biome -> excluded == null || !excluded.contains(biome))
+                .sorted(Comparator.comparing(MultiBiomeSelector::biomeKey))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    protected String getTitleKey() {
+        return "biome-selector";
+    }
+
+    @Override
+    protected String getElementKeyPrefix() {
+        return "biome.";
+    }
+
+    @Override
+    protected String getElementPlaceholder() {
+        return "[biome]";
+    }
+
+    @Override
+    protected ItemStack getIcon(Biome element) {
+        return new ItemStack(iconMaterial(biomeKey(element)));
+    }
+
+    @Override
+    protected String getElementDisplayName(Biome element) {
+        return Utils.prettifyBiome(biomeKey(element));
+    }
+
+    @Override
+    protected String elementToString(Biome element) {
+        return biomeKey(element);
+    }
+
+    /**
+     * Returns the namespaced key string (e.g. "minecraft:plains") for a biome.
+     *
+     * @param biome the biome.
+     * @return its namespaced key.
+     */
+    public static String biomeKey(Biome biome) {
+        return biome.getKey().toString();
+    }
+
+    /**
+     * Picks a rough representative icon for a biome key. Biomes have no natural item, so this
+     * is only a visual hint; the biome name in the button title is what identifies it.
+     *
+     * @param key the biome key.
+     * @return a Material to use as the button icon.
+     */
+    private static Material iconMaterial(String key) {
+        String path = key.contains(":") ? key.substring(key.indexOf(':') + 1) : key;
+
+        if (path.contains("nether") || path.contains("basalt") || path.contains("soul") || path.contains("crimson")
+                || path.contains("warped")) {
+            return Material.NETHERRACK;
+        }
+        if (path.contains("end")) {
+            return Material.END_STONE;
+        }
+        if (path.contains("ocean") || path.contains("river")) {
+            return Material.WATER_BUCKET;
+        }
+        if (path.contains("desert") || path.contains("beach") || path.contains("badlands")) {
+            return Material.SAND;
+        }
+        if (path.contains("snow") || path.contains("frozen") || path.contains("ice") || path.contains("cold")) {
+            return Material.SNOW_BLOCK;
+        }
+        if (path.contains("cave") || path.contains("deep") || path.contains("lush")) {
+            return Material.STONE;
+        }
+        if (path.contains("mushroom")) {
+            return Material.RED_MUSHROOM_BLOCK;
+        }
+
+        return Material.GRASS_BLOCK;
+    }
+}

--- a/src/main/java/world/bentobox/challenges/tasks/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/tasks/TryToComplete.java
@@ -1251,6 +1251,21 @@ public class TryToComplete
             return emptyResult;
         }
 
+        // Check biome requirement: the player must be standing in one of the required biomes.
+        Set<String> requiredBiomes = this.getIslandRequirements().getRequiredBiomes();
+
+        if (!requiredBiomes.isEmpty())
+        {
+            String currentBiome = this.user.getLocation().getBlock().getBiome().getKey().toString();
+
+            if (!requiredBiomes.contains(currentBiome))
+            {
+                Utils.sendMessage(this.user, this.world, Constants.ERRORS + "wrong-biome",
+                        "[biome]", Utils.prettifyBiome(currentBiome));
+                return emptyResult;
+            }
+        }
+
         // Init location in player position.
         BoundingBox boundingBox = this.user.getPlayer().getBoundingBox().clone();
 

--- a/src/main/java/world/bentobox/challenges/utils/Constants.java
+++ b/src/main/java/world/bentobox/challenges/utils/Constants.java
@@ -249,6 +249,8 @@ public class Constants
 
     public static final String CLICK_TO_CHANGE = TIPS + "click-to-change";
 
+    public static final String CLICK_TO_ADD = TIPS + "click-to-add";
+
     public static final String CLICK_TO_TOGGLE = TIPS + "click-to-toggle";
 
     public static final String CLICK_TO_OPEN = TIPS + "click-to-open";

--- a/src/main/java/world/bentobox/challenges/utils/Utils.java
+++ b/src/main/java/world/bentobox/challenges/utils/Utils.java
@@ -257,6 +257,43 @@ public class Utils
 
 
 	/**
+	 * Turns a biome key such as "minecraft:snowy_taiga" into a readable "Snowy Taiga".
+	 * The namespace is dropped and snake_case becomes Title Case.
+	 *
+	 * @param key the namespaced (or plain) biome key.
+	 * @return a human-readable name, or an empty string for a blank key.
+	 */
+	public static String prettifyBiome(String key)
+	{
+		if (key == null || key.isBlank())
+		{
+			return "";
+		}
+
+		String path = key.contains(":") ? key.substring(key.indexOf(':') + 1) : key;
+		StringBuilder builder = new StringBuilder(path.length());
+
+		for (String word : path.split("_"))
+		{
+			if (word.isEmpty())
+			{
+				continue;
+			}
+
+			if (builder.length() > 0)
+			{
+				builder.append(' ');
+			}
+
+			builder.append(Character.toUpperCase(word.charAt(0))).
+				append(word.substring(1).toLowerCase(Locale.ENGLISH));
+		}
+
+		return builder.toString();
+	}
+
+
+	/**
 	 * Sanitizes the provided input. It replaces spaces and hyphens with underscores and lower cases the input.
 	 * This code also removes all color codes from the input.
 	 * @param input input to sanitize

--- a/src/main/java/world/bentobox/challenges/utils/Utils.java
+++ b/src/main/java/world/bentobox/challenges/utils/Utils.java
@@ -280,7 +280,7 @@ public class Utils
 				continue;
 			}
 
-			if (builder.length() > 0)
+			if (!builder.isEmpty())
 			{
 				builder.append(' ');
 			}

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -73,6 +73,7 @@ challenges:
             challenge-selector: "<black><bold>Challenge Selector"
             statistic-selector: "<black><bold>Statistic Selector"
             environment-selector: "<black><bold>Environment Selector"
+            biome-selector: "<black><bold>Biome Selector"
         buttons:
             # Button in the Challenges GUI that allows to select free challenges.
             free-challenges:
@@ -362,11 +363,20 @@ challenges:
                 name: "<white><bold>Required Blocks"
                 description: |-
                     <gray>Allows you to change the required
-                    <gray>blocks for this challenge to be 
+                    <gray>blocks for this challenge to be
                     <gray>completed.
                 title: "<gray>Blocks: "
                 list: " <dark_gray>- [number] x [block]"
                 none: "<gray>No blocks have been added."
+            required_biomes:
+                name: "<white><bold>Required Biomes"
+                description: |-
+                    <gray>The player must be standing in one
+                    <gray>of these biomes to complete this
+                    <gray>island challenge.
+                title: "<gray>Biomes: "
+                list: " <dark_gray>- <yellow>[biome]"
+                none: "<gray>No biomes required (any biome)."
             required_statistics:
                 name: "<white><bold>Required Statistics"
                 description: |-
@@ -913,6 +923,11 @@ challenges:
                 description: |-
                     <gray>Entity ID: [id]
                 selected: "<dark_green>Selected"
+            biome:
+                name: "<white><bold>[biome]"
+                description: |-
+                    <gray>Biome ID: [id]
+                selected: "<dark_green>Selected"
             entity-group:
                 name: "<white><bold>[id]"
                 description: ""
@@ -1005,6 +1020,7 @@ challenges:
             click-to-change: "<yellow>Click <gray>to change."
             shift-click-to-reset: "<yellow>Shift Click <gray>to reset."
             click-to-add: "<yellow>Click <gray>to add."
+            right-click-to-clear: "<yellow>Right Click <gray>to clear."
             click-to-remove: "<yellow>Click <gray>to remove."
             left-click-to-cycle: "<yellow>Left Click <gray>to cycle down."
             right-click-to-cycle: "<yellow>Right Click <gray>to cycle up."
@@ -1092,9 +1108,14 @@ challenges:
                         lore: |-
                             [blocks]
                             [entities]
+                            [biomes]
                             [search-radius]
                             [warning-block]
                             [warning-entity]
+                        # Title that will be used if there are defined biomes in an island challenge
+                        biomes-title: "<gray><bold>Required Biome(s):"
+                        # Listing of biomes the player must stand in.
+                        biome-value: "  <gray>- <yellow>[biome]"
                         # Title that will be used if there are defined blocks in an island challenge
                         blocks-title: "<gray><bold>Required Blocks:"
                         # Listing of blocks that are required on the island.
@@ -1305,6 +1326,7 @@ challenges:
         challenge-level-not-available: "<red>You have not unlocked the required level to complete this challenge."
         not-repeatable: "<red>This challenge is not repeatable!"
         wrong-environment: "<red>You are in the wrong environment!"
+        wrong-biome: "<red>You must be standing in the [biome] biome to complete this challenge!"
         not-enough-items: "<red>You do not have enough [items] to complete this challenge!"
         not-close-enough: "<red>You must be standing within [number] blocks of all required items."
         you-still-need: "<red>You still need [amount] x [item]"

--- a/src/test/java/world/bentobox/challenges/tasks/TryToCompleteTest.java
+++ b/src/test/java/world/bentobox/challenges/tasks/TryToCompleteTest.java
@@ -31,6 +31,8 @@ import org.bukkit.Material;
 import org.bukkit.Statistic;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -376,6 +378,49 @@ class TryToCompleteTest extends AbstractChallengesTest {
                 eq("[item]"), eq("challenges.entities.pufferfish.name"));
         verify(user).getTranslation(any(World.class), eq("challenges.errors.you-still-need"), eq("[amount]"), eq("5"),
                 eq("[item]"), eq("challenges.entities.chicken.name"));
+    }
+
+    /**
+     * Mocks the biome at the player's location and returns the requirements for further setup.
+     */
+    private IslandRequirements setupBiomeChallenge(String currentBiomeKey, Set<String> requiredBiomes) {
+        challenge.setChallengeType(ChallengeType.ISLAND_TYPE);
+        IslandRequirements req = new IslandRequirements();
+        req.setSearchRadius(1);
+        req.setRequiredBiomes(requiredBiomes);
+        challenge.setRequirements(req);
+
+        Block block = mock(Block.class);
+        Biome biome = mock(Biome.class);
+        String[] parts = currentBiomeKey.split(":");
+        when(biome.getKey()).thenReturn(NamespacedKey.minecraft(parts[parts.length - 1]));
+        when(block.getBiome()).thenReturn(biome);
+        when(user.getLocation().getBlock()).thenReturn(block);
+        return req;
+    }
+
+    @Test
+    void testIslandChallengeSucceedsWhenInRequiredBiome() {
+        setupBiomeChallenge("minecraft:plains", new HashSet<>(Set.of("minecraft:plains")));
+        assertTrue(TryToComplete.complete(addon, user, challenge, world, topLabel, permissionPrefix));
+    }
+
+    @Test
+    void testIslandChallengeFailsWhenNotInRequiredBiome() {
+        setupBiomeChallenge("minecraft:plains", new HashSet<>(Set.of("minecraft:desert")));
+        assertFalse(TryToComplete.complete(addon, user, challenge, world, topLabel, permissionPrefix));
+        verify(user).getTranslation(any(World.class), eq("challenges.errors.wrong-biome"), eq("[biome]"),
+                eq("Plains"));
+    }
+
+    @Test
+    void testIslandChallengeIgnoresBiomeWhenNoneRequired() {
+        // No required biomes: the biome gate is skipped and the (empty) island challenge completes.
+        challenge.setChallengeType(ChallengeType.ISLAND_TYPE);
+        IslandRequirements req = new IslandRequirements();
+        req.setSearchRadius(1);
+        challenge.setRequirements(req);
+        assertTrue(TryToComplete.complete(addon, user, challenge, world, topLabel, permissionPrefix));
     }
 
     @Test

--- a/src/test/java/world/bentobox/challenges/utils/UtilsTest.java
+++ b/src/test/java/world/bentobox/challenges/utils/UtilsTest.java
@@ -192,4 +192,23 @@ class UtilsTest {
     void testApplyDefaultColorSupportsHexColor() {
         assertEquals("&#55FFFFHello", Utils.applyDefaultColor("Hello", "&#55FFFF"));
     }
+
+    @Test
+    void testPrettifyBiomeStripsNamespaceAndTitleCases() {
+        assertEquals("Plains", Utils.prettifyBiome("minecraft:plains"));
+        assertEquals("Snowy Taiga", Utils.prettifyBiome("minecraft:snowy_taiga"));
+        assertEquals("Mangrove Swamp", Utils.prettifyBiome("minecraft:mangrove_swamp"));
+    }
+
+    @Test
+    void testPrettifyBiomeWithoutNamespace() {
+        assertEquals("Desert", Utils.prettifyBiome("desert"));
+    }
+
+    @Test
+    void testPrettifyBiomeBlankInput() {
+        assertEquals("", Utils.prettifyBiome(null));
+        assertEquals("", Utils.prettifyBiome(""));
+        assertEquals("", Utils.prettifyBiome("   "));
+    }
 }


### PR DESCRIPTION
Closes #335

Island challenges can now require the player to be **standing in one of a set of biomes** to complete, enabling exploration-style challenges (e.g. "stand in a Cherry Grove").

### Design
The issue asked for this on *island* challenges ("Island Challenges to have an option which tracks what biome the player is currently standing in"), so it's added as an option on `IslandRequirements` rather than a whole new `ChallengeType` — much simpler, and it composes with the existing block/entity/search-radius requirements.

Biomes are stored as **namespaced key strings** (e.g. `minecraft:plains`) rather than `Biome` objects, because `Biome` is now a registry-backed type that doesn't Gson-serialise cleanly. This also makes it version-robust: an unknown biome key simply never matches, no crash, and no data migration is needed.

### Changes
- **IslandRequirements** — `requiredBiomes` set (in `copy()`; empty = no restriction).
- **TryToComplete.checkSurrounding** — gates on the player's current biome, with a `wrong-biome` message.
- **MultiBiomeSelector** — paged biome picker on the existing `UnifiedMultiSelector` base, enumerating `Registry.BIOME` with rough per-biome icons.
- **EditChallengePanel** — `REQUIRED_BIOMES` button in the island requirements menu (left-click adds, right-click clears), at slot 24.
- **CommonPanel** — required biomes shown in the challenge lore.
- **Utils.prettifyBiome** — `minecraft:snowy_taiga` → `Snowy Taiga`.
- Locale keys for the button, selector, lore, and error.

### Tests
`TryToCompleteTest`: succeeds in a required biome, fails (with the right message) outside it, and ignores the gate when none are set. `UtilsTest`: `prettifyBiome`. Full suite green (508 tests).

### In-game check
Create an island challenge, add e.g. Plains + Forest via the new button, deploy, and verify it only completes while standing in those biomes and reports the wrong-biome message elsewhere; a challenge with no biomes set behaves exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)