### PR TITLE
Address Copilot review on the 1.8.0 release PR (#421)

### DIFF
--- a/src/main/java/world/bentobox/challenges/ChallengesAddon.java
+++ b/src/main/java/world/bentobox/challenges/ChallengesAddon.java
@@ -234,6 +234,7 @@ public class ChallengesAddon extends Addon {
             this.log("Challenges Addon hooked into Level addon.");
         }, () -> {
             this.levelAddon = null;
+            this.levelProvided = false;
             this.logWarning("Level add-on not found so level challenges will not work!");
         });
 

--- a/src/main/java/world/bentobox/challenges/panel/admin/EditChallengePanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/admin/EditChallengePanel.java
@@ -962,8 +962,11 @@ public class EditChallengePanel extends CommonPanel {
             description.add(this.user.getTranslation(reference + "none"));
         } else {
             description.add(this.user.getTranslation(reference + Constants.TITLE_KEY));
-            requirements.getRequiredBiomes().forEach(biomeKey -> description.add(
-                    this.user.getTranslation(reference + "list", "[biome]", Utils.prettifyBiome(biomeKey))));
+            // Sort so the biome list renders in a stable order (the underlying set is unordered).
+            requirements.getRequiredBiomes().stream()
+                    .sorted(Comparator.comparing(Utils::prettifyBiome))
+                    .forEach(biomeKey -> description.add(
+                            this.user.getTranslation(reference + "list", "[biome]", Utils.prettifyBiome(biomeKey))));
         }
 
         description.add("");

--- a/src/main/java/world/bentobox/challenges/panel/user/ChallengesPanel.java
+++ b/src/main/java/world/bentobox/challenges/panel/user/ChallengesPanel.java
@@ -714,7 +714,7 @@ public class ChallengesPanel extends CommonPanel
             builder.name(this.user.getTranslation(this.world, template.title()));
         }
 
-        if (template.description() != null)
+        if (template.description() != null && !template.description().isBlank())
         {
             builder.description(this.user.getTranslation(this.world, template.description()));
         }

--- a/src/test/java/world/bentobox/challenges/ChallengesAddonTest.java
+++ b/src/test/java/world/bentobox/challenges/ChallengesAddonTest.java
@@ -377,9 +377,10 @@ class ChallengesAddonTest {
 
         addon.onEnable();
 
-        // Verify that the completed_percent placeholder was registered
+        // Capture every registered placeholder name; assert the one under test is present without
+        // pinning the exact total (which changes whenever any placeholder is added or removed).
         ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass(String.class);
-        verify(phm, org.mockito.Mockito.times(13)).registerPlaceholder(any(GameModeAddon.class), nameCaptor.capture(), any());
+        verify(phm, org.mockito.Mockito.atLeastOnce()).registerPlaceholder(any(GameModeAddon.class), nameCaptor.capture(), any());
 
         List<String> names = nameCaptor.getAllValues();
         assertTrue(names.contains("challenges_completed_percent"),
@@ -398,9 +399,10 @@ class ChallengesAddonTest {
 
         addon.onEnable();
 
-        // Verify that the latest_level_completed_percent placeholder was registered
+        // Capture every registered placeholder name; assert the one under test is present without
+        // pinning the exact total (which changes whenever any placeholder is added or removed).
         ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass(String.class);
-        verify(phm, org.mockito.Mockito.times(13)).registerPlaceholder(any(GameModeAddon.class), nameCaptor.capture(), any());
+        verify(phm, org.mockito.Mockito.atLeastOnce()).registerPlaceholder(any(GameModeAddon.class), nameCaptor.capture(), any());
 
         List<String> names = nameCaptor.getAllValues();
         assertTrue(names.contains("challenges_latest_level_completed_percent"),


### PR DESCRIPTION
Addresses the five Copilot review comments on the 1.8.0 release PR #421.

- **`ChallengesAddon.allLoaded()`** — reset `levelProvided = false` in the "Level add-on not found" branch. Previously only `levelAddon` was nulled, so `isLevelProvided()` could return a stale `true` and `TryToComplete.rewardIslandLevel()` would NPE dereferencing a null Level add-on.
- **`EditChallengePanel`** — sort the required-biome list before rendering it into the button description. The backing collection is a `Set`, so the admin GUI could shuffle biome order between runs.
- **`ChallengesPanel.createToggleUndeployedButton()`** — guard the template description with `!isBlank()` so a blank template doesn't add an empty lore line, matching the other button builders in the class.
- **`ChallengesAddonTest`** — verify placeholder registration with `atLeastOnce()` instead of `times(13)`. The exact count is incidental to what these tests assert and made them brittle to any placeholder being added/removed.

## Verification
`mvn compile test-compile` clean; `ChallengesAddonTest`, `ChallengesPanelTest` and `TryToCompleteTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfEq1X2sy57G8nq2Cd23ba