### PR TITLE
fix: ignore anvil repair cost when matching required inventory items

### DIFF
--- a/src/main/java/world/bentobox/challenges/tasks/TryToComplete.java
+++ b/src/main/java/world/bentobox/challenges/tasks/TryToComplete.java
@@ -1993,7 +1993,8 @@ public class TryToComplete
      * Checks if two items match, considering the ignore-metadata setting. For potion-like materials
      * that are in the ignore-metadata set, compares the base potion type while ignoring other metadata.
      * For non-potion materials in the ignore-metadata set, uses type-only comparison. For materials
-     * not in the ignore-metadata set, uses full similarity comparison.
+     * not in the ignore-metadata set, uses full similarity comparison, except that the anvil
+     * repair cost component is ignored.
      *
      * @param candidate candidate item from inventory
      * @param required required item template
@@ -2012,10 +2013,11 @@ public class TryToComplete
             return false;
         }
 
-        // If metadata should not be ignored, use full similarity check
+        // If metadata should not be ignored, use full similarity check. The anvil repair cost is
+        // disregarded so that, e.g., enchanted books combined in an anvil still match (#433).
         if (!ignoreMetaData.contains(required.getType()))
         {
-            return candidate.isSimilar(required);
+            return Utils.isSimilarIgnoringRepairCost(candidate, required);
         }
 
         // Metadata is being ignored. For potion-like materials, still compare base potion type.

--- a/src/main/java/world/bentobox/challenges/utils/Utils.java
+++ b/src/main/java/world/bentobox/challenges/utils/Utils.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.inventory.meta.Repairable;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.potion.PotionType;
 import org.eclipse.jdt.annotation.Nullable;
@@ -52,10 +53,61 @@ public class Utils
 		}
 		else
 		{
+			input = withoutRepairCost(input);
+			stack = withoutRepairCost(stack);
+
 			return input.getType() == stack.getType() &&
 				input.hasItemMeta() == stack.hasItemMeta() &&
 				(!input.hasItemMeta() || Bukkit.getItemFactory().equals(input.getItemMeta(), stack.getItemMeta()));
 		}
+	}
+
+
+	/**
+	 * Checks if two item stacks are similar (same type and meta, ignoring amount) while disregarding
+	 * the anvil {@code repair_cost} component. Anvils add this bookkeeping component to any item they
+	 * produce (for example when combining two enchanted books), so a strict {@link ItemStack#isSimilar}
+	 * would treat an anvil-made book as a different item from one obtained by other means.
+	 * @param first First item.
+	 * @param second Second item.
+	 * @return {@code true} if items are similar once the repair cost is ignored, {@code false} otherwise.
+	 */
+	public static boolean isSimilarIgnoringRepairCost(@Nullable ItemStack first, @Nullable ItemStack second)
+	{
+		if (first == null || second == null)
+		{
+			return false;
+		}
+
+		return withoutRepairCost(first).isSimilar(withoutRepairCost(second));
+	}
+
+
+	/**
+	 * Returns the given item without an anvil repair cost. If the item carries a repair cost, a copy
+	 * with the repair cost cleared is returned; otherwise the original item is returned untouched.
+	 * @param item Item to inspect.
+	 * @return Item without a repair cost, or the same item if it had none.
+	 */
+	public static ItemStack withoutRepairCost(ItemStack item)
+	{
+		if (item == null || !item.hasItemMeta())
+		{
+			return item;
+		}
+
+		ItemMeta meta = item.getItemMeta();
+
+		if (meta instanceof Repairable repairable && repairable.hasRepairCost())
+		{
+			repairable.setRepairCost(0);
+
+			ItemStack copy = item.clone();
+			copy.setItemMeta(meta);
+			return copy;
+		}
+
+		return item;
 	}
 
 

--- a/src/test/java/world/bentobox/challenges/tasks/TryToCompleteTest.java
+++ b/src/test/java/world/bentobox/challenges/tasks/TryToCompleteTest.java
@@ -2,6 +2,7 @@ package world.bentobox.challenges.tasks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -34,11 +35,14 @@ import org.bukkit.World.Environment;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.inventory.meta.Repairable;
 import org.bukkit.potion.PotionType;
 import org.bukkit.util.BoundingBox;
 import org.eclipse.jdt.annotation.NonNull;
@@ -47,6 +51,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import net.md_5.bungee.api.chat.TextComponent;
 import world.bentobox.bentobox.hooks.VaultHook;
