### PR TITLE
Add E2E toggle tests for 1.8.0 settings (#349, #179)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -39,6 +39,15 @@ First run downloads Paper 1.21.11 (~50 MB) and the plugin jars; later runs reuse
 - **`confirmation prompts tell the player how to answer (#329)`** — opens the Challenges admin GUI,
   clicks "Challenge Wipe", and asserts the bot receives the confirmation instruction line
   ("Type 'confirm' ... or 'cancel' ...") added in #415. A real in-game validation of a 1.8.0 feature.
+- **`open-anywhere setting toggles in the admin settings GUI (#349)`** — opens admin → Settings,
+  finds the new "Open GUI Anywhere" (Elytra) toggle, clicks it and asserts the Enabled/Disabled
+  lore flips, then clicks again to restore it. Proves the full config → Settings → panel button →
+  click-handler → saveSettings chain works on a live server.
+- **`include-undeployed setting toggles in the admin settings GUI (#179)`** — same live toggle check
+  for the "Include Undeployed Challenges" (Barrel) button that now ships in config.yml.
+
+Both toggle tests are self-restoring (they read the current state, flip it, assert, then flip back),
+so they don't depend on the persisted run-dir config or the order the tests run in.
 
 ## Notes / next steps
 

--- a/e2e/src/test/e2e/challenges.spec.ts
+++ b/e2e/src/test/e2e/challenges.spec.ts
@@ -1,4 +1,9 @@
-import { expect, test } from '@drownek/plugwright';
+import { expect, test, PlayerWrapper } from '@drownek/plugwright';
+
+// LiveGuiHandle / GuiItemLocator are not re-exported from the package entry point, so derive them
+// from PlayerWrapper's public API instead of importing them directly.
+type LiveGuiHandle = Awaited<ReturnType<PlayerWrapper['gui']>>;
+type GuiItemLocator = ReturnType<LiveGuiHandle['locator']>;
 
 /**
  * Baseline: bot joins the real Paper 1.21.11 server (BentoBox 3.14.0 + BSkyBlock + the staged
@@ -29,3 +34,64 @@ test('confirmation prompts tell the player how to answer (#329)', async ({ playe
   // The #329 change appends this instruction to every confirmation prompt.
   await expect(player).toHaveReceivedMessage('to proceed, or');
 });
+
+/**
+ * Feature validation for 1.8.0 (#349): a new "Open GUI Anywhere" setting lets players open the
+ * challenges GUI while off their island. It surfaces as an Elytra toggle in the admin settings
+ * GUI. Confirm the button renders in a real server and that clicking it flips the Enabled/Disabled
+ * state — proving the whole config -> Settings -> panel button -> click-handler -> saveSettings
+ * chain is wired up, not just present in the JUnit tests.
+ */
+test('open-anywhere setting toggles in the admin settings GUI (#349)', async ({ player }) => {
+  await player.makeOp();
+
+  const settings = await openSettingsPanel(player);
+  const openAnywhere = settings.locator(item => item.getDisplayName().includes('Open GUI Anywhere'));
+
+  await expectToggleFlips(openAnywhere);
+});
+
+/**
+ * Feature validation for 1.8.0 (#179): the include-undeployed option now ships in config.yml and
+ * is editable from the admin settings GUI as an "Include Undeployed Challenges" barrel toggle
+ * (it controls whether undeployed challenges count toward level completion). Same live wiring
+ * check as above, on a different setting.
+ */
+test('include-undeployed setting toggles in the admin settings GUI (#179)', async ({ player }) => {
+  await player.makeOp();
+
+  const settings = await openSettingsPanel(player);
+  const includeUndeployed = settings.locator(item => item.getDisplayName().includes('Include Undeployed'));
+
+  await expectToggleFlips(includeUndeployed);
+});
+
+/**
+ * Open the Challenges admin GUI and click through to the Settings sub-panel, returning a live
+ * handle to it. The admin menu is registered under the BSkyBlock admin command; the "Settings"
+ * button opens EditSettingsPanel (window title "Settings").
+ */
+async function openSettingsPanel(player: PlayerWrapper): Promise<LiveGuiHandle> {
+  player.chat('/bsbadmin challenges');
+  const admin = await player.gui({ title: /Challenges Admin/i });
+  await admin.locator(item => item.getDisplayName().includes('Settings')).click();
+  return player.gui({ title: /Settings/i });
+}
+
+/**
+ * Assert a settings toggle button really toggles on a live server: read its current Enabled/Disabled
+ * state, click it and assert the state flipped, then click again to restore it. Restoring keeps the
+ * test independent of the persisted run-dir config and of the order tests run in.
+ */
+async function expectToggleFlips(button: GuiItemLocator): Promise<void> {
+  // Wait for the panel to finish drawing this button with a known toggle state.
+  await expect.poll(() => button.loreText()).toMatch(/Enabled|Disabled/);
+  const wasEnabled = button.loreText().includes('Enabled');
+
+  await button.click();
+  await expect(button).toHaveLore(wasEnabled ? 'Disabled' : 'Enabled');
+
+  // Put it back the way we found it.
+  await button.click();
+  await expect(button).toHaveLore(wasEnabled ? 'Enabled' : 'Disabled');
+}


### PR DESCRIPTION
Extends the plugwright in-game E2E suite with two tests that drive the admin **Settings GUI** on a live Paper 1.21.11 server (BentoBox 3.14.0 + BSkyBlock + Challenges 1.8.0) — the richest surface reachable without bootstrapping an island.

## New tests

- **`open-anywhere setting toggles in the admin settings GUI (#349)`** — finds the new "Open GUI Anywhere" Elytra toggle, clicks it, asserts the Enabled/Disabled lore flips, then restores it. Proves the full `config → Settings → panel button → click-handler → saveSettings` chain works on a real server, not just in the JUnit tests.
- **`include-undeployed setting toggles in the admin settings GUI (#179)`** — same live toggle check for the "Include Undeployed Challenges" barrel button now shipped in `config.yml`.

Both tests are **self-restoring** (read current state → flip → assert → flip back), so they don't depend on the persisted run-dir config or on the order tests run in. Shared `openSettingsPanel()` / `expectToggleFlips()` helpers were extracted; `LiveGuiHandle` / `GuiItemLocator` types are derived from the exported `PlayerWrapper` since the package doesn't re-export them.

## Verification

- `npm run build` (tsc, `strict: true`) — clean.
- `./gradlew plugwrightTest` on Java 21 — **4/4 pass**:

```
PASS  bot can interact with the server
PASS  confirmation prompts tell the player how to answer (#329)
PASS  open-anywhere setting toggles in the admin settings GUI (#349)
PASS  include-undeployed setting toggles in the admin settings GUI (#179)
```

## Not covered

Other 1.8.0 features (toggleable-undeployed #175, default text colour #340, `challenges_completed_percent` #352, biome requirement #335, reward chance #76, island-level rewards #279) need an island + imported challenges to exercise in-game — the island-bootstrap the original spike deferred. Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfEq1X2sy57G8nq2Cd23ba