@@ -1580,5 +1585,122 @@ class TryToCompleteTest extends AbstractChallengesTest {
 
         // Verify items were not removed
         assertEquals(10, invEmerald.getAmount(), "Items should not be removed when requirement fails");
+    }
+
+    // -------------------------------------------------------------------------
+    // Anvil repair cost handling (Issue #433)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Helper method to create an enchanted book with a single stored enchantment and, optionally,
+     * an anvil repair cost (as produced when books are combined in an anvil).
+     */
+    private ItemStack createEnchantedBook(Enchantment enchantment, int level, int repairCost) {
+        ItemStack book = new ItemStack(Material.ENCHANTED_BOOK);
+        EnchantmentStorageMeta meta = (EnchantmentStorageMeta) book.getItemMeta();
+        meta.addStoredEnchant(enchantment, level, true);
+        if (repairCost > 0) {
+            ((Repairable) meta).setRepairCost(repairCost);
+        }
+        book.setItemMeta(meta);
+        return book;
+    }
+
+    @Test
+    void testInventoryChallengeEnchantedBookFromAnvilMatches() {
+        // Required: Unbreaking III book with no repair cost (as configured by an admin)
+        InventoryRequirements req = new InventoryRequirements();
+        ItemStack requiredBook = createEnchantedBook(Enchantment.UNBREAKING, 3, 0);
+        req.setRequiredItems(Collections.singletonList(requiredBook));
+        req.setTakeItems(true);
+        challenge.setRequirements(req);
+
+        // Player holds an Unbreaking III book that was combined in an anvil (has repair_cost)
+        ItemStack anvilBook = createEnchantedBook(Enchantment.UNBREAKING, 3, 1);
+        assertFalse(anvilBook.isSimilar(requiredBook), "Sanity: strict isSimilar must differ on repair cost");
+        when(inv.getContents()).thenReturn(new ItemStack[] { anvilBook });
+        when(player.getInventory()).thenReturn(inv);
+
+        assertTrue(TryToComplete.complete(addon, user, challenge, world, topLabel, permissionPrefix));
+        verify(user, never()).getTranslation(any(World.class), eq("challenges.errors.not-enough-items"), any(), any());
+        assertEquals(0, anvilBook.getAmount(), "The anvil-made book should have been taken");
+    }
+
+    @Test
+    void testInventoryChallengeEnchantedBookRequiredHasRepairCost() {
+        // Required item itself was created from an anvil-made book; player holds a clean one
+        InventoryRequirements req = new InventoryRequirements();
+        ItemStack requiredBook = createEnchantedBook(Enchantment.UNBREAKING, 3, 2);
+        req.setRequiredItems(Collections.singletonList(requiredBook));
+        challenge.setRequirements(req);
+
+        ItemStack cleanBook = createEnchantedBook(Enchantment.UNBREAKING, 3, 0);
+        when(inv.getContents()).thenReturn(new ItemStack[] { cleanBook });
+        when(player.getInventory()).thenReturn(inv);
+
+        assertTrue(TryToComplete.complete(addon, user, challenge, world, topLabel, permissionPrefix));
+    }
+
+    @Test
+    void testInventoryChallengeEnchantedBookWrongLevelStillFails() {
+        // Ignoring repair cost must not loosen the enchantment check itself
+        InventoryRequirements req = new InventoryRequirements();
+        ItemStack requiredBook = createEnchantedBook(Enchantment.UNBREAKING, 3, 0);
+        req.setRequiredItems(Collections.singletonList(requiredBook));
+        challenge.setRequirements(req);
+
+        ItemStack lowerBook = createEnchantedBook(Enchantment.UNBREAKING, 2, 1);
+        when(inv.getContents()).thenReturn(new ItemStack[] { lowerBook });
+        when(player.getInventory()).thenReturn(inv);
+        // The "missing items" message prettifies the enchanted book, which needs vararg translations
+        Mockito.doAnswer(invocation -> invocation.getArgument(0, String.class))
+                .when(user).getTranslationOrNothing(anyString(), Mockito.any(String[].class));
+
+        assertFalse(TryToComplete.complete(addon, user, challenge, world, topLabel, permissionPrefix));
+        verify(user).getTranslation(any(World.class), eq("challenges.errors.not-enough-items"), eq("[items]"),
+                any());
+    }
+
+    @Test
+    void testUtilsIsSimilarIgnoringRepairCost() {
+        ItemStack clean = createEnchantedBook(Enchantment.UNBREAKING, 3, 0);
+        ItemStack anvil = createEnchantedBook(Enchantment.UNBREAKING, 3, 5);
+        ItemStack other = createEnchantedBook(Enchantment.MENDING, 1, 5);
+
+        assertTrue(Utils.isSimilarIgnoringRepairCost(clean, anvil));
+        assertTrue(Utils.isSimilarIgnoringRepairCost(anvil, clean));
+        assertTrue(Utils.isSimilarIgnoringRepairCost(anvil, anvil.clone()));
+        assertFalse(Utils.isSimilarIgnoringRepairCost(anvil, other));
+        assertFalse(Utils.isSimilarIgnoringRepairCost(null, clean));
+        assertFalse(Utils.isSimilarIgnoringRepairCost(clean, null));
+
+        // The original item must not be modified
+        assertEquals(5, ((Repairable) anvil.getItemMeta()).getRepairCost());
+    }
+
+    @Test
+    void testUtilsWithoutRepairCost() {
+        ItemStack clean = createEnchantedBook(Enchantment.UNBREAKING, 3, 0);
+        ItemStack anvil = createEnchantedBook(Enchantment.UNBREAKING, 3, 5);
+        ItemStack plain = new ItemStack(Material.DIRT);
+
+        // Items without a repair cost are returned as-is
+        assertTrue(clean == Utils.withoutRepairCost(clean));
+        assertTrue(plain == Utils.withoutRepairCost(plain));
+        assertNull(Utils.withoutRepairCost(null));
+
+        ItemStack stripped = Utils.withoutRepairCost(anvil);
+        assertFalse(((Repairable) stripped.getItemMeta()).hasRepairCost());
+        assertTrue(stripped.isSimilar(clean));
+        assertEquals(5, ((Repairable) anvil.getItemMeta()).getRepairCost(), "Original must be untouched");
+    }
+
+    @Test
+    void testGroupEqualItemsMergesAnvilBooks() {
+        ItemStack clean = createEnchantedBook(Enchantment.UNBREAKING, 3, 0);
+        ItemStack anvil = createEnchantedBook(Enchantment.UNBREAKING, 3, 3);
+        List<ItemStack> grouped = Utils.groupEqualItems(Arrays.asList(clean, anvil), Set.of());
+        assertEquals(1, grouped.size());
+        assertEquals(2, grouped.get(0).getAmount());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #433.

Items that pass through an anvil (for example two enchanted books combined into a higher-level one) gain a `minecraft:repair_cost` component. The strict `ItemStack#isSimilar` check used for inventory challenges treated such items as different from the admin-configured requirement, so the challenge could not be completed. The only workaround was "ignore metadata", which then accepts *any* enchanted book.

## Changes

- **`Utils.withoutRepairCost`** returns a copy of an item with the repair cost cleared (via the Bukkit `Repairable` meta interface), or the same item if it had none. The original stack is never mutated.
- **`Utils.isSimilarIgnoringRepairCost`** strips the repair cost from both items and then performs the normal strict comparison. Enchantments, levels, names, lore and all other meta are still compared.
- **`TryToComplete.itemsMatch`** uses it for the non-ignore-metadata path, so both counting and taking items honour it. Because both sides are normalised, a requirement that an admin created from an anvil-made book also matches a clean book.
- **`Utils.isSimilarNoDurability`** strips the repair cost as well so the GUI's required-item grouping stays consistent with the completion check.

## Tests

Six new tests in `TryToCompleteTest` (MockBukkit-backed real enchanted books):
- anvil-made Unbreaking III book completes the challenge and is consumed
- required item itself carrying a repair cost matches a clean book
- a wrong enchantment level still fails
- the two new helpers directly, including non-mutation of the original
- `groupEqualItems` merges an anvil-made and a clean book

Full suite: 528 run, 0 failures, 0 errors, 3 skipped.

**In-game verification** on Paper 1.21.11 with a local build of this branch: an inventory challenge requiring an Unbreaking III enchanted book fails on 1.8.0 when the player holds an anvil-made (`repair_cost`) copy, and completes with this fix. A lower-level anvil-made book still fails, confirming the enchantment check is unchanged.

## Note

The reporter also runs EcoEnchants, which may add its own components to enchanted books. That is out of scope here and would need a separate look if mismatches persist after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYkfNqJY8BjLmWTDp32R4Q